### PR TITLE
(WIP) Thesaurus agnostic dcat:theme implementation

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -31,13 +31,13 @@
         max="1"
         labelKey="dcat.addType"/>
     </for>
-    <for name="dcat:theme" use="thesaurus-list-picker">
-      <directiveAttributes
-        thesaurus="external.theme.datatheme"
-        xpath="/dcat:theme"
-        max=""
-        labelKey="dcat.addThemes"/>
-    </for>
+    <!-- <for name="dcat:theme" use="thesaurus-list-picker"> -->
+    <!--   <directiveAttributes -->
+    <!--     thesaurus="external.theme.datatheme" -->
+    <!--     xpath="/dcat:theme" -->
+    <!--     max="" -->
+    <!--     labelKey="dcat.addThemes"/> -->
+    <!-- </for> -->
     <for name="dct:accessRights" xpath="dcat:Dataset" use="thesaurus-list-picker">
       <directiveAttributes
         thesaurus="external.theme.access-right"
@@ -453,6 +453,7 @@
     <name>dct:creator</name>
     <name>spdx:checksum</name>
     <name>spdx:Checksum</name>
+    <name>dcat:theme</name>
   </fieldsWithFieldset>
 
   <multilingualFields>
@@ -499,6 +500,7 @@
       <name>vcard:postal-code</name>
       <name>vcard:fn</name>
       <name>skos:inScheme</name>
+      <name>skos:notation</name>
     </exclude>
   </multilingualFields>
 
@@ -586,6 +588,20 @@
                  or="keyword"
                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
 
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme[not(skos:Concept/skos:inScheme/@rdf:resource = ('http://vocab.belgif.be/auth/datatheme'))]"/>
+          <action type="add" or="theme" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+            <template>
+              <snippet>
+                <dcat:theme>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel xml:lang=""/>
+                    <skos:inScheme rdf:resource=""/>
+                  </skos:Concept>
+                </dcat:theme>
+              </snippet>
+            </template>
+          </action>
+
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:identifier"
                  or="identifier"
                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
@@ -632,15 +648,10 @@
             </template>
           </action>
 
-          <!-- Theme: vocab.belgif.be/auth/datatheme -->
-          <!-- TODO: custom label to indicate this is about themes from the specific thesaurus? -->
-          <!--          <dcat:theme>-->
-          <!--            <skos:Concept rdf:about="http://vocab.belgif.be/auth/datatheme/CULT">-->
-          <!--              <skos:prefLabel xml:lang="nl">Cultuur en sport</skos:prefLabel>-->
-          <!--              <skos:prefLabel xml:lang="en">Culture and sport</skos:prefLabel>-->
-          <!--              <skos:inScheme rdf:resource="http://vocab.belgif.be/auth/datatheme"/>-->
-          <!--            </skos:Concept>-->
-          <!--          </dcat:theme>-->
+          <!--
+            TODO: Custom label for theme based on thesaurus or label key
+            TODO: Nested directiveAttributes not working
+          -->
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme[skos:Concept/skos:inScheme/@rdf:resource = 'http://vocab.belgif.be/auth/datatheme']"
                  or="theme"
                  use="data-gn-keyword-picker"
@@ -651,6 +662,21 @@
               max=""
               labelKey="dcat-addThemes"/>
           </field>
+          <action type="add"
+                  or="theme"
+                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(skos:Concept/skos:inScheme/@rdf:resource = 'http://vocab.belgif.be/auth/datatheme') = 0">
+            <template>
+              <snippet>
+                <dcat:theme>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel/>
+                    <skos:inScheme rdf:resource="http://vocab.belgif.be/auth/datatheme"/>
+                  </skos:Concept>
+                </dcat:theme>
+              </snippet>
+            </template>
+          </action>
         </section>
 
         <section name="versionInformation">
@@ -1039,6 +1065,20 @@
               </snippet>
             </template>
           </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:theme[not(skos:Concept/skos:inScheme/@rdf:resource = ('http://vocab.belgif.be/auth/datatheme'))]"/>
