### PR TITLE
Feature/vl install

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>gn-schemas</artifactId>
     <groupId>org.geonetwork-opensource.schemas</groupId>
-    <version>4.4.6-SNAPSHOT</version>
+    <version>4.4.6-0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -884,7 +884,7 @@
                   if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:description)=0">
             <template>
               <snippet>
-                <dct:description xml:lang=""></dct:description>
+                <dct:description xml:lang=""/>
               </snippet>
             </template>
           </action>
@@ -918,15 +918,45 @@
         </section>
 
         <section name="versionInformation">
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/owl:versionInfo"
-                 or="versionInfo"
-                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:modified"
-                 or="modified"
-                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:issued"
-                 or="issued"
-                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/owl:versionInfo" />
+          <action type="add" or="versionInfo" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/owl:versionInfo)=0">
+            <template>
+              <snippet>
+                <owl:versionInfo/>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:created" />
+          <action type="add" or="created" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:created)=0">
+            <template>
+              <snippet>
+                <dct:created/>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:modified" />
+          <action type="add" or="modified" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:modified)=0">
+            <template>
+              <snippet>
+                <dct:modified/>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:issued" />
+          <action type="add" or="issued" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:issued)=0">
+            <template>
+              <snippet>
+                <dct:issued/>
+              </snippet>
+            </template>
+          </action>
         </section>
         <section name="usageInformation">
           <section xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:contactPoint"/>
@@ -942,9 +972,24 @@
             </template>
           </action>
 
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:accessRights"
-                 or="accessRights"
-                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
+          <field
+            xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:accessRights"/>
+          <action type="add"
+                  or="accessRights"
+                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:accessRights) = 0"
+          >
+            <template>
+              <snippet>
+                <dct:accessRights>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel/>
+                    <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/access-right"/>
+                  </skos:Concept>
+                </dct:accessRights>
+              </snippet>
+            </template>
+          </action>
 
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:landingPage"/>
           <action type="add" or="landingPage" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
@@ -954,7 +999,22 @@
               </snippet>
             </template>
           </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:rights"/>
+          <action type="add" or="rights" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+            <template>
+              <snippet>
+                <dct:rights>
+                  <dct:RightsStatement>
+                    <dct:title/>
+                    <dct:description/>
+                  </dct:RightsStatement>
+                </dct:rights>
+              </snippet>
+            </template>
+          </action>
         </section>
+
         <section name="geographicalInformation">
           <section xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:spatial"/>
           <action type="add" or="spatial" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -135,6 +135,27 @@
         useReference="true"/>
     </for>
 
+    <for name="mdcat:statuut" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.GDI-Vlaanderen-trefwoorden"
+        xpath="/mdcat:statuut"/>
+    </for>
+    <for name="mdcat:ontwikkelingstoestand" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.ontwikkelingstoestand"
+        xpath="/mdcat:ontwikkelingstoestand"/>
+    </for>
+    <for name="mdcat:levensfase" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.levensfase"
+        xpath="/mdcat:levensfase"/>
+    </for>
+    <for name="mdcat:MAGDA-categorie" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.magda-domain"
+        xpath="/mdcat:MAGDA-categorie"/>
+    </for>
+
     <for name="mobilitydcatap:mobilityTheme" use="thesaurus-list-picker">
       <directiveAttributes
         thesaurus="external.theme.mobility-theme"
@@ -683,6 +704,7 @@
               </snippet>
             </template>
           </action>
+
           <!-- landingspaginaVoorAuthenticatie -->
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:landingspaginaVoorAuthenticatie"/>
           <action type="add" or="landingspaginaVoorAuthenticatie"
@@ -787,14 +809,14 @@
           displayTooltips="true"
           displayTooltipsMode="onhover"
           hideTimeInCalendar="true">
-      <tab id="hvd-tab"  default="true">
-        <section name="hvd-section">
+      <tab id="hvd-dataset-tab"  default="true" displayIfRecord="count(//dcat:dataset) > 0" hideIfNotDisplayed="true">
+        <section name="hvd-dataset-section">
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcatap:hvdCategory"/>
 
           <action type="add"
-                       or="hvdCategory"
-                       in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
-                       if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcatap:hvdCategory) = 0">
+                  or="hvdCategory"
+                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcatap:hvdCategory) = 0">
             <template>
               <snippet>
                 <dcatap:hvdCategory>
@@ -811,6 +833,38 @@
                   or="applicableLegislation"
                   in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
                   if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcatap:applicableLegislation) = 0">
+            <template>
+              <snippet>
+                <dcatap:applicableLegislation rdf:resource="http://data.europa.eu/eli/reg_impl/2023/138/oj"/>
+              </snippet>
+            </template>
+          </action>
+        </section>
+      </tab>
+      <tab id="hvd-dataservice-tab"  default="true" displayIfRecord="count(//dcat:service) > 0" hideIfNotDisplayed="true">
+        <section name="hvd-dataservice-section">
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcatap:hvdCategory"/>
+
+          <action type="add"
+                       or="hvdCategory"
+                       in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                       if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcatap:hvdCategory) = 0">
+            <template>
+              <snippet>
+                <dcatap:hvdCategory>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel xml:lang=""></skos:prefLabel>
+                  </skos:Concept>
+                </dcatap:hvdCategory>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcatap:applicableLegislation"/>
+          <action type="add"
+                  or="applicableLegislation"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcatap:applicableLegislation) = 0">
             <template>
               <snippet>
                 <dcatap:applicableLegislation rdf:resource="http://data.europa.eu/eli/reg_impl/2023/138/oj"/>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -442,6 +442,10 @@
   </multilingualFields>
 
   <views>
+    <view name="dcat-ap-vl">
+      <TODO></TODO>
+    </view>
+
     <view name="hvd-view"
           class="gn-label-above-input gn-indent-bluescale vl-editor-view"
           displayTooltips="true"

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -572,6 +572,27 @@
 <!--                   in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>-->
 
         </section>
+
+        <section name="geographicalInformation">
+          <section xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:spatial"/>
+          <action type="add" or="spatial" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+            <template>
+              <snippet>
+                <dct:spatial xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dct:Location rdf:about="http://mir.geopunt.be/cl/Geopunt/VlaamseAdminRegios/Vlaanderen">
+                    <locn:geometry rdf:datatype="http://www.opengis.net/ont/geosparql#wktLiteral">POLYGON ((5.92
+                      50.67,5.92 51.51,2.53 51.51,2.53 50.67,5.92 50.67))
+                    </locn:geometry>
+                    <locn:geometry rdf:datatype="http://www.opengis.net/ont/geosparql#gmlLiteral">&lt;gml:Polygon&gt;&lt;gml:exterior&gt;&lt;gml:LinearRing&gt;&lt;gml:posList&gt;50.67
+                      5.92 51.51 5.92 51.51 2.53 50.67 2.53 50.67 5.92&lt;/gml:posList&gt;&lt;/gml:LinearRing&gt;&lt;/gml:exterior&gt;&lt;/gml:Polygon&gt;
+                    </locn:geometry>
+                    <skos:prefLabel xml:lang="nl">Vlaams Gewest</skos:prefLabel>
+                  </dct:Location>
+                </dct:spatial>
+              </snippet>
+            </template>
+          </action>
+        </section>
       </tab>
 
       <tab id="vl-tab-service" default="true" mode="flat" displayIfRecord="count(//dcat:service) > 0" hideIfNotDisplayed="true">
@@ -1048,6 +1069,7 @@
             </template>
           </action>
         </section>
+
         <section name="extraInformation">
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:language"
                  or="language"

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -1095,14 +1095,13 @@
             <template>
               <snippet>
                 <dct:spatial xmlns:dc="http://purl.org/dc/elements/1.1/">
