### PR TITLE
Tweaks and translations

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -135,6 +135,27 @@
         useReference="true"/>
     </for>
 
+    <for name="mdcat:statuut" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.GDI-Vlaanderen-trefwoorden"
+        xpath="/mdcat:statuut"/>
+    </for>
+    <for name="mdcat:ontwikkelingstoestand" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.ontwikkelingstoestand"
+        xpath="/mdcat:ontwikkelingstoestand"/>
+    </for>
+    <for name="mdcat:levensfase" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.levensfase"
+        xpath="/mdcat:levensfase"/>
+    </for>
+    <for name="mdcat:MAGDA-categorie" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.magda-domain"
+        xpath="/mdcat:MAGDA-categorie"/>
+    </for>
+
     <for name="mobilitydcatap:mobilityTheme" use="thesaurus-list-picker">
       <directiveAttributes
         thesaurus="external.theme.mobility-theme"
@@ -442,19 +463,129 @@
   </multilingualFields>
 
   <views>
+    <view name="metadatadcat-view"
+          class="gn-label-above-input gn-indent-bluescale vl-editor-view"
+          displayTooltips="true"
+          displayTooltipsMode="onhover"
+          hideTimeInCalendar="true">
+      <tab id="metadatadcat-dataset-tab"  default="true" displayIfRecord="count(//dcat:dataset) > 0" hideIfNotDisplayed="true">
+        <section name="metadatadcat-dataset-section">
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mdcat:statuut"/>
+          <action type="add"
+                  or="statuut"
+                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mdcat:statuut) = 0">
+            <template>
+              <snippet>
+                <mdcat:statuut>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel xml:lang=""></skos:prefLabel>
+                  </skos:Concept>
+                </mdcat:statuut>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mdcat:MAGDA-categorie"/>
+          <action type="add"
+                  or="MAGDA-categorie"
+                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mdcat:MAGDA-categorie) = 0">
+            <template>
+              <snippet>
+                <mdcat:statuut>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel xml:lang=""></skos:prefLabel>
+                  </skos:Concept>
+                </mdcat:statuut>
+              </snippet>
+            </template>
+          </action>
+        </section>
+      </tab>
+
+      <tab id="metadatadcat-dataservice-tab"  default="true" displayIfRecord="count(//dcat:dataservice) > 0" hideIfNotDisplayed="true">
+        <section name="metadatadcat-dataservice-section">
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:ontwikkelingstoestand"/>
+          <action type="add"
+                  or="ontwikkelingstoestand"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:ontwikkelingstoestand) = 0">
+            <template>
+              <snippet>
+                <mdcat:ontwikkelingstoestand>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel xml:lang=""></skos:prefLabel>
+                  </skos:Concept>
+                </mdcat:ontwikkelingstoestand>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:statuut"/>
+          <action type="add"
+                  or="statuut"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:statuut) = 0">
+            <template>
+              <snippet>
+                <mdcat:statuut>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel xml:lang=""></skos:prefLabel>
+                  </skos:Concept>
+                </mdcat:statuut>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:levensfase"/>
+          <action type="add"
+                  or="levensfase"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:levensfase) = 0">
+            <template>
+              <snippet>
+                <mdcat:levensfase>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel xml:lang=""></skos:prefLabel>
+                  </skos:Concept>
+                </mdcat:levensfase>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:MAGDA-categorie"/>
+          <action type="add"
+                  or="MAGDA-categorie"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:MAGDA-categorie) = 0">
+            <template>
+              <snippet>
+                <mdcat:statuut>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel xml:lang=""></skos:prefLabel>
+                  </skos:Concept>
+                </mdcat:statuut>
+              </snippet>
+            </template>
+          </action>
+        </section>
+      </tab>
+    </view>
+
     <view name="hvd-view"
           class="gn-label-above-input gn-indent-bluescale vl-editor-view"
           displayTooltips="true"
           displayTooltipsMode="onhover"
           hideTimeInCalendar="true">
-      <tab id="hvd-tab"  default="true">
-        <section name="hvd-section">
+      <tab id="hvd-dataset-tab"  default="true" displayIfRecord="count(//dcat:dataset) > 0" hideIfNotDisplayed="true">
+        <section name="hvd-dataset-section">
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcatap:hvdCategory"/>
 
           <action type="add"
-                       or="hvdCategory"
-                       in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
-                       if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcatap:hvdCategory) = 0">
+                  or="hvdCategory"
+                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcatap:hvdCategory) = 0">
             <template>
               <snippet>
                 <dcatap:hvdCategory>
