### PR TITLE
Support metadata thumbnails

### DIFF
--- a/src/main/plugin/dcat-ap/extract-relations.xsl
+++ b/src/main/plugin/dcat-ap/extract-relations.xsl
@@ -23,26 +23,65 @@
   -->
 
 <xsl:stylesheet version="2.0"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
-                xmlns:adms="http://www.w3.org/ns/adms#"
+                xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:gn-fn-rel="http://geonetwork-opensource.org/xsl/functions/relations"
                 exclude-result-prefixes="#all">
 
+  <xsl:import href="layout/utility-tpl-multilingual.xsl" />
+
+  <!-- Checks if an URL refers to an image, checking the file extension.
+       Formats supported: png, gif, jpeg, jpg
+  -->
+  <xsl:function name="gn-fn-rel:is-image" as="xs:boolean">
+    <xsl:param name="url"/>
+
+    <xsl:variable name="normalizedUrl" select="lower-case($url)" />
+
+    <xsl:value-of select="ends-with(lower-case($normalizedUrl), '.png') or
+                          ends-with($normalizedUrl, '.gif') or
+                          ends-with($normalizedUrl, '.jpeg') or
+                          ends-with($normalizedUrl, '.jpg')" />
+  </xsl:function>
+
+
   <xsl:template mode="relation" match="metadata[rdf:RDF/dcat:Catalog]" priority="100">
-    <xsl:if test="count(*/descendant::*[name(.) = 'adms:sample']/*) > 0">
+    <xsl:if test="count(*/descendant::*[name(.) = 'foaf:page']/*) > 0">
+
+      <xsl:variable name="mainLanguage">
+        <xsl:call-template name="get-dcat-ap-language">
+          <xsl:with-param name="languageIri"
+                          select=".//dcat:CatalogRecord/dct:language[1]/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)" />
+        </xsl:call-template>
+      </xsl:variable>
+
       <thumbnails>
-        <xsl:for-each select="*/descendant::*[name(.) = 'adms:sample']">
+        <xsl:for-each select="*/descendant::*[name(.) = 'foaf:page' and gn-fn-rel:is-image(foaf:Document/@rdf:about)]">
           <item>
             <id>
-              <xsl:value-of select="dcat:Distribution/dcat:downloadURL/@rdf:resource"/>
+              <xsl:value-of select="foaf:Document/@rdf:about"/>
             </id>
             <url>
-              <value lang="dut"><xsl:value-of select="dcat:Distribution/dcat:downloadURL/@rdf:resource"/></value>
+              <xsl:variable name="url" select="foaf:Document/@rdf:about" />
+
+              <value lang="{$mainLanguage}">
+                <xsl:value-of select="$url"/>
+              </value>
             </url>
             <title>
-              <value lang="dut"><xsl:value-of select="dct:title[1]"/></value>
+                <xsl:for-each select="dct:description">
+                  <xsl:variable name="localeId"
+                                select="@xml:lang"/>
+
+                  <value lang="{$localeId}">
+                    <xsl:value-of select="."/>
+                  </value>
+                </xsl:for-each>
             </title>
             <type>thumbnail</type>
           </item>

--- a/src/main/plugin/dcat-ap/extract-relations.xsl
+++ b/src/main/plugin/dcat-ap/extract-relations.xsl
@@ -35,21 +35,6 @@
 
   <xsl:import href="layout/utility-tpl-multilingual.xsl" />
 
-  <!-- Checks if an URL refers to an image, checking the file extension.
-       Formats supported: png, gif, jpeg, jpg
-  -->
-  <xsl:function name="gn-fn-rel:is-image" as="xs:boolean">
-    <xsl:param name="url"/>
-
-    <xsl:variable name="normalizedUrl" select="lower-case($url)" />
-
-    <xsl:value-of select="ends-with(lower-case($normalizedUrl), '.png') or
-                          ends-with($normalizedUrl, '.gif') or
-                          ends-with($normalizedUrl, '.jpeg') or
-                          ends-with($normalizedUrl, '.jpg')" />
-  </xsl:function>
-
-
   <xsl:template mode="relation" match="metadata[rdf:RDF/dcat:Catalog]" priority="100">
     <xsl:if test="count(*/descendant::*[name(.) = 'foaf:page']/*) > 0">
 
@@ -61,7 +46,7 @@
       </xsl:variable>
 
       <thumbnails>