-                  <dct:Location rdf:about="http://mir.geopunt.be/cl/Geopunt/VlaamseAdminRegios/Vlaanderen">
-                    <locn:geometry rdf:datatype="http://www.opengis.net/ont/geosparql#wktLiteral">POLYGON ((5.92
-                      50.67,5.92 51.51,2.53 51.51,2.53 50.67,5.92 50.67))
+                  <dct:Location rdf:about="http://www.naturalearthdata.com/ne_admin#Continent/Europe">
+                    <locn:geometry rdf:datatype="http://www.opengis.net/ont/geosparql#wktLiteral">
+                      POLYGON ((43.2 35.3,43.2 81.4,-11.5 81.4,-11.5 35.3,43.2 35.3))
                     </locn:geometry>
-                    <locn:geometry rdf:datatype="http://www.opengis.net/ont/geosparql#gmlLiteral">&lt;gml:Polygon&gt;&lt;gml:exterior&gt;&lt;gml:LinearRing&gt;&lt;gml:posList&gt;50.67
-                      5.92 51.51 5.92 51.51 2.53 50.67 2.53 50.67 5.92&lt;/gml:posList&gt;&lt;/gml:LinearRing&gt;&lt;/gml:exterior&gt;&lt;/gml:Polygon&gt;
+                    <locn:geometry rdf:datatype="http://www.opengis.net/ont/geosparql#gmlLiteral">
+                      &lt;gml:Polygon&gt;&lt;gml:exterior&gt;&lt;gml:LinearRing&gt;&lt;gml:posList&gt;35.3 43.2 81.4 43.2 81.4 -11.5 35.3 -11.5 35.3 43.2&lt;/gml:posList&gt;&lt;/gml:LinearRing&gt;&lt;/gml:exterior&gt;&lt;/gml:Polygon&gt;
                     </locn:geometry>
-                    <skos:prefLabel xml:lang="nl">Vlaams Gewest</skos:prefLabel>
                   </dct:Location>
                 </dct:spatial>
               </snippet>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -502,7 +502,7 @@
 
   <views>
     <view name="vl-view"
-          class="gn-label-above-input gn-indent-bluescale vl-editor-view"
+          class="gn-label-above-input gn-indent-bluescale"
           displayTooltips="true"
           displayTooltipsMode="onhover"
           displayIfRecord="count(//dcat:CatalogRecord/dct:conformsTo) > 0"
@@ -589,6 +589,19 @@
                     <skos:prefLabel xml:lang="nl">Vlaams Gewest</skos:prefLabel>
                   </dct:Location>
                 </dct:spatial>
+              </snippet>
+            </template>
+          </action>
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:temporal"/>
+          <action type="add" or="temporal" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+            <template>
+              <snippet>
+                <dct:temporal>
+                  <dct:PeriodOfTime>
+                    <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"/>
+                    <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"/>
+                  </dct:PeriodOfTime>
+                </dct:temporal>
               </snippet>
             </template>
           </action>
@@ -770,7 +783,7 @@
     </view>
 
     <view name="hvd-view"
-          class="gn-label-above-input gn-indent-bluescale vl-editor-view"
+          class="gn-label-above-input gn-indent-bluescale"
           displayTooltips="true"
           displayTooltipsMode="onhover"
           hideTimeInCalendar="true">
@@ -809,7 +822,7 @@
     </view>
 
     <view name="mobility-view"
-          class="gn-label-above-input gn-indent-bluescale vl-editor-view"
+          class="gn-label-above-input gn-indent-bluescale"
           displayTooltips="true"
           displayTooltipsMode="onhover"
           hideTimeInCalendar="true">
@@ -912,7 +925,7 @@
 
     <view name="default"
           default="true"
-          class="gn-label-above-input gn-indent-bluescale vl-editor-view"
+          class="gn-label-above-input gn-indent-bluescale"
           displayTooltips="true"
           displayTooltipsMode="onhover"
           hideTimeInCalendar="true">
@@ -1032,6 +1045,7 @@
             </template>
           </action>
         </section>
+
         <section name="usageInformation">
           <section xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:contactPoint"/>
           <action type="add" or="contactPoint" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
@@ -1220,13 +1234,19 @@
             </template>
           </action>
 
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:keyword"
-                 or="keyword"
-                 in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"/>
-
-<!--          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:theme"-->
-<!--                 or="theme"-->
-<!--                 in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"/>-->
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:publisher"/>
+          <action type="add" or="publisher" in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:publisher) = 0">
+            <template>
+              <snippet>
+                <dct:publisher>
+                  <foaf:Agent>
+                    <foaf:name xml:lang="nl"/>
+                  </foaf:Agent>
+                </dct:publisher>
+              </snippet>
+            </template>
+          </action>
 
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:endpointURL"/>
           <action type="add" or="endpointURL" in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
@@ -1255,15 +1275,96 @@
             </template>
           </action>
           <action type="associatedResource" name="linkToDataset" process="dataset"/>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:keyword"/>
+          <action type="add" or="keyword" in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+            <template>
+              <snippet>
+                <dcat:keyword/>
+              </snippet>
+            </template>
+          </action>
+        </section>
+
+        <section name="usageInformation">
+          <section xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:contactPoint"/>
+          <action type="add" or="contactPoint" in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+            <template>
+              <snippet>
+                <dcat:contactPoint>
+                  <vcard:Organization>
+                    <vcard:hasEmail rdf:resource=""/>
+                  </vcard:Organization>
+                </dcat:contactPoint>
+              </snippet>
+            </template>
+          </action>
+
+          <field
+            xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:accessRights"/>
+          <action type="add"
+                  or="accessRights"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:accessRights) = 0"
+          >
+            <template>
+              <snippet>
+                <dct:accessRights>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel/>
+                    <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/access-right"/>
+                  </skos:Concept>
+                </dct:accessRights>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:landingPage"/>
+          <action type="add" or="landingPage" in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+            <template>
+              <snippet>
+                <dcat:landingPage rdf:resource=""/>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:rights"/>
+          <action type="add" or="rights" in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+            <template>
+              <snippet>
+                <dct:rights>
+                  <dct:RightsStatement>
+                    <dct:title/>
+                    <dct:description/>
+                  </dct:RightsStatement>
+                </dct:rights>
+              </snippet>
+            </template>
+          </action>
         </section>
 
         <section name="serviceInformation">
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:accessRights" or="accessRights"
-                 in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"/>
           <section xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:license"/>
           <action type="add" or="license" in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
             <template>
               <snippets name="licenses"/>
+            </template>
+          </action>
+        </section>
+
+        <section name="extraInformation">
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:conformsTo"/>
+          <action type="add" or="conformsTo" in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+            <template>
+              <snippet>
+                <dct:conformsTo>
+                  <dct:Standard>
+                    <dct:identifier/>
+                    <dct:title xml:lang=""/>
+                    <dct:description xml:lang=""/>
+                  </dct:Standard>
+                </dct:conformsTo>
+              </snippet>
             </template>
           </action>
         </section>
@@ -1280,6 +1381,7 @@
                  or="language"
                  in="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord"/>
         </section>
+
         <section name="conformToInformation">
           <field
             xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:conformsTo/dct:Standard/dct:identifier"/>
@@ -1290,6 +1392,7 @@
             xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:conformsTo/dct:Standard/owl:versionInfo"/>
         </section>
       </tab>
+
       <flatModeExceptions>
         <!-- Basic information -->
         <for name="rdf:about"/>
@@ -1330,7 +1433,7 @@
     </view>
 
     <view name="advanced"
-          class="gn-label-above-input gn-indent-bluescale vl-editor-view"
+          class="gn-label-above-input gn-indent-bluescale"
           displayTooltips="true"
           displayTooltipsMode="onhover"
           hideTimeInCalendar="true">

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -714,6 +714,59 @@
                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"/>
         </section>
       </tab>