@@ -471,6 +602,38 @@
                   or="applicableLegislation"
                   in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
                   if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcatap:applicableLegislation) = 0">
+            <template>
+              <snippet>
+                <dcatap:applicableLegislation rdf:resource="http://data.europa.eu/eli/reg_impl/2023/138/oj"/>
+              </snippet>
+            </template>
+          </action>
+        </section>
+      </tab>
+      <tab id="hvd-dataservice-tab"  default="true" displayIfRecord="count(//dcat:service) > 0" hideIfNotDisplayed="true">
+        <section name="hvd-dataservice-section">
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcatap:hvdCategory"/>
+
+          <action type="add"
+                       or="hvdCategory"
+                       in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                       if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcatap:hvdCategory) = 0">
+            <template>
+              <snippet>
+                <dcatap:hvdCategory>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel xml:lang=""></skos:prefLabel>
+                  </skos:Concept>
+                </dcatap:hvdCategory>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcatap:applicableLegislation"/>
+          <action type="add"
+                  or="applicableLegislation"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcatap:applicableLegislation) = 0">
             <template>
               <snippet>
                 <dcatap:applicableLegislation rdf:resource="http://data.europa.eu/eli/reg_impl/2023/138/oj"/>

--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -631,4 +631,51 @@
     <description>Tooltip: Resource URI</description>
     <btnLabel>Resource URI</btnLabel>
   </element>
+
+  <element name="mobilitydcatap:mobilityTheme">
+    <label>Mobility theme</label>
+    <description>This property refers to the mobility-related theme (i.e., a specific subject, category, or type) of the delivered content.
+      A dataset may be associated with multiple themes. A theme is important for data seekers who are interested in a particular type of data content.</description>
+  </element>
+  <element name="mobilitydcatap:transportMode">
+    <label>Transport mode</label>
+    <description>This property describes the transport mode that is covered by the delivered content. Data can be valid for more than one mode, so a multiple choice should be applied.</description>
+  </element>
+  <element name="mobilitydcatap:networkCoverage">
+    <label>Network coverage</label>
+    <description>This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed.
+      For other transport modes, the property is meant to refer to the physical infrastructure which is used by the services covered by the data.
+      For all modes, the property SHOULD also indicate if the data content relates to the EU’s trans-European transport network [EU-TEN-T].</description>
+  </element>
+  <element name="mobilitydcatap:georeferencingMethod">
+    <label>Georeferencing method</label>
+    <description>This property SHOULD be used to specify the georeferencing method used in the dataset.</description>
+  </element>
+  <element name="mobilitydcatap:intendedInformationService">
+    <label>Intended information service</label>
+    <description>This property MAY describe predefined information services, which the data content is intended to support.
+      Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR].
+      Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
+  </element>
+
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Dataset belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Data Service belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Dataset.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Data Service.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
 </labels>

--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd-cardinalities.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd-cardinalities.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Kardinaliteiten</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd-rec.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Aanbevolen</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Verplicht</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/dut/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/strings.xml
@@ -86,4 +86,20 @@
   <protocol-49>LINK-1.0-http--link</protocol-49>
   <protocol-50>LINK-1.0-http--related</protocol-50>
   <protocol-51>Vul uw eigen protocol in...</protocol-51>
+
+  <hvd-dataservice-section>High Value Dataset (HVD)</hvd-dataservice-section>
+  <hvd-dataservice-tab>Data Service</hvd-dataservice-tab>
+  <hvd-dataset-section>High Value Dataset (HVD)</hvd-dataset-section>
+  <hvd-dataset-tab>Dataset</hvd-dataset-tab>
+  <hvd-view>High Value Dataset</hvd-view>
+
+  <mobility-section>Mobility</mobility-section>
+  <mobility-tab>Mobility</mobility-tab>
+  <mobility-view>Mobility</mobility-view>
+
+  <metadatadcat-dataservice-section>Data Service</metadatadcat-dataservice-section>
+  <metadatadcat-dataservice-tab>Metadata DCAT</metadatadcat-dataservice-tab>
+  <metadatadcat-dataset-section>Dataset</metadatadcat-dataset-section>
+  <metadatadcat-dataset-tab>Metadata DCAT</metadatadcat-dataset-tab>
+  <metadatadcat-view>Metadata DCAT</metadatadcat-view>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/labels.xml
@@ -926,26 +926,6 @@
     <btnLabel>Language</btnLabel>
   </element>
 
