### PR TITLE
Configuration / skos:notation is a typed literal

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -499,6 +499,7 @@
       <name>vcard:postal-code</name>
       <name>vcard:fn</name>
       <name>skos:inScheme</name>
+      <name>skos:notation</name>
     </exclude>
   </multilingualFields>
 


### PR DESCRIPTION
Cf. https://www.w3.org/TR/skos-reference/#notations

It is not a multilingual element and can't have an `xml:lang` attribute (which was causing validation error).