+
+      <tab id="vl-tab-distribution" mode="flat" displayIfRecord="count(//dcat:dataset) > 0" hideIfNotDisplayed="true">
+        <section>
+          <section name="distribution"
+                   forEach="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:distribution"
+                   del=".">
+            <field xpath="dcat:Distribution/dct:title" or="title" in="dcat:Distribution"/>
+            <field xpath="dcat:Distribution/dct:description" or="description" in="dcat:Distribution"/>
+            <field xpath="dcat:Distribution/dcat:accessURL" or="accessURL" in="dcat:Distribution"/>
+            <field xpath="dcat:Distribution/dct:format" or="format" in="dcat:Distribution"/>
+            <field xpath="dcat:Distribution/dcat:mediaType" or="mediaType" in="dcat:Distribution"/>
+            <field xpath="dcat:Distribution/dct:language" or="language" in="dcat:Distribution"/>
+            <section xpath="dcat:Distribution/dct:license"/>
+            <action type="add" or="license" in="dcat:Distribution">
+              <template>
+                <snippets name="licenses-vl"/>
+              </template>
+            </action>
+            <section xpath="dcat:Distribution/dct:rights"/>
+            <action type="add" or="rights" in="dcat:Distribution">
+              <template>
+                <snippet>
+                  <dct:rights>
+                    <dct:RightsStatement>
+                      <dct:title xml:lang="nl"/>
+                      <dct:description xml:lang="nl"/>
+                    </dct:RightsStatement>
+                  </dct:rights>
+                </snippet>
+              </template>
+            </action>
+            <section xpath="dcat:Distribution/dct:conformsTo"/>
+            <action type="add" or="conformsTo" in="dcat:Distribution">
+              <template>
+                <snippets name="protocols"/>
+              </template>
+            </action>
+          </section>
+          <action type="add" or="distribution" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+            <template>
+              <snippet>
+                <dcat:distribution>
+                  <dcat:Distribution>
+                    <dct:title xml:lang="nl"/>
+                    <dct:description xml:lang="nl"/>
+                    <dcat:accessURL rdf:resource=""/>
+                  </dcat:Distribution>
+                </dcat:distribution>
+              </snippet>
+            </template>
+          </action>
+        </section>
+      </tab>
     </view>
 
     <view name="hvd-view"
@@ -1524,6 +1577,98 @@
             </dct:type>
             <dct:title xml:lang=""/>
             <dct:description xml:lang=""/>
+            <!--dct:identifier/-->
+          </dct:LicenseDocument>
+        </dct:license>
+      </snippet>
+    </list>
+    <list name="licenses-vl">
+      <snippet label="license-modellicentie-gratis">
+        <dct:license>
+          <dct:LicenseDocument rdf:about="https://data.vlaanderen.be/id/licentie/modellicentie-gratis-hergebruik/v1.0">
+            <dct:type>
+              <skos:Concept rdf:about="http://purl.org/adms/licencetype/Attribution">
+                <skos:prefLabel xml:lang="nl">Verplichte bronvermelding</skos:prefLabel>
+                <skos:prefLabel xml:lang="en">Attribution</skos:prefLabel>
+                <skos:prefLabel xml:lang="fr">Attribution</skos:prefLabel>
+                <skos:prefLabel xml:lang="de">Attribution</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0"/>
+              </skos:Concept>
+            </dct:type>
+            <dct:title xml:lang="nl">Modellicentie voor gratis hergebruik</dct:title>
+            <dct:description xml:lang="nl">Onder deze licentie doet de instantie geen afstand van haar intellectuele rechten, maar mag de data voor eender welk doel hergebruikt worden, gratis en onder minimale restricties.</dct:description>
+            <dct:identifier>https://data.vlaanderen.be/id/licentie/modellicentie-gratis-hergebruik/v1.0</dct:identifier>
+          </dct:LicenseDocument>
+        </dct:license>
+      </snippet>
+      <snippet label="license-cc0">
+        <dct:license>
+          <dct:LicenseDocument rdf:about="https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0">
+            <dct:type>
+              <skos:Concept rdf:about="http://purl.org/adms/licencetype/PublicDomain">
+                <skos:prefLabel xml:lang="nl">Werk in het publiek domein</skos:prefLabel>
+                <skos:prefLabel xml:lang="en">Public domain</skos:prefLabel>
+                <skos:prefLabel xml:lang="fr">Public domain</skos:prefLabel>
+                <skos:prefLabel xml:lang="de">Public domain</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0"/>
+              </skos:Concept>
+            </dct:type>
+            <dct:title xml:lang="nl">Creative Commons Zero verklaring</dct:title>
+            <dct:description xml:lang="nl">De instantie doet afstand van haar intellectuele eigendomsrechten voor zover dit wettelijk mogelijk is. Hierdoor kan de gebruiker de data hergebruiken voor eender welk doel, zonder een verplichting op naamsvermelding. Deze is de welbekende CC0 licentie.</dct:description>
+            <dct:identifier>https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0</dct:identifier>
+          </dct:LicenseDocument>
+        </dct:license>
+      </snippet>
+      <snippet label="license-modellicentie-hergebruik">
+        <dct:license>
+          <dct:LicenseDocument rdf:about="https://data.vlaanderen.be/id/licentie/modellicentie-hergebruik-tegen-vergoeding/v1.0">
+            <dct:type>
+              <skos:Concept rdf:about="http://purl.org/adms/licencetype/Attribution">
+                <skos:prefLabel xml:lang="nl">Verplichte bronvermelding</skos:prefLabel>
+                <skos:prefLabel xml:lang="en">Attribution</skos:prefLabel>
+                <skos:prefLabel xml:lang="fr">Attribution</skos:prefLabel>
+                <skos:prefLabel xml:lang="de">Attribution</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0" />
+              </skos:Concept>
+            </dct:type>
+            <dct:title xml:lang="nl">Modellicentie voor hergebruik tegen vergoeding</dct:title>
+            <dct:description xml:lang="nl">Onder deze licentie stelt de instantie nog steeds haar data ter beschikking voor eender welk hergebruik, maar wil zij hiervoor een vergoeding ontvangen. In regel is deze vergoeding beperkt tot de marginale kosten voor vermenigvuldiging, verstrekking en verspreiding.</dct:description>
+            <dct:identifier>https://data.vlaanderen.be/id/licentie/modellicentie-hergebruik-tegen-vergoeding/v1.0</dct:identifier>
+          </dct:LicenseDocument>
+        </dct:license>
+      </snippet>
+      <snippet label="license-onvoorwaardelijk">
+        <dct:license>
+          <dct:LicenseDocument rdf:about="https://data.vlaanderen.be/id/licentie/onvoorwaardelijk-hergebruik/v1.0">
+            <dct:type>
+              <skos:Concept rdf:about="http://purl.org/adms/licencetype/PublicDomain">
+                <skos:prefLabel xml:lang="nl">Werk in het publiek domein</skos:prefLabel>
+                <skos:prefLabel xml:lang="en">Public domain</skos:prefLabel>
+                <skos:prefLabel xml:lang="fr">Public domain</skos:prefLabel>
+                <skos:prefLabel xml:lang="de">Public domain</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0" />
+              </skos:Concept>
+            </dct:type>
+            <dct:title xml:lang="nl">Onvoorwaardelijk hergebruik</dct:title>
+            <dct:description xml:lang="nl">Onvoorwaardelijk hergebruik</dct:description>
+            <dct:identifier>https://data.vlaanderen.be/id/licentie/onvoorwaardelijk-hergebruik/v1.0</dct:identifier>
+          </dct:LicenseDocument>
+        </dct:license>
+      </snippet>
+      <snippet label="license-empty">
+        <dct:license>
+          <dct:LicenseDocument rdf:about="">
+            <dct:type>
+              <skos:Concept>
+                <skos:prefLabel xml:lang="nl"/>
+                <skos:prefLabel xml:lang="en"/>
+                <skos:prefLabel xml:lang="fr"/>
+                <skos:prefLabel xml:lang="de"/>
+                <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0"/>
+              </skos:Concept>
+            </dct:type>
+            <dct:title xml:lang="nl"/>
+            <dct:description xml:lang="nl"/>
             <!--dct:identifier/-->
           </dct:LicenseDocument>
         </dct:license>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -165,6 +165,33 @@
         xpath="/mobilitydcatap:intendedInformationService"/>
     </for>
 