-
-  <!-- PROFILE / DCAT-AP-HVD -->
-  <element name="dcatap:hvdCategory">
-    <label>HVD category</label>
-    <description>The HVD category to which this Dataset belongs.
-      The HVD IR defines six thematic data categories: geospatial, earth observation and environment, meteorological, statistics, companies and company ownership, and mobility.
-      A new property HVD category is introduced to indicate the HVD category to which an resource, i.e. a dataset, belongs.
-      The controlled vocabulary with all possible values is maintained by the Publications Office.
-      A resource may belong to more than one data category.</description>
-  </element>
-  <element name="dcatap:applicableLegislation">
-    <label>Applicable legislation</label>
-    <description>The legislation that mandates the creation or management of the Data Service. For HVD the value MUST include the ELI http://data.europa.eu/eli/reg_impl/2023/138/oj.
-      As multiple legislations may apply to the resource the maximum cardinality is not limited. </description>
-  </element>
-
-
-
-
-
   <element name="mobilitydcatap:mobilityTheme">
     <label>Mobility theme</label>
     <description>This property refers to the mobility-related theme (i.e., a specific subject, category, or type) of the delivered content.
@@ -972,4 +952,24 @@
       Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
   </element>
 
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Dataset belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Data Service belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Dataset.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Data Service.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
 </labels>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd-cardinalities.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd-cardinalities.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Cardinalities</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd-rec.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Recommended</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Mandatory</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/eng/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/strings.xml
@@ -87,11 +87,19 @@
   <protocol-50>LINK-1.0-http--related</protocol-50>
   <protocol-51>Enter your own protocol...</protocol-51>
 
+  <hvd-dataservice-section>High Value Dataset (HVD)</hvd-dataservice-section>
+  <hvd-dataservice-tab>Data Service</hvd-dataservice-tab>
+  <hvd-dataset-section>High Value Dataset (HVD)</hvd-dataset-section>
+  <hvd-dataset-tab>Dataset</hvd-dataset-tab>
   <hvd-view>High Value Dataset</hvd-view>
-  <hvd-tab>High Value Dataset</hvd-tab>
-  <hvd-section>High Value Dataset (HVD)</hvd-section>
 
-  <mobility-view>Mobility</mobility-view>
-  <mobility-tab>Mobility</mobility-tab>
   <mobility-section>Mobility</mobility-section>
+  <mobility-tab>Mobility</mobility-tab>
+  <mobility-view>Mobility</mobility-view>
+
+  <metadatadcat-dataservice-section>Data Service</metadatadcat-dataservice-section>
+  <metadatadcat-dataservice-tab>Metadata DCAT</metadatadcat-dataservice-tab>
+  <metadatadcat-dataset-section>Dataset</metadatadcat-dataset-section>
+  <metadatadcat-dataset-tab>Metadata DCAT</metadatadcat-dataset-tab>
+  <metadatadcat-view>Metadata DCAT</metadatadcat-view>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/fre/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/labels.xml
@@ -2196,4 +2196,51 @@
     <description>Tooltip: in scheme</description>
     <btnLabel>in scheme</btnLabel>
   </element>
+
+  <element name="mobilitydcatap:mobilityTheme">
+    <label>Mobility theme</label>
+    <description>This property refers to the mobility-related theme (i.e., a specific subject, category, or type) of the delivered content.
+      A dataset may be associated with multiple themes. A theme is important for data seekers who are interested in a particular type of data content.</description>
+  </element>
+  <element name="mobilitydcatap:transportMode">
+    <label>Transport mode</label>
+    <description>This property describes the transport mode that is covered by the delivered content. Data can be valid for more than one mode, so a multiple choice should be applied.</description>
+  </element>
+  <element name="mobilitydcatap:networkCoverage">
+    <label>Network coverage</label>
+    <description>This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed.
+      For other transport modes, the property is meant to refer to the physical infrastructure which is used by the services covered by the data.
+      For all modes, the property SHOULD also indicate if the data content relates to the EU’s trans-European transport network [EU-TEN-T].</description>
+  </element>
+  <element name="mobilitydcatap:georeferencingMethod">
+    <label>Georeferencing method</label>
+    <description>This property SHOULD be used to specify the georeferencing method used in the dataset.</description>
+  </element>
+  <element name="mobilitydcatap:intendedInformationService">
+    <label>Intended information service</label>
+    <description>This property MAY describe predefined information services, which the data content is intended to support.
+      Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR].
+      Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
+  </element>
+
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Dataset belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Data Service belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Dataset.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Data Service.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
 </labels>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd-cardinalities.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd-cardinalities.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Cardinalités</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd-rec.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Recommendé</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Obligatoire</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/fre/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/strings.xml