+          <action type="add" or="theme" in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+            <template>
+              <snippet>
+                <dcat:theme>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel xml:lang=""/>
+                    <skos:inScheme rdf:resource=""/>
+                  </skos:Concept>
+                </dcat:theme>
+              </snippet>
+            </template>
+          </action>
         </section>
 
         <section name="vl-section-metadatadcat"
@@ -1153,11 +1193,35 @@
             </template>
           </action>
 
-          <!-- Theme: vocab.belgif.be/auth/datatheme -->
-          <!-- TODO: custom label to indicate this is about themes from the specific thesaurus? -->
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:theme"
+          <!--
+            TODO: Custom label for theme based on thesaurus or label key
+            TODO: Nested directiveAttributes not working
+           -->
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:theme[skos:Concept/skos:inScheme/@rdf:resource = 'http://vocab.belgif.be/auth/datatheme']"
                  or="theme"
-                 in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"/>
+                 use="data-gn-keyword-picker"
+                 in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">
+            <directiveAttributes
+              thesaurus="external.theme.datatheme"
+              xpath="/dcat:theme"
+              max=""
+              labelKey="dcat-addThemes"/>
+          </field>
+          <action type="add"
+                  or="theme"
+                  in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService"
+                  if="count(skos:Concept/skos:inScheme/@rdf:resource = 'http://vocab.belgif.be/auth/datatheme') = 0">
+            <template>
+              <snippet>
+                <dcat:theme>
+                  <skos:Concept rdf:about="">
+                    <skos:prefLabel/>
+                    <skos:inScheme rdf:resource="http://vocab.belgif.be/auth/datatheme"/>
+                  </skos:Concept>
+                </dcat:theme>
+              </snippet>
+            </template>
+          </action>
         </section>
 
         <section name="versionInformation">
@@ -1326,6 +1390,7 @@
         <for name="dct:description"/>
         <for name="dcat:keyword"/>
         <for name="dcat:theme"/>
+        <for name="skos:Concept"/>
         <!-- Version info -->
         <for name="owl:versionInfo"/>
         <for name="dct:created"/>


### PR DESCRIPTION
Hi @fxprunayre, this PR is an attempt at enabling the edition of `dcat:theme` elements with different concepts.  
The idea is as follow:  

By default, the a dcat:theme is editable as a fieldset element when simply defined in the config-editor: 
```xml
<field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme[not(skos:Concept/skos:inScheme/@rdf:resource = ('http://vocab.belgif.be/auth/datatheme'))]"/>
<action type="add" or="theme" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
  <template>
    <snippet>
      <dcat:theme>
        <skos:Concept rdf:about="">
          <skos:prefLabel xml:lang=""/>
          <skos:inScheme rdf:resource=""/>
        </skos:Concept>
      </dcat:theme>
    </snippet>
  </template>
</action>
```
Resulting in:
![image](https://github.com/user-attachments/assets/7500ae1f-4f07-456e-8ad4-1cb561e93f30)

As you can see, the XPATH for the generic DCAT exclude a list of `inScheme`. In this example, the Vocab one. 
This is because the second way to define a `dcat:theme` field is by specifying the concept:  
```xml
<field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme[skos:Concept/skos:inScheme/@rdf:resource = 'http://vocab.belgif.be/auth/datatheme']"
       or="theme"
       use="data-gn-keyword-picker"
       in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
  <directiveAttributes
    thesaurus="external.theme.datatheme"
    xpath="/dcat:theme"
    max=""
    labelKey="dcat-addThemes"/>
</field>
<action type="add"
        or="theme"
        in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
        if="count(skos:Concept/skos:inScheme/@rdf:resource = 'http://vocab.belgif.be/auth/datatheme') = 0">
  <template>
    <snippet>
      <dcat:theme>
        <skos:Concept rdf:about="">
          <skos:prefLabel/>
          <skos:inScheme rdf:resource="http://vocab.belgif.be/auth/datatheme"/>
        </skos:Concept>
      </dcat:theme>
    </snippet>
  </template>
</action>
```

However, in the current state, it looks like locally defined `directiveAttributes` does not work. Only the one defined at the `/editor/fields/for` path is taken in account.  
Since we want the default `dcat:theme` to behave like a normal fieldset, we have to remove the dcat:theme configuration from this path.  
Do you have an idea why this doesn't works ?