+    <for name="mdcat:MAGDA-categorie" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.magda-domain"
+        xpath="/mdcat:MAGDA-categorie"
+        labelKey="mdcat.addMagdaCategorie"/>
+    </for>
+    <for name="mdcat:statuut" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.GDI-Vlaanderen-trefwoorden"
+        xpath="/mdcat:statuut"
+        labelKey="mdcat.addStatuut"/>
+    </for>
+    <for name="mdcat:levensfase" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.levensfase"
+        xpath="/mdcat:levensfase"
+        max="1"
+        labelKey="mdcat.addLevensfase"/>
+    </for>
+    <for name="mdcat:ontwikkelingstoestand" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.ontwikkelingstoestand"
+        xpath="/mdcat:ontwikkelingstoestand"
+        max="1"
+        labelKey="mdcat.addOntwikkelingstoestand"/>
+    </for>
+
     <!-- Check layout-custom-fields-date.xsl for logic -->
     <for name="dct:created" use="gn-date-picker"/>
     <for name="dct:issued" use="gn-date-picker"/>
@@ -343,6 +370,38 @@
         </snippet>
       </template>
     </for>
+
+    <!-- dcat-ap-vl -->
+    <for name="mdcat:landingspaginaVoorAuthenticatie" templateModeOnly="true" forceLabel="true" label="key">
+      <template>
+        <values>
+          <key label="key" xpath="@rdf:resource" tooltip="mdcat:landingspaginaVoorAuthenticatie"/>
+        </values>
+        <snippet>
+          <mdcat:landingspaginaVoorAuthenticatie rdf:resource="{{key}}"/>
+        </snippet>
+      </template>
+    </for>
+    <for name="mdcat:landingspaginaVoorGebruiksinformatie" templateModeOnly="true" forceLabel="true" label="key">
+      <template>
+        <values>
+          <key label="key" xpath="@rdf:resource" tooltip="mdcat:landingspaginaVoorGebruiksinformatie"/>
+        </values>
+        <snippet>
+          <mdcat:landingspaginaVoorGebruiksinformatie rdf:resource="{{key}}"/>
+        </snippet>
+      </template>
+    </for>
+    <for name="mdcat:landingspaginaVoorStatusinformatie" templateModeOnly="true" forceLabel="true" label="key">
+      <template>
+        <values>
+          <key label="key" xpath="@rdf:resource" tooltip="mdcat:landingspaginaVoorStatusinformatie"/>
+        </values>
+        <snippet>
+          <mdcat:landingspaginaVoorStatusinformatie rdf:resource="{{key}}"/>
+        </snippet>
+      </template>
+    </for>
   </fields>
 
   <!-- Complex fields. -->
@@ -442,8 +501,198 @@
   </multilingualFields>
 
   <views>
-    <view name="dcat-ap-vl">
-      <TODO></TODO>
+    <view name="vl-view"
+          class="gn-label-above-input gn-indent-bluescale vl-editor-view"
+          displayTooltips="true"
+          displayTooltipsMode="onhover"
+          displayIfRecord="count(//dcat:CatalogRecord/dct:conformsTo) > 0"
+          hideTimeInCalendar="true">
+      <tab id="vl-tab-dataset" default="true" mode="flat" displayIfRecord="count(//dcat:dataset) > 0" hideIfNotDisplayed="true">
+        <section name="vl-section-metadatadcat">
+          <!-- MAGDA-categorie-->
+          <field
+            xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mdcat:MAGDA-categorie"/>
+          <action type="add"
+                  or="MAGDA-categorie"
+                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mdcat:MAGDA-categorie) = 0"
+          >
+            <template>
+              <snippet>
+                <mdcat:MAGDA-categorie>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel/>
+                    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/MAGDA-categorie"/>
+                  </skos:Concept>
+                </mdcat:MAGDA-categorie>
+              </snippet>
+            </template>
+          </action>
+
+          <!-- statuut-->
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mdcat:statuut"/>
+          <action type="add"
+                  or="statuut"
+                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mdcat:statuut) = 0"
+          >
+            <template>
+              <snippet>
+                <mdcat:statuut>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel/>
+                    <skos:inScheme rdf:resource="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden"/>
+                  </skos:Concept>
+                </mdcat:statuut>
+              </snippet>
+            </template>
+          </action>
+
+          <!-- Theme: vocab.belgif.be/auth/datatheme -->
+          <!-- TODO: custom label to indicate this is about themes from the specific thesaurus? -->
+<!--          <dcat:theme>-->
+<!--            <skos:Concept rdf:about="http://vocab.belgif.be/auth/datatheme/CULT">-->
+<!--              <skos:prefLabel xml:lang="nl">Cultuur en sport</skos:prefLabel>-->
+<!--              <skos:prefLabel xml:lang="en">Culture and sport</skos:prefLabel>-->
+<!--              <skos:inScheme rdf:resource="http://vocab.belgif.be/auth/datatheme"/>-->
+<!--            </skos:Concept>-->
+<!--          </dcat:theme>-->
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme[skos:Concept/skos:inScheme/@rdf:resource = 'http://vocab.belgif.be/auth/datatheme']"
+                 or="theme"
+                 use="data-gn-keyword-picker"
+                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+            <directiveAttributes
+              thesaurus="external.theme.datatheme"
+              xpath="/dcat:theme"
+              max=""
+              labelKey="dcat-addThemes"/>
+          </field>
+<!--            <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme"-->
+<!--                   or="theme"-->
+<!--                   in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>-->
+
+        </section>
+      </tab>
+
+      <tab id="vl-tab-service" default="true" mode="flat" displayIfRecord="count(//dcat:service) > 0" hideIfNotDisplayed="true">
+        <!-- TODO the standard is referred to as https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22, and sometimes as https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat. How to deal with these variants? -->
+        <section name="vl-section-metadatadcat" displayIfRecord="count(//dct:conformsTo/dct:Standard[starts-with(@rdf:about,'https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat')]) > 0">
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:MAGDA-categorie"/>
+          <action type="add"
+                  or="MAGDA-categorie"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:MAGDA-categorie) = 0">
+            <template>
+              <snippet>
+                <mdcat:MAGDA-categorie>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel/>
+                    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/MAGDA-categorie"/>
+                  </skos:Concept>
+                </mdcat:MAGDA-categorie>
+              </snippet>
+            </template>
+          </action>
+
+          <!-- statuut-->
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:statuut"/>
+          <action type="add"
+                  or="statuut"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:statuut) = 0"
+          >
+            <template>
+              <snippet>
+                <mdcat:statuut>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel/>
+                    <skos:inScheme rdf:resource="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden"/>
+                  </skos:Concept>
+                </mdcat:statuut>
+              </snippet>
+            </template>
+          </action>
+
+          <!-- levensfase -->
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:levensfase"/>
+          <action type="add"
+                  or="levensfase"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:levensfase) = 0"
+          >
+            <template>
+              <snippet>
+                <mdcat:levensfase>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel/>
+                    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/levensfase"/>
+                  </skos:Concept>
+                </mdcat:levensfase>
+              </snippet>
+            </template>
+          </action>
+
+          <!-- ontwikkelingstoestand -->
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:ontwikkelingstoestand"/>
+          <action type="add"
+                  or="ontwikkelingstoestand"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:ontwikkelingstoestand) = 0">
+            <template>
+              <snippet>
+                <mdcat:ontwikkelingstoestand>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel/>
+                    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/ontwikkelingstoestand"/>
+                  </skos:Concept>
+                </mdcat:ontwikkelingstoestand>
+              </snippet>
+            </template>
+          </action>
+          <!-- landingspaginaVoorAuthenticatie -->
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:landingspaginaVoorAuthenticatie"/>
+          <action type="add" or="landingspaginaVoorAuthenticatie"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:landingspaginaVoorAuthenticatie) = 0">
+            <template>
+              <snippet>
+                <mdcat:landingspaginaVoorAuthenticatie rdf:resource=""/>
+              </snippet>
+            </template>
+          </action>
+
+          <!-- landingspaginaVoorStatusinformatie -->
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:landingspaginaVoorStatusinformatie"/>
+          <action type="add" or="landingspaginaVoorStatusinformatie"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:landingspaginaVoorStatusinformatie) = 0">
+            <template>
+              <snippet>
+                <mdcat:landingspaginaVoorStatusinformatie rdf:resource=""/>
+              </snippet>
+            </template>
+          </action>
+
+          <!-- landingspaginaVoorGebruiksinformatie -->
+          <field
+            xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:landingspaginaVoorGebruiksinformatie"/>
+          <action type="add" or="landingspaginaVoorGebruiksinformatie"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:landingspaginaVoorGebruiksinformatie) = 0">
+            <template>
+              <snippet>
+                <mdcat:landingspaginaVoorGebruiksinformatie rdf:resource=""/>
+              </snippet>
+            </template>
+          </action>
+
+          <!-- Theme: vocab.belgif.be/auth/datatheme -->
+          <!-- TODO: custom label to indicate this is about themes from the specific thesaurus? -->
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:theme"
+                 or="theme"
+                 in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"/>
+        </section>
+      </tab>
     </view>
 
     <view name="hvd-view"