@@ -100,4 +100,20 @@
   <protocol-49>LINK-1.0-http--link</protocol-49>
   <protocol-50>LINK-1.0-http--related</protocol-50>
   <protocol-51>Vul uw eigen protocol in...</protocol-51>
+
+  <hvd-dataservice-section>High Value Dataset (HVD)</hvd-dataservice-section>
+  <hvd-dataservice-tab>Data Service</hvd-dataservice-tab>
+  <hvd-dataset-section>High Value Dataset (HVD)</hvd-dataset-section>
+  <hvd-dataset-tab>Dataset</hvd-dataset-tab>
+  <hvd-view>High Value Dataset</hvd-view>
+
+  <mobility-section>Mobility</mobility-section>
+  <mobility-tab>Mobility</mobility-tab>
+  <mobility-view>Mobility</mobility-view>
+
+  <metadatadcat-dataservice-section>Data Service</metadatadcat-dataservice-section>
+  <metadatadcat-dataservice-tab>Metadata DCAT</metadatadcat-dataservice-tab>
+  <metadatadcat-dataset-section>Dataset</metadatadcat-dataset-section>
+  <metadatadcat-dataset-tab>Metadata DCAT</metadatadcat-dataset-tab>
+  <metadatadcat-view>Metadata DCAT</metadatadcat-view>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/ger/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/labels.xml
@@ -2196,4 +2196,51 @@
     <description>Tooltip: in scheme</description>
     <btnLabel>in scheme</btnLabel>
   </element>
+
+  <element name="mobilitydcatap:mobilityTheme">
+    <label>Mobility theme</label>
+    <description>This property refers to the mobility-related theme (i.e., a specific subject, category, or type) of the delivered content.
+      A dataset may be associated with multiple themes. A theme is important for data seekers who are interested in a particular type of data content.</description>
+  </element>
+  <element name="mobilitydcatap:transportMode">
+    <label>Transport mode</label>
+    <description>This property describes the transport mode that is covered by the delivered content. Data can be valid for more than one mode, so a multiple choice should be applied.</description>
+  </element>
+  <element name="mobilitydcatap:networkCoverage">
+    <label>Network coverage</label>
+    <description>This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed.
+      For other transport modes, the property is meant to refer to the physical infrastructure which is used by the services covered by the data.
+      For all modes, the property SHOULD also indicate if the data content relates to the EU’s trans-European transport network [EU-TEN-T].</description>
+  </element>
+  <element name="mobilitydcatap:georeferencingMethod">
+    <label>Georeferencing method</label>
+    <description>This property SHOULD be used to specify the georeferencing method used in the dataset.</description>
+  </element>
+  <element name="mobilitydcatap:intendedInformationService">
+    <label>Intended information service</label>
+    <description>This property MAY describe predefined information services, which the data content is intended to support.
+      Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR].
+      Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
+  </element>
+
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Dataset belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Data Service belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Dataset.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Data Service.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
 </labels>

--- a/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd-cardinalities.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd-cardinalities.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Kardinalitäten</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd-rec.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Empfohlen</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Obligatorisch</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/ger/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/strings.xml
@@ -100,4 +100,20 @@
   <protocol-49>LINK-1.0-http--link</protocol-49>
   <protocol-50>LINK-1.0-http--related</protocol-50>
   <protocol-51>Vul uw eigen protocol in...</protocol-51>
+
+  <hvd-dataservice-section>High Value Dataset (HVD)</hvd-dataservice-section>
+  <hvd-dataservice-tab>Data Service</hvd-dataservice-tab>
+  <hvd-dataset-section>High Value Dataset (HVD)</hvd-dataset-section>
+  <hvd-dataset-tab>Dataset</hvd-dataset-tab>
+  <hvd-view>High Value Dataset</hvd-view>
+
+  <mobility-section>Mobility</mobility-section>
+  <mobility-tab>Mobility</mobility-tab>
+  <mobility-view>Mobility</mobility-view>
+
+  <metadatadcat-dataservice-section>Data Service</metadatadcat-dataservice-section>
+  <metadatadcat-dataservice-tab>Metadata DCAT</metadatadcat-dataservice-tab>
+  <metadatadcat-dataset-section>Dataset</metadatadcat-dataset-section>
+  <metadatadcat-dataset-tab>Metadata DCAT</metadatadcat-dataset-tab>
+  <metadatadcat-view>Metadata DCAT</metadatadcat-view>
 </strings>

