### PR TITLE
Editor / Service / Link to dataset

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -1030,7 +1030,16 @@
               </snippet>
             </template>
           </action>
-          <action type="associatedResource" name="linkToDataset" process="dataset"/>
+          
+          <action type="associatedResource" name="linkToDataset" process="dataset">
+            <directiveAttributes>{"sources": {
+              "metadataStore": {"params": {
+                "resourceType": ["dataset"],
+                "isTemplate": "n"
+              }},
+              "remoteurl": {"multiple": false}
+              }}</directiveAttributes>
+          </action>
 
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dcat:keyword"/>
           <action type="add" or="keyword" in="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService">


### PR DESCRIPTION
When using action for associated resource in main form, the configuration of the panel is required.

Cf. side panel configuration https://github.com/metadata101/dcat-ap/blob/main/src/main/plugin/dcat-ap/config/associated-panel/default.json#L31-L46

If not, here the search results was not displayed.