@@ -619,9 +868,8 @@
       <tab id="tabDataset" default="true" mode="flat" displayIfRecord="count(//dcat:dataset) > 0"
            hideIfNotDisplayed="true">
         <section name="basicInformation">
+
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:title"/>
-
-
           <action type="add" or="title" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
                   if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:title)=0">
             <template>
@@ -631,9 +879,7 @@
             </template>
           </action>
 
-
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:description"/>
-
           <action type="add" or="description" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
                   if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:description)=0">
             <template>
@@ -644,7 +890,6 @@
           </action>
 
           <section xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:publisher"/>
-
           <action type="add" or="publisher" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
             <template>
               <snippet>
@@ -662,16 +907,16 @@
               </snippet>
             </template>
           </action>
+
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:keyword"
                  or="keyword"
                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme"
-                 or="theme"
-                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
+
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:identifier"
                  or="identifier"
                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
         </section>
+
         <section name="versionInformation">
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/owl:versionInfo"
                  or="versionInfo"
@@ -829,6 +1074,7 @@
               </snippet>
             </template>
           </action>
+
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:description"/>
           <action type="add" or="description"
                   in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
@@ -839,6 +1085,15 @@
               </snippet>
             </template>
           </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:keyword"
+                 or="keyword"
+                 in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"/>
+
+<!--          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:theme"-->
+<!--                 or="theme"-->
+<!--                 in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"/>-->
+
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:endpointURL"/>
           <action type="add" or="endpointURL" in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
             <template>

--- a/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
@@ -58,13 +58,24 @@
 
   <!-- Get the list of other languages in JSON -->
   <xsl:template name="get-dcat-ap-other-languages-as-json">
-    <xsl:variable name="langs">
-      <xsl:for-each select="$metadata//dcat:CatalogRecord/dct:language">
 
+    <xsl:variable name="langURIs">
+      <xsl:for-each select="$metadata//dcat:CatalogRecord/dct:language/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)">
+        <langURI>
+          <xsl:value-of select="string()"/>
+        </langURI>
+      </xsl:for-each>
+      <langURI>http://publications.europa.eu/resource/authority/language/ENG</langURI>
+      <langURI>http://publications.europa.eu/resource/authority/language/NLD</langURI>
+      <langURI>http://publications.europa.eu/resource/authority/language/DEU</langURI>
+      <langURI>http://publications.europa.eu/resource/authority/language/FRA</langURI>
+    </xsl:variable>
+    <xsl:variable name="langs">
+      <xsl:for-each select="distinct-values($langURIs/langURI)">
         <xsl:variable name="languageCode">
           <xsl:call-template name="get-dcat-ap-language">
             <xsl:with-param name="languageIri"
-                            select="(@rdf:resource, skos:Concept/@rdf:about, dct:LinguisticSystem/@rdf:about)[1]"/>
+                            select="."/>
           </xsl:call-template>
         </xsl:variable>
 

--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -631,4 +631,51 @@
     <description>Tooltip: Resource URI</description>
     <btnLabel>Resource URI</btnLabel>
   </element>
+
+  <element name="mobilitydcatap:mobilityTheme">
+    <label>Mobility theme</label>
+    <description>This property refers to the mobility-related theme (i.e., a specific subject, category, or type) of the delivered content.
+      A dataset may be associated with multiple themes. A theme is important for data seekers who are interested in a particular type of data content.</description>
+  </element>
+  <element name="mobilitydcatap:transportMode">
+    <label>Transport mode</label>
+    <description>This property describes the transport mode that is covered by the delivered content. Data can be valid for more than one mode, so a multiple choice should be applied.</description>
+  </element>
+  <element name="mobilitydcatap:networkCoverage">
+    <label>Network coverage</label>
+    <description>This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed.
+      For other transport modes, the property is meant to refer to the physical infrastructure which is used by the services covered by the data.
+      For all modes, the property SHOULD also indicate if the data content relates to the EU’s trans-European transport network [EU-TEN-T].</description>
+  </element>
+  <element name="mobilitydcatap:georeferencingMethod">
+    <label>Georeferencing method</label>
+    <description>This property SHOULD be used to specify the georeferencing method used in the dataset.</description>
+  </element>
+  <element name="mobilitydcatap:intendedInformationService">
+    <label>Intended information service</label>
+    <description>This property MAY describe predefined information services, which the data content is intended to support.
+      Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR].
+      Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
+  </element>
+
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Dataset belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Data Service belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Dataset.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Data Service.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
 </labels>

--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd-cardinalities.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd-cardinalities.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Kardinaliteiten</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd-rec.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Aanbevolen</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-hvd.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Verplicht</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/dut/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/strings.xml
@@ -86,4 +86,18 @@
   <protocol-49>LINK-1.0-http--link</protocol-49>
   <protocol-50>LINK-1.0-http--related</protocol-50>
   <protocol-51>Vul uw eigen protocol in...</protocol-51>
+
+  <hvd-view>High Value Dataset</hvd-view>
+  <hvd-tab>High Value Dataset</hvd-tab>
+  <hvd-section>High Value Dataset (HVD)</hvd-section>
+
+  <mobility-view>Mobility</mobility-view>
+  <mobility-tab>Mobility</mobility-tab>
+  <mobility-section>Mobility</mobility-section>
+
+  <vl-view>Vlaanderen</vl-view>
+  <vl-tab-service>Service</vl-tab-service>
+  <vl-tab-dataset>Dataset</vl-tab-dataset>
+  <vl-section-metadatadcat>Metadata DCAT</vl-section-metadatadcat>
+  <vl-section-dcatapvl>DCAT-AP Vlaanderen</vl-section-dcatapvl>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/dut/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/strings.xml
@@ -98,6 +98,7 @@
   <vl-view>Vlaanderen</vl-view>
   <vl-tab-service>Service</vl-tab-service>
   <vl-tab-dataset>Dataset</vl-tab-dataset>
+  <vl-tab-distribution>Distributies</vl-tab-distribution>
   <vl-section-metadatadcat>Metadata DCAT</vl-section-metadatadcat>
   <vl-section-dcatapvl>DCAT-AP Vlaanderen</vl-section-dcatapvl>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/labels.xml
