### PR TITLE
Handle changeDate that contains plain date

### DIFF
--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -294,7 +294,9 @@
             <dcat:CatalogRecord>
               <xsl:call-template name="handle-record-id"/>
               <dct:modified>
-                <xsl:value-of select="format-dateTime(/root/env/changeDate, '[Y0001]-[M01]-[D01]')"/>
+                <xsl:value-of select="if (matches(/root/env/changeDate, '^\d{4}-\d{2}-\d{2}$')) then format-date(/root/env/changeDate,'[Y0001]-[M01]-[D01]')
+                  else if(/root/env/changeDate) then format-dateTime(/root/env/changeDate,'[Y0001]-[M01]-[D01]')
+                  else dct:modified"/>
               </dct:modified>
             </dcat:CatalogRecord>
           </dcat:record>
@@ -309,7 +311,9 @@
     <xsl:copy copy-namespaces="no">
       <xsl:call-template name="handle-record-id"/>
       <dct:modified>
-        <xsl:value-of select="if (/root/env/changeDate) then format-dateTime(/root/env/changeDate,'[Y0001]-[M01]-[D01]') else dct:modified"/>
+        <xsl:value-of select="if (matches(/root/env/changeDate, '^\d{4}-\d{2}-\d{2}$')) then format-date(/root/env/changeDate,'[Y0001]-[M01]-[D01]')
+          else if(/root/env/changeDate) then format-dateTime(/root/env/changeDate,'[Y0001]-[M01]-[D01]')
+          else dct:modified"/>
       </dct:modified>
       <xsl:apply-templates select="* except (dct:identifier|dct:modified|foaf:primaryTopic)"/>
     </xsl:copy>


### PR DESCRIPTION
I was encountering some records in VL that contained a plain date (yyyy-mm-dd) in the changeDate, which was incorrectly handled by format-dateTime which expects a full datetime. This should rectify the problem by checking for a date format and then passing it to the corresponding format-date function.

@CMath04 we discussed this previously but only now got round to fixing it - was probably the cause for the erroneous CSW updates in the case of select dcat records. Could you take a quick look at the change so we can merge?