-        <xsl:for-each select="*/descendant::*[name(.) = 'foaf:page' and gn-fn-rel:is-image(foaf:Document/@rdf:about)]">
+        <xsl:for-each select="*/descendant::*[name(.) = 'foaf:page' and foaf:Document[matches(@rdf:about, '.*(.gif|.png|.jpeg|.jpg)$', 'i')]]">
           <item>
             <id>
               <xsl:value-of select="foaf:Document/@rdf:about"/>

--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -193,11 +193,11 @@
         </span>
       </h4>
 
-      <xsl:for-each select="//adms:sample[normalize-space(dcat:Distribution/dcat:downloadURL/@rdf:resource)!='']">
+      <xsl:for-each select="//foaf:page/foaf:Document[matches(@rdf:about, '.*(.gif|.png|.jpeg|.jpg)$', 'i')]">
         <img data-gn-img-modal="md"
              class="gn-img-thumbnail center-block"
              alt="{$schemaStrings/overview}"
-             src="{normalize-space(dcat:Distribution/dcat:downloadURL/@rdf:resource)}"/>
+             src="{normalize-space(@rdf:about)}"/>
           <div class="gn-img-thumbnail-caption"><xsl:value-of select="dct:title" /></div>
       </xsl:for-each>
     </section>

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -252,7 +252,7 @@
 
         <!-- Overviews -->
         <xsl:variable name="overviews"
-                      select="foaf:page/foaf:Document[@rdf:about != '']"/>
+                      select="foaf:page/foaf:Document[matches(@rdf:about, '.*(.gif|.png|.jpeg|.jpg)$', 'i')]"/>
         <xsl:copy-of select="gn-fn-index:add-field('hasOverview', if (count($overviews) > 0) then 'true' else 'false')"/>
 
         <xsl:for-each select="$overviews">
@@ -621,7 +621,6 @@
     <xsl:param name="fieldSuffix" select="''" as="xs:string"/>
     <xsl:param name="role" select="''" as="xs:string"/>
 
-    <xsl:variable name="organisationName" select="vcard:Organization/vcard:organization-name"/>
     <xsl:variable name="website" select="vcard:Organization/vcard:hasURL/@rdf:resource"/>
     <xsl:variable name="email" select="vcard:Organization/vcard:hasEmail/@rdf:resource"/>
     <xsl:variable name="phone" select="vcard:Organization/vcard:hasTelephone"/>
@@ -631,7 +630,7 @@
         <xsl:when test="vcard:Organization/vcard:hasAddress/vcard:Address">
           <xsl:for-each select="vcard:Organization/vcard:hasAddress/vcard:Address">
             <xsl:value-of
-              select="concat(vcard:street-address, ', ', vcard:locality, ', ', vcard:postal-code, ', ', vcard:country-name)"/>
+              select="concat(vcard:street-address[1], ', ', vcard:locality[1], ', ', vcard:postal-code[1], ', ', vcard:country-name[1])"/>
           </xsl:for-each>
         </xsl:when>
         <xsl:otherwise>
@@ -655,7 +654,7 @@
       "website":"<xsl:value-of select="$website"/>",
       "individual":"<xsl:value-of select="util:escapeForJson($individualName)"/>",
       "phone":"<xsl:value-of select="util:escapeForJson($phone[1])"/>",
-      "address":"<xsl:value-of select="util:escapeForJson($address)"/>"
+      "address":"<xsl:value-of select="util:escapeForJson($address[1])"/>"
       }
     </xsl:element>
   </xsl:template>

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -249,8 +249,21 @@
           </resolutionScaleDenominator>
         </xsl:for-each>
 
-        <!--        TODO check how to implement overviews in dcat-->
-        <xsl:copy-of select="gn-fn-index:add-field('hasOverview', 'false')"/>
+
+        <!-- Overviews -->
+        <xsl:variable name="overviews"
+                      select="foaf:page/foaf:Document[@rdf:about != '']"/>
+        <xsl:copy-of select="gn-fn-index:add-field('hasOverview', if (count($overviews) > 0) then 'true' else 'false')"/>
+
+        <xsl:for-each select="$overviews">
+          <overview type="object">{
+            "url": "<xsl:value-of select="util:escapeForJson(normalize-space(@rdf:about))"/>"
+            <xsl:if test="normalize-space(dct:description) != ''">,
+              "nameObject": <xsl:value-of select="gn-fn-index:add-multilingual-field('name', dct:description, $allLanguages, true())"/>
+            </xsl:if>
+            }</overview>
+        </xsl:for-each>
+
 
         <xsl:variable name="openKeywords" select="*[name() = ('dct:subject', 'mdcat:statuut') and
           skos:Concept/@rdf:about = ('https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden/VLOPENDATA', 'https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden/VLOPENDATASERVICE')

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -403,6 +403,9 @@
           displayTooltipsMode="onhover"
           hideTimeInCalendar="true">
       <sidePanel>