@@ -972,4 +972,62 @@
       Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
   </element>
 
+  <element name="mdcat:statuut">
+    <label>Statute</label>
+    <description>Tooltip: Statute</description>
+    <btnLabel>Statute</btnLabel>
+  </element>
+  <element name="mdcat:MAGDA-categorie">
+    <label>MAGDA-category</label>
+    <description>Tooltip: MAGDA-category</description>
+    <btnLabel>MAGDA-category</btnLabel>
+  </element>
+  <element name="mdcat:landingspaginaVoorAuthenticatie">
+    <label>Landingpage for authentication</label>
+    <description>Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de
+      dataservice.
+    </description>
+    <btnLabel>Landingpage for authentication</btnLabel>
+  </element>
+  <element name="rdf:resource" context="mdcat:landingspaginaVoorAuthenticatie">
+    <label>Landingpage for authentication</label>
+    <description>Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de
+      dataservice.
+    </description>
+    <btnLabel>Landingpage for authentication</btnLabel>
+  </element>
+  <element name="mdcat:landingspaginaVoorGebruiksinformatie">
+    <label>Landingpage for usage information</label>
+    <description>Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de
+      dataservice.
+    </description>
+    <btnLabel>Landingpage for usage information</btnLabel>
+  </element>
+  <element name="rdf:resource" context="mdcat:landingspaginaVoorGebruiksinformatie">
+    <label>Landingpage for usage information</label>
+    <description>Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de
+      dataservice.
+    </description>
+    <btnLabel>Landingpage for usage information</btnLabel>
+  </element>
+  <element name="mdcat:landingspaginaVoorStatusinformatie">
+    <label>Landingpage for status information</label>
+    <description>Een verwijzing naar de statuspagina van de dataservice.</description>
+    <btnLabel>Landingpage for status information</btnLabel>
+  </element>
+  <element name="rdf:resource" context="mdcat:landingspaginaVoorStatusinformatie">
+    <label>Landingpage for status information</label>
+    <description>Een verwijzing naar de statuspagina van de dataservice.</description>
+    <btnLabel>Landingpage for status information</btnLabel>
+  </element>
+  <element name="mdcat:levensfase">
+    <label>Lifecycle phase</label>
+    <description>The phase of the lifecycle of the dataservice.</description>
+    <btnLabel>Lifecycle phase</btnLabel>
+  </element>
+  <element name="mdcat:ontwikkelingstoestand">
+    <label>Development status</label>
+    <description>The development status of the deployed dataservice.</description>
+    <btnLabel>Development status</btnLabel>
+  </element>
 </labels>

--- a/src/main/plugin/dcat-ap/loc/eng/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/labels.xml
@@ -191,9 +191,9 @@
     <btnLabel>Frequency</btnLabel>
   </element>
   <element name="dct:conformsTo">
-    <label>conforms to standard</label>
+    <label>Conforms to standard</label>
     <description>An established standard to which the described resource conforms.</description>
-    <btnLabel>conforms to standard</btnLabel>
+    <btnLabel>Conforms to standard</btnLabel>
   </element>
   <element name="dct:created">
     <label>Creation date</label>

--- a/src/main/plugin/dcat-ap/loc/eng/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/labels.xml
@@ -1,4 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
 <labels xmlns:dct="http://purl.org/dc/terms/" xmlns:spdx="http://spdx.org/rdf/terms#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:locn="http://www.w3.org/ns/locn#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:schema="http://schema.org/">
   <element name="adms:Identifier">
     <label>Other identifier</label>
@@ -926,26 +950,6 @@
     <btnLabel>Language</btnLabel>
   </element>
 
-
-  <!-- PROFILE / DCAT-AP-HVD -->
-  <element name="dcatap:hvdCategory">
-    <label>HVD category</label>
-    <description>The HVD category to which this Dataset belongs.
-      The HVD IR defines six thematic data categories: geospatial, earth observation and environment, meteorological, statistics, companies and company ownership, and mobility.
-      A new property HVD category is introduced to indicate the HVD category to which an resource, i.e. a dataset, belongs.
-      The controlled vocabulary with all possible values is maintained by the Publications Office.
-      A resource may belong to more than one data category.</description>
-  </element>
-  <element name="dcatap:applicableLegislation">
-    <label>Applicable legislation</label>
-    <description>The legislation that mandates the creation or management of the Data Service. For HVD the value MUST include the ELI http://data.europa.eu/eli/reg_impl/2023/138/oj.
-      As multiple legislations may apply to the resource the maximum cardinality is not limited. </description>
-  </element>
-
-
-
-
-
   <element name="mobilitydcatap:mobilityTheme">
     <label>Mobility theme</label>
     <description>This property refers to the mobility-related theme (i.e., a specific subject, category, or type) of the delivered content.
@@ -970,6 +974,27 @@
     <description>This property MAY describe predefined information services, which the data content is intended to support.
       Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR].
       Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
+  </element>
+
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Dataset belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Data Service belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Dataset.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Data Service.</description>
+    <btnLabel>applicable legislation</btnLabel>
   </element>
 
   <element name="mdcat:statuut">

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd-cardinalities.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd-cardinalities.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Cardinalities</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd-rec.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Recommended</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-hvd.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Mandatory</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/eng/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/strings.xml
@@ -98,6 +98,7 @@
   <vl-view>Flanders</vl-view>
   <vl-tab-service>Service</vl-tab-service>
   <vl-tab-dataset>Dataset</vl-tab-dataset>
+  <vl-tab-distribution>Distributions</vl-tab-distribution>
   <vl-section-metadatadcat>Metadata DCAT</vl-section-metadatadcat>
   <vl-section-dcatapvl>DCAT-AP Vlaanderen</vl-section-dcatapvl>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/strings.xml
@@ -94,4 +94,10 @@
   <mobility-view>Mobility</mobility-view>
   <mobility-tab>Mobility</mobility-tab>
   <mobility-section>Mobility</mobility-section>
+
+  <vl-view>Flanders</vl-view>
+  <vl-tab-service>Service</vl-tab-service>
+  <vl-tab-dataset>Dataset</vl-tab-dataset>
+  <vl-section-metadatadcat>Metadata DCAT</vl-section-metadatadcat>
+  <vl-section-dcatapvl>DCAT-AP Vlaanderen</vl-section-dcatapvl>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/strings.xml
@@ -87,13 +87,15 @@
   <protocol-50>LINK-1.0-http--related</protocol-50>
   <protocol-51>Enter your own protocol...</protocol-51>
 
+  <hvd-dataservice-section>High Value Dataset (HVD)</hvd-dataservice-section>
+  <hvd-dataservice-tab>Data Service</hvd-dataservice-tab>
+  <hvd-dataset-section>High Value Dataset (HVD)</hvd-dataset-section>
+  <hvd-dataset-tab>Dataset</hvd-dataset-tab>
   <hvd-view>High Value Dataset</hvd-view>
-  <hvd-tab>High Value Dataset</hvd-tab>
-  <hvd-section>High Value Dataset (HVD)</hvd-section>
 
-  <mobility-view>Mobility</mobility-view>
-  <mobility-tab>Mobility</mobility-tab>
   <mobility-section>Mobility</mobility-section>
+  <mobility-tab>Mobility</mobility-tab>
+  <mobility-view>Mobility</mobility-view>
 
   <vl-view>Flanders</vl-view>
   <vl-tab-service>Service</vl-tab-service>

--- a/src/main/plugin/dcat-ap/loc/fre/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/labels.xml
@@ -2196,4 +2196,51 @@
     <description>Tooltip: in scheme</description>
     <btnLabel>in scheme</btnLabel>
   </element>