--- a/src/main/plugin/dcat-ap/schema/dcat.xsd
+++ b/src/main/plugin/dcat-ap/schema/dcat.xsd
@@ -319,6 +319,10 @@
                 <xs:element ref="mdcat:ontwikkelingstoestand" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="mdcat:statuut" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="owl:versionInfo" minOccurs="0" maxOccurs="unbounded"/>
+
+                <!-- Profile / DCAT-AP-HVD -->
+                <xs:element ref="dcatap:hvdCategory" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="dcatap:applicableLegislation" minOccurs="0" maxOccurs="unbounded"/>
               </xs:sequence>
             </xs:extension>
           </xs:complexContent>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd-cardinalities.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd-cardinalities.sch
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  <sch:ns prefix="spdx" uri="http://spdx.org/rdf/terms#"/>
+  <sch:ns prefix="owl" uri="http://www.w3.org/2002/07/owl#"/>
+  <sch:ns prefix="adms" uri="http://www.w3.org/ns/adms#"/>
+  <sch:ns prefix="locn" uri="http://www.w3.org/ns/locn#"/>
+  <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+  <sch:ns prefix="foaf" uri="http://xmlns.com/foaf/0.1/"/>
+  <sch:ns prefix="dct" uri="http://purl.org/dc/terms/"/>
+  <sch:ns prefix="vcard" uri="http://www.w3.org/2006/vcard/ns#"/>
+  <sch:ns prefix="dcat" uri="http://www.w3.org/ns/dcat#"/>
+  <sch:ns prefix="dcatap" uri="http://data.europa.eu/r5r/"/>
+  <sch:ns prefix="schema" uri="http://schema.org/"/>
+  <sch:ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="xml" uri="http://www.w3.org/XML/1998/namespace"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="dc" uri="http://purl.org/dc/elements/1.1/"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="mdcat" uri="https://data.vlaanderen.be/ns/metadata-dcat#"/>
+  <sch:ns prefix="geodcat" uri="http://data.europa.eu/930/"/>
+  <sch:ns prefix="generiek" uri="https://data.vlaanderen.be/ns/generiek#"/>
+  <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
+  <sch:ns prefix="prov" uri="http://www.w3.org/ns/prov#"/>
+
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
+
+  <sch:pattern abstract="true" id="CardinalityCheck">
+    <sch:title>Cardinality of $element in $context</sch:title>
+    <sch:rule context="$context">
+      <sch:assert test="count($element) &gt;= $min and ('$max' = 'n' or count($element) &lt;= $max)">
+        <sch:value-of select="'$context'"/>/<sch:value-of select="'$element'"/> should be of cardinality <sch:value-of select="'$min'"/>..<sch:value-of select="'$max'"/> but found <sch:value-of select="count($element)"/> nodes.</sch:assert>
+      <sch:report test="count($element) &gt;= $min and ('$max' = 'n' or count($element) &lt;= $max)">
+        <sch:value-of select="'$context'"/>/<sch:value-of select="'$element'"/> is of cardinality <sch:value-of select="'$min'"/>..<sch:value-of select="'$max'"/>. Found <sch:value-of select="count($element)"/> nodes.</sch:report>
+    </sch:rule>
+  </sch:pattern>
+
+  <sch:pattern is-a="CardinalityCheck" id="Dataset_hvdCategory">
+    <sch:param name="context" value="//dcat:Dataset"/>
+    <sch:param name="element" value="dcatap:hvdCategory"/>
+    <sch:param name="min" value="1"/>
+    <sch:param name="max" value="1"/>
+  </sch:pattern>
+  <sch:pattern is-a="CardinalityCheck" id="Dataset_applicableLegislation">
+    <sch:param name="context" value="//dcat:Dataset"/>
+    <sch:param name="element" value="dcatap:applicableLegislation"/>
+    <sch:param name="min" value="1"/>
+    <sch:param name="max" value="n"/>
+  </sch:pattern>
+  <sch:pattern is-a="CardinalityCheck" id="DataService_hvdCategory">
+    <sch:param name="context" value="//dcat:DataService"/>
+    <sch:param name="element" value="dcatap:hvdCategory"/>
+    <sch:param name="min" value="1"/>
+    <sch:param name="max" value="1"/>
+  </sch:pattern>
+  <sch:pattern is-a="CardinalityCheck" id="DataService_applicableLegislation">
+    <sch:param name="context" value="//dcat:DataService"/>
+    <sch:param name="element" value="dcatap:applicableLegislation"/>
+    <sch:param name="min" value="1"/>
+    <sch:param name="max" value="n"/>
+  </sch:pattern>
+</sch:schema>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd-rec.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd-rec.sch
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  <sch:ns prefix="spdx" uri="http://spdx.org/rdf/terms#"/>
+  <sch:ns prefix="owl" uri="http://www.w3.org/2002/07/owl#"/>
+  <sch:ns prefix="adms" uri="http://www.w3.org/ns/adms#"/>
+  <sch:ns prefix="locn" uri="http://www.w3.org/ns/locn#"/>
+  <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+  <sch:ns prefix="foaf" uri="http://xmlns.com/foaf/0.1/"/>
+  <sch:ns prefix="dct" uri="http://purl.org/dc/terms/"/>
+  <sch:ns prefix="vcard" uri="http://www.w3.org/2006/vcard/ns#"/>
+  <sch:ns prefix="dcat" uri="http://www.w3.org/ns/dcat#"/>
+  <sch:ns prefix="dcatap" uri="http://data.europa.eu/r5r/"/>
+  <sch:ns prefix="schema" uri="http://schema.org/"/>
+  <sch:ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="xml" uri="http://www.w3.org/XML/1998/namespace"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="dc" uri="http://purl.org/dc/elements/1.1/"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="mdcat" uri="https://data.vlaanderen.be/ns/metadata-dcat#"/>
+  <sch:ns prefix="geodcat" uri="http://data.europa.eu/930/"/>
+  <sch:ns prefix="generiek" uri="https://data.vlaanderen.be/ns/generiek#"/>
+  <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
+
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
+
+</sch:schema>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd.sch
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  <sch:ns prefix="spdx" uri="http://spdx.org/rdf/terms#"/>
+  <sch:ns prefix="owl" uri="http://www.w3.org/2002/07/owl#"/>
+  <sch:ns prefix="adms" uri="http://www.w3.org/ns/adms#"/>
+  <sch:ns prefix="locn" uri="http://www.w3.org/ns/locn#"/>
+  <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+  <sch:ns prefix="foaf" uri="http://xmlns.com/foaf/0.1/"/>
+  <sch:ns prefix="dct" uri="http://purl.org/dc/terms/"/>
+  <sch:ns prefix="vcard" uri="http://www.w3.org/2006/vcard/ns#"/>
+  <sch:ns prefix="dcat" uri="http://www.w3.org/ns/dcat#"/>
+  <sch:ns prefix="dcatap" uri="http://data.europa.eu/r5r/"/>
+  <sch:ns prefix="schema" uri="http://schema.org/"/>
+  <sch:ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="xml" uri="http://www.w3.org/XML/1998/namespace"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="dc" uri="http://purl.org/dc/elements/1.1/"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="mdcat" uri="https://data.vlaanderen.be/ns/metadata-dcat#"/>
+  <sch:ns prefix="geodcat" uri="http://data.europa.eu/930/"/>
+  <sch:ns prefix="generiek" uri="https://data.vlaanderen.be/ns/generiek#"/>
+  <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
+
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
+
+  <sch:pattern id="required_applicableLegislation">
+    <sch:title>Required applicable legislation value.</sch:title>
+    <sch:rule context="/">
+      <sch:assert test="//dcatap:applicableLegislation[@rdf:resource='http://data.europa.eu/eli/reg_impl/2023/138/oj']">
+        For HVD the value must include the ELI http://data.europa.eu/eli/reg_impl/2023/138/oj.
+      </sch:assert>
+      <sch:report test="//dcatap:applicableLegislation[@rdf:resource='http://data.europa.eu/eli/reg_impl/2023/138/oj']">
+        For HVD the value must include the ELI http://data.europa.eu/eli/reg_impl/2023/138/oj.
+      </sch:report>
+    </sch:rule>
+  </sch:pattern>
+</sch:schema>


### PR DESCRIPTION
- added translations
- added missing elements for DataService
- added hvd schematrons

I had a question @fxprunayre : you mentioned adding a fallback for the thesaurus dropdown menu, when the language is not available. An example would be dcatap:applicableLegislation, which doesn't have a `nl` label. Did you see this fallback happen in the core `XslUtil`, or would you solve it through the editor XSL?