+        <directive data-gn-overview-manager=""
+                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+
         <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata" />
         <directive data-gn-validation-report=""/>
       </sidePanel>
@@ -746,6 +749,9 @@
           displayTooltipsMode="onhover"
           hideTimeInCalendar="true">
       <sidePanel>
+        <directive data-gn-overview-manager=""
+                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+
         <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata" />
         <directive data-gn-validation-report=""/>
       </sidePanel>
@@ -889,6 +895,9 @@
 
     <view name="fromroot">
       <sidePanel>
+        <directive data-gn-overview-manager=""
+                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+
         <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata" />
         <directive data-gn-validation-report=""/>
       </sidePanel>

--- a/src/main/plugin/dcat-ap/process/thumbnail-add.xsl
+++ b/src/main/plugin/dcat-ap/process/thumbnail-add.xsl
@@ -26,14 +26,22 @@
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
-                xmlns:adms="http://www.w3.org/ns/adms#"
+                xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
                 xmlns:geonet="http://www.fao.org/geonetwork"
                 exclude-result-prefixes="#all"
                 version="2.0">
 
+  <xsl:import href="../layout/utility-tpl-multilingual.xsl" />
   <!-- Thumbnail base url (mandatory) -->
   <xsl:param name="thumbnail_url"/>
   <xsl:param name="thumbnail_desc" select="''"/>
+
+  <xsl:variable name="metadata" select="//rdf:RDF" />
+
+  <xsl:variable name="mainLanguage">
+    <xsl:call-template name="get-dcat-ap-language" />
+  </xsl:variable>
 
   <xsl:template match="/root">
     <xsl:apply-templates select="rdf:RDF"/>
@@ -55,14 +63,13 @@
 
   <xsl:template name="fill">
     <xsl:if test="$thumbnail_url != ''">
-      <adms:sample>
-        <dcat:Distribution>
-          <dcat:downloadURL rdf:resource="{$thumbnail_url}"/>
+      <foaf:page>
+        <foaf:Document rdf:about="{$thumbnail_url}">
           <xsl:if test="$thumbnail_desc!=''">
-            <dct:title xml:lang="nl"><xsl:value-of select="$thumbnail_desc"/></dct:title>
+            <dct:description xml:lang="{$mainLanguage}"><xsl:value-of select="$thumbnail_desc"/></dct:description>
           </xsl:if>
-        </dcat:Distribution>
-      </adms:sample>
+        </foaf:Document>
+      </foaf:page>
     </xsl:if>
   </xsl:template>
 

--- a/src/main/plugin/dcat-ap/process/thumbnail-remove.xsl
+++ b/src/main/plugin/dcat-ap/process/thumbnail-remove.xsl
@@ -26,6 +26,7 @@
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
                 xmlns:adms="http://www.w3.org/ns/adms#"
+                xmlns:foaf="http://xmlns.com/foaf/0.1/"
                 xmlns:geonet="http://www.fao.org/geonetwork" exclude-result-prefixes="#all"
                 version="2.0">
 
@@ -39,7 +40,11 @@
   <!-- Remove the thumbnail define in thumbnail_url parameter -->
   <xsl:template
     priority="2"
-    match="adms:sample[normalize-space(dcat:Distribution/dcat:downloadURL/@rdf:resource) = normalize-space($thumbnail_url)]"/>
+    match="foaf:page[normalize-space(foaf:Document/@rdf:about) = normalize-space($thumbnail_url)]"/>
+
+  <!--<xsl:template
+    priority="2"
+    match="adms:sample[normalize-space(dcat:Distribution/dcat:downloadURL/@rdf:resource) = normalize-space($thumbnail_url)]"/>-->
 
   <!-- Do a copy of every nodes and attributes -->
   <xsl:template match="@*|node()">


### PR DESCRIPTION
* Use `foaf:page/foaf:Document` with an image png, gif, jpg extension to encode an overview
* Add overview manager to editor side panel
* Add overview in index 
* Add overview to record default and full view