+
+  <element name="mobilitydcatap:mobilityTheme">
+    <label>Mobility theme</label>
+    <description>This property refers to the mobility-related theme (i.e., a specific subject, category, or type) of the delivered content.
+      A dataset may be associated with multiple themes. A theme is important for data seekers who are interested in a particular type of data content.</description>
+  </element>
+  <element name="mobilitydcatap:transportMode">
+    <label>Transport mode</label>
+    <description>This property describes the transport mode that is covered by the delivered content. Data can be valid for more than one mode, so a multiple choice should be applied.</description>
+  </element>
+  <element name="mobilitydcatap:networkCoverage">
+    <label>Network coverage</label>
+    <description>This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed.
+      For other transport modes, the property is meant to refer to the physical infrastructure which is used by the services covered by the data.
+      For all modes, the property SHOULD also indicate if the data content relates to the EU’s trans-European transport network [EU-TEN-T].</description>
+  </element>
+  <element name="mobilitydcatap:georeferencingMethod">
+    <label>Georeferencing method</label>
+    <description>This property SHOULD be used to specify the georeferencing method used in the dataset.</description>
+  </element>
+  <element name="mobilitydcatap:intendedInformationService">
+    <label>Intended information service</label>
+    <description>This property MAY describe predefined information services, which the data content is intended to support.
+      Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR].
+      Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
+  </element>
+
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Dataset belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Data Service belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Dataset.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Data Service.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
 </labels>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd-cardinalities.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd-cardinalities.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Cardinalités</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd-rec.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Recommendé</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Obligatoire</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/fre/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/strings.xml
@@ -100,4 +100,20 @@
   <protocol-49>LINK-1.0-http--link</protocol-49>
   <protocol-50>LINK-1.0-http--related</protocol-50>
   <protocol-51>Vul uw eigen protocol in...</protocol-51>
+
+  <hvd-dataservice-section>High Value Dataset (HVD)</hvd-dataservice-section>
+  <hvd-dataservice-tab>Data Service</hvd-dataservice-tab>
+  <hvd-dataset-section>High Value Dataset (HVD)</hvd-dataset-section>
+  <hvd-dataset-tab>Dataset</hvd-dataset-tab>
+  <hvd-view>High Value Dataset</hvd-view>
+
+  <mobility-section>Mobility</mobility-section>
+  <mobility-tab>Mobility</mobility-tab>
+  <mobility-view>Mobility</mobility-view>
+
+  <metadatadcat-dataservice-section>Data Service</metadatadcat-dataservice-section>
+  <metadatadcat-dataservice-tab>Metadata DCAT</metadatadcat-dataservice-tab>
+  <metadatadcat-dataset-section>Dataset</metadatadcat-dataset-section>
+  <metadatadcat-dataset-tab>Metadata DCAT</metadatadcat-dataset-tab>
+  <metadatadcat-view>Metadata DCAT</metadatadcat-view>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/ger/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/labels.xml
@@ -2196,4 +2196,51 @@
     <description>Tooltip: in scheme</description>
     <btnLabel>in scheme</btnLabel>
   </element>
+
+  <element name="mobilitydcatap:mobilityTheme">
+    <label>Mobility theme</label>
+    <description>This property refers to the mobility-related theme (i.e., a specific subject, category, or type) of the delivered content.
+      A dataset may be associated with multiple themes. A theme is important for data seekers who are interested in a particular type of data content.</description>
+  </element>
+  <element name="mobilitydcatap:transportMode">
+    <label>Transport mode</label>
+    <description>This property describes the transport mode that is covered by the delivered content. Data can be valid for more than one mode, so a multiple choice should be applied.</description>
+  </element>
+  <element name="mobilitydcatap:networkCoverage">
+    <label>Network coverage</label>
+    <description>This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed.
+      For other transport modes, the property is meant to refer to the physical infrastructure which is used by the services covered by the data.
+      For all modes, the property SHOULD also indicate if the data content relates to the EU’s trans-European transport network [EU-TEN-T].</description>
+  </element>
+  <element name="mobilitydcatap:georeferencingMethod">
+    <label>Georeferencing method</label>
+    <description>This property SHOULD be used to specify the georeferencing method used in the dataset.</description>
+  </element>
+  <element name="mobilitydcatap:intendedInformationService">
+    <label>Intended information service</label>
+    <description>This property MAY describe predefined information services, which the data content is intended to support.
+      Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR].
+      Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
+  </element>
+
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Dataset belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>HVD Category</label>
+    <description>The HVD category to which this Data Service belongs.</description>
+    <btnLabel>HVD Category</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Dataset.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
+  <element name="dcatap:applicableLegislation" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+    <label>Applicable legislation</label>
+    <description>The legislation that mandates the creation or management of the Data Service.</description>
+    <btnLabel>applicable legislation</btnLabel>
+  </element>
 </labels>

--- a/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd-cardinalities.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd-cardinalities.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Kardinalitäten</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd-rec.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Empfohlen</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-hvd.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+  <schematron.title>High Value Datasets - Obligatorisch</schematron.title>
+</strings>

--- a/src/main/plugin/dcat-ap/loc/ger/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/strings.xml
@@ -100,4 +100,20 @@
   <protocol-49>LINK-1.0-http--link</protocol-49>
   <protocol-50>LINK-1.0-http--related</protocol-50>
   <protocol-51>Vul uw eigen protocol in...</protocol-51>
+
+  <hvd-dataservice-section>High Value Dataset (HVD)</hvd-dataservice-section>
+  <hvd-dataservice-tab>Data Service</hvd-dataservice-tab>
+  <hvd-dataset-section>High Value Dataset (HVD)</hvd-dataset-section>
+  <hvd-dataset-tab>Dataset</hvd-dataset-tab>
+  <hvd-view>High Value Dataset</hvd-view>
+
+  <mobility-section>Mobility</mobility-section>
+  <mobility-tab>Mobility</mobility-tab>
+  <mobility-view>Mobility</mobility-view>
+
+  <metadatadcat-dataservice-section>Data Service</metadatadcat-dataservice-section>
+  <metadatadcat-dataservice-tab>Metadata DCAT</metadatadcat-dataservice-tab>
+  <metadatadcat-dataset-section>Dataset</metadatadcat-dataset-section>
+  <metadatadcat-dataset-tab>Metadata DCAT</metadatadcat-dataset-tab>
+  <metadatadcat-view>Metadata DCAT</metadatadcat-view>
 </strings>

--- a/src/main/plugin/dcat-ap/schema/dcat.xsd
+++ b/src/main/plugin/dcat-ap/schema/dcat.xsd
@@ -319,6 +319,10 @@
                 <xs:element ref="mdcat:ontwikkelingstoestand" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="mdcat:statuut" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="owl:versionInfo" minOccurs="0" maxOccurs="unbounded"/>
