### PR TITLE
Added missing label for snippet

### DIFF
--- a/src/main/plugin/dcat-ap/loc/dut/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/strings.xml
@@ -79,6 +79,7 @@
   <protocol-41>WMTS-1.0.0-http-get-capabilities</protocol-41>
   <protocol-42>WMTS-1.0.0-http-get-tile</protocol-42>
   <protocol-43>WMTS</protocol-43>
+  <protocol-44>REST richtlijnen Digitaal Vlaanderen</protocol-44>
   <protocol-45>REST</protocol-45>
   <protocol-46>DOWNLOAD-1.0-ftp--download</protocol-46>
   <protocol-47>DOWNLOAD-1.0-http--download</protocol-47>

--- a/src/main/plugin/dcat-ap/loc/eng/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/strings.xml
@@ -79,6 +79,7 @@
   <protocol-41>WMTS-1.0.0-http-get-capabilities</protocol-41>
   <protocol-42>WMTS-1.0.0-http-get-tile</protocol-42>
   <protocol-43>WMTS</protocol-43>
+  <protocol-44>REST guidelines Digitaal Vlaanderen</protocol-44>
   <protocol-45>REST</protocol-45>
   <protocol-46>DOWNLOAD-1.0-ftp--download</protocol-46>
   <protocol-47>DOWNLOAD-1.0-http--download</protocol-47>

--- a/src/main/plugin/dcat-ap/loc/fre/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/strings.xml
@@ -79,6 +79,7 @@
   <protocol-41>WMTS-1.0.0-http-get-capabilities</protocol-41>
   <protocol-42>WMTS-1.0.0-http-get-tile</protocol-42>
   <protocol-43>WMTS</protocol-43>
+  <protocol-44>REST lignes directrices Digitaal Vlaanderen</protocol-44>
   <protocol-45>REST</protocol-45>
   <protocol-46>DOWNLOAD-1.0-ftp--download</protocol-46>
   <protocol-47>DOWNLOAD-1.0-http--download</protocol-47>

--- a/src/main/plugin/dcat-ap/loc/ger/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/strings.xml
@@ -92,7 +92,7 @@
   <protocol-41>WMTS-1.0.0-http-get-capabilities</protocol-41>
   <protocol-42>WMTS-1.0.0-http-get-tile</protocol-42>
   <protocol-43>WMTS</protocol-43>
-  <protocol-44>REST richtlijnen Digitaal Vlaanderen</protocol-44>
+  <protocol-44>REST Richtlinien Digitaal Vlaanderen</protocol-44>
   <protocol-45>REST</protocol-45>
   <protocol-46>DOWNLOAD-1.0-ftp--download</protocol-46>
   <protocol-47>DOWNLOAD-1.0-http--download</protocol-47>


### PR DESCRIPTION
Would be nice to sort the snippet list based on their label, but then we'd have to:
- make sure the "fill it in yourself" element is put at the bottom 
- modify the core

I tried playing around with form-builder.xsl:579 and adding `<xsl:sort>` in the for-each loop, based on the `$label` value, but the sort didn't seem to take. If there's no quick win here we can just merge the missing label and consider it ok @fxprunayre.