+
+                <!-- Profile / DCAT-AP-HVD -->
+                <xs:element ref="dcatap:hvdCategory" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="dcatap:applicableLegislation" minOccurs="0" maxOccurs="unbounded"/>
               </xs:sequence>
             </xs:extension>
           </xs:complexContent>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd-cardinalities.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd-cardinalities.sch
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  <sch:ns prefix="spdx" uri="http://spdx.org/rdf/terms#"/>
+  <sch:ns prefix="owl" uri="http://www.w3.org/2002/07/owl#"/>
+  <sch:ns prefix="adms" uri="http://www.w3.org/ns/adms#"/>
+  <sch:ns prefix="locn" uri="http://www.w3.org/ns/locn#"/>
+  <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+  <sch:ns prefix="foaf" uri="http://xmlns.com/foaf/0.1/"/>
+  <sch:ns prefix="dct" uri="http://purl.org/dc/terms/"/>
+  <sch:ns prefix="vcard" uri="http://www.w3.org/2006/vcard/ns#"/>
+  <sch:ns prefix="dcat" uri="http://www.w3.org/ns/dcat#"/>
+  <sch:ns prefix="dcatap" uri="http://data.europa.eu/r5r/"/>
+  <sch:ns prefix="schema" uri="http://schema.org/"/>
+  <sch:ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="xml" uri="http://www.w3.org/XML/1998/namespace"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="dc" uri="http://purl.org/dc/elements/1.1/"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="mdcat" uri="https://data.vlaanderen.be/ns/metadata-dcat#"/>
+  <sch:ns prefix="geodcat" uri="http://data.europa.eu/930/"/>
+  <sch:ns prefix="generiek" uri="https://data.vlaanderen.be/ns/generiek#"/>
+  <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
+  <sch:ns prefix="prov" uri="http://www.w3.org/ns/prov#"/>
+
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
+
+  <sch:pattern abstract="true" id="CardinalityCheck">
+    <sch:title>Cardinality of $element in $context</sch:title>
+    <sch:rule context="$context">
+      <sch:assert test="count($element) &gt;= $min and ('$max' = 'n' or count($element) &lt;= $max)">
+        <sch:value-of select="'$context'"/>/<sch:value-of select="'$element'"/> should be of cardinality <sch:value-of select="'$min'"/>..<sch:value-of select="'$max'"/> but found <sch:value-of select="count($element)"/> nodes.</sch:assert>
+      <sch:report test="count($element) &gt;= $min and ('$max' = 'n' or count($element) &lt;= $max)">
+        <sch:value-of select="'$context'"/>/<sch:value-of select="'$element'"/> is of cardinality <sch:value-of select="'$min'"/>..<sch:value-of select="'$max'"/>. Found <sch:value-of select="count($element)"/> nodes.</sch:report>
+    </sch:rule>
+  </sch:pattern>
+
+  <sch:pattern is-a="CardinalityCheck" id="Dataset_hvdCategory">
+    <sch:param name="context" value="//dcat:Dataset"/>
+    <sch:param name="element" value="dcatap:hvdCategory"/>
+    <sch:param name="min" value="1"/>
+    <sch:param name="max" value="1"/>
+  </sch:pattern>
+  <sch:pattern is-a="CardinalityCheck" id="Dataset_applicableLegislation">
+    <sch:param name="context" value="//dcat:Dataset"/>
+    <sch:param name="element" value="dcatap:applicableLegislation"/>
+    <sch:param name="min" value="1"/>
+    <sch:param name="max" value="n"/>
+  </sch:pattern>
+  <sch:pattern is-a="CardinalityCheck" id="DataService_hvdCategory">
+    <sch:param name="context" value="//dcat:DataService"/>
+    <sch:param name="element" value="dcatap:hvdCategory"/>
+    <sch:param name="min" value="1"/>
+    <sch:param name="max" value="1"/>
+  </sch:pattern>
+  <sch:pattern is-a="CardinalityCheck" id="DataService_applicableLegislation">
+    <sch:param name="context" value="//dcat:DataService"/>
+    <sch:param name="element" value="dcatap:applicableLegislation"/>
+    <sch:param name="min" value="1"/>
+    <sch:param name="max" value="n"/>
+  </sch:pattern>
+</sch:schema>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd-rec.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd-rec.sch
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  <sch:ns prefix="spdx" uri="http://spdx.org/rdf/terms#"/>
+  <sch:ns prefix="owl" uri="http://www.w3.org/2002/07/owl#"/>
+  <sch:ns prefix="adms" uri="http://www.w3.org/ns/adms#"/>
+  <sch:ns prefix="locn" uri="http://www.w3.org/ns/locn#"/>
+  <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+  <sch:ns prefix="foaf" uri="http://xmlns.com/foaf/0.1/"/>
+  <sch:ns prefix="dct" uri="http://purl.org/dc/terms/"/>
+  <sch:ns prefix="vcard" uri="http://www.w3.org/2006/vcard/ns#"/>
+  <sch:ns prefix="dcat" uri="http://www.w3.org/ns/dcat#"/>
+  <sch:ns prefix="dcatap" uri="http://data.europa.eu/r5r/"/>
+  <sch:ns prefix="schema" uri="http://schema.org/"/>
+  <sch:ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="xml" uri="http://www.w3.org/XML/1998/namespace"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="dc" uri="http://purl.org/dc/elements/1.1/"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="mdcat" uri="https://data.vlaanderen.be/ns/metadata-dcat#"/>
+  <sch:ns prefix="geodcat" uri="http://data.europa.eu/930/"/>
+  <sch:ns prefix="generiek" uri="https://data.vlaanderen.be/ns/generiek#"/>
+  <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
+
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
+
+</sch:schema>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-hvd.sch
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  <sch:ns prefix="spdx" uri="http://spdx.org/rdf/terms#"/>
+  <sch:ns prefix="owl" uri="http://www.w3.org/2002/07/owl#"/>
+  <sch:ns prefix="adms" uri="http://www.w3.org/ns/adms#"/>
+  <sch:ns prefix="locn" uri="http://www.w3.org/ns/locn#"/>
+  <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+  <sch:ns prefix="foaf" uri="http://xmlns.com/foaf/0.1/"/>
+  <sch:ns prefix="dct" uri="http://purl.org/dc/terms/"/>
+  <sch:ns prefix="vcard" uri="http://www.w3.org/2006/vcard/ns#"/>
+  <sch:ns prefix="dcat" uri="http://www.w3.org/ns/dcat#"/>
+  <sch:ns prefix="dcatap" uri="http://data.europa.eu/r5r/"/>
+  <sch:ns prefix="schema" uri="http://schema.org/"/>
+  <sch:ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="xml" uri="http://www.w3.org/XML/1998/namespace"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="dc" uri="http://purl.org/dc/elements/1.1/"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="mdcat" uri="https://data.vlaanderen.be/ns/metadata-dcat#"/>
+  <sch:ns prefix="geodcat" uri="http://data.europa.eu/930/"/>
+  <sch:ns prefix="generiek" uri="https://data.vlaanderen.be/ns/generiek#"/>
+  <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
+
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
+
+  <sch:pattern id="required_applicableLegislation">
+    <sch:title>Required applicable legislation value.</sch:title>
+    <sch:rule context="/">
+      <sch:assert test="//dcatap:applicableLegislation[@rdf:resource='http://data.europa.eu/eli/reg_impl/2023/138/oj']">
+        For HVD the value must include the ELI http://data.europa.eu/eli/reg_impl/2023/138/oj.
+      </sch:assert>
+      <sch:report test="//dcatap:applicableLegislation[@rdf:resource='http://data.europa.eu/eli/reg_impl/2023/138/oj']">
+        For HVD the value must include the ELI http://data.europa.eu/eli/reg_impl/2023/138/oj.
+      </sch:report>
+    </sch:rule>
+  </sch:pattern>
+</sch:schema>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap.sch
@@ -24,4 +24,14 @@
   <sch:ns prefix="prov" uri="http://www.w3.org/ns/prov#"/>
 
   <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
+
+  <sch:pattern>
+    <sch:title>dct:language is required</sch:title>
+    <sch:rule context="//dcat:Catalog/dcat:record/dcat:CatalogRecord">
+      <sch:let name="languages" value="count(dct:language/skos:Concept)"/>
+      <sch:assert test="$languages > 0">The dcat:CatalogRecord need at least one dct:language to be defined.</sch:assert>
+      <sch:report test="$languages > 0">The dcat:CatalogRecord need at least one dct:language to be defined.</sch:report>
+    </sch:rule>
+  </sch:pattern>
+
 </sch:schema>


### PR DESCRIPTION
This PR contains various changes necessary to mirror the original VL profile in the generic plugin:
- create VL view that should be compatible with the original setup (there's some issues remaining though, to be concluded)
- merged the PR on translations and tweaks to schematron files (https://github.com/metadata101/dcat-ap/pull/20) in here as well, to prevent merge conflicts

A development goal would be to deploy this version to the VL fork, on the dev environment, and make it available for testing purposes.