### PR TITLE
Feature/schematron translations

### DIFF
--- a/script/generate-strings.xsl
+++ b/script/generate-strings.xsl
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  <xsl:output encoding="UTF-8"/>
+
+  <!-- Extract strings from a given XML schematron file, to be used in a localisation file -->
+  <!-- example usage: xsltproc generate-strings.xsl schematron-rules-dcat-ap-vl.sch | xmllint &#45;&#45;format - > output-strings.xml -->
+
+  <xsl:template match="/">
+    <strings>
+      <xsl:apply-templates select="//sch:pattern"/>
+    </strings>
+  </xsl:template>
+
+  <!-- Override the strings themselves, replace them by the placeholders -->
+  <xsl:template match="sch:pattern">
+    <xsl:element name="{concat('pattern.title.', position())}"><xsl:value-of select="sch:title/text()"/></xsl:element>
+    <xsl:element name="{concat('pattern.assert.', position())}"><xsl:value-of select="sch:rule/sch:assert/text()"/></xsl:element>
+    <xsl:element name="{concat('pattern.report.', position())}"><xsl:value-of select="sch:rule/sch:report/text()"/></xsl:element>
+  </xsl:template>
+</xsl:stylesheet>

--- a/script/insert-placeholders.xsl
+++ b/script/insert-placeholders.xsl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  <xsl:output encoding="UTF-8"/>
+
+  <!-- Replace strings in the given schematron file by placeholders, to be used by a corresponding schematron localisation file. -->
+  <!-- example usage: xsltproc insert-placeholders.xsl schematron-rules-dcat-ap-vl.sch | xmllint &#45;&#45;format - > output-placeholders.xml -->
+
+  <!-- Identity template : copy all text nodes, elements and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Override the strings themselves, replace them by the placeholders -->
+  <xsl:template match="//sch:pattern/sch:title">
+    <sch:title>$loc/strings/pattern.title.<xsl:value-of select="count(../preceding-sibling::sch:pattern)+1"/></sch:title>
+  </xsl:template>
+
+  <xsl:template match="//sch:pattern/sch:rule/sch:assert/text()">$loc/strings/pattern.assert.<xsl:value-of select="count(../../../preceding-sibling::sch:pattern)+1"/></xsl:template>
+  <xsl:template match="//sch:pattern/sch:rule/sch:report/text()">$loc/strings/pattern.report.<xsl:value-of select="count(../../../preceding-sibling::sch:pattern)+1"/></xsl:template>
+</xsl:stylesheet>

--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-vl-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-vl-rec.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>DCAT-AP-Vlaanderen - Aanbevolen</schematron.title>
+  <required.datatheme.title>Tenminste één thema uit de data.gov.be codelijst wordt verwacht</required.datatheme.title>
+  <required.datatheme.assert>De dcat:Resource heeft geen data.gov.be thema</required.datatheme.assert>
+  <required.datatheme.report>De dcat:Resource heeft een data.gov.be thema</required.datatheme.report>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-vl.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-vl.xml
@@ -1,84 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>DCAT-AP-Vlaanderen - Verplicht</schematron.title>
-  <pattern.title.1>vcard:hasEmail is a URI with the mailto protocol.</pattern.title.1>
-  <pattern.assert.1>vcard:hasEmail property is not a URI with the mailto: protocol.</pattern.assert.1>
-  <pattern.report.1>vcard:hasEmail property is a URI with the mailto: protocol.</pattern.report.1>
+  <pattern.title.1>vcard:hasEmail is een URI met het mailto-protocol.</pattern.title.1>
+  <pattern.assert.1>vcard:hasEmail eigenschap is geen URI met het mailto: protocol.</pattern.assert.1>
+  <pattern.report.1>vcard:hasEmail eigenschap is een URI met het mailto: protocol.</pattern.report.1>
   <pattern.title.2>dct:license is CC0</pattern.title.2>
-  <pattern.assert.2>The dcat:Catalog does not have a dct:license property with value 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0'.</pattern.assert.2>
-  <pattern.report.2>The dcat:Catalog has a dct:license property with value 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0'.</pattern.report.2>
-  <pattern.title.3>dct:accessRights must be public</pattern.title.3>
-  <pattern.assert.3>The dcat:Dataset does not have a dct:accessRights property with value 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'.</pattern.assert.3>
-  <pattern.report.3>The dcat:Dataset has a dct:accessRights property with value 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'.</pattern.report.3>
-  <pattern.title.4>At least one keyword is required.</pattern.title.4>
-  <pattern.assert.4>The dcat:Resource doesn't have any keyword.</pattern.assert.4>
-  <pattern.report.4>The dcat:Resource have at least one keyword.</pattern.report.4>
-  <pattern.title.5>At least one of vcard:hasEmail or vcard:hasURL is a required for a contactpoint.</pattern.title.5>
-  <pattern.assert.5>A vcard:Organization does not have a vcard:hasEmail or a vcard:hasURL property.</pattern.assert.5>
-  <pattern.report.5>A vcard:Organization has a vcard:hasEmail or a vcard:hasURL property.</pattern.report.5>
+  <pattern.assert.2>De dcat:Catalog heeft geen dct:license eigenschap met waarde 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0'.</pattern.assert.2>
+  <pattern.report.2>De dcat:Catalog heeft een dct:license eigenschap met waarde 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0'.</pattern.report.2>
+  <pattern.title.3>dct:accessRights moeten openbaar zijn</pattern.title.3>
+  <pattern.assert.3>De dcat:Dataset heeft geen dct:accessRights eigenschap met waarde 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'.</pattern.assert.3>
+  <pattern.report.3>De dcat:Dataset heeft een dct:accessRights eigenschap met waarde 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'.</pattern.report.3>
+  <pattern.title.4>Minimaal één trefwoord is vereist.</pattern.title.4>
+  <pattern.assert.4>De dcat:Resource heeft geen trefwoord.</pattern.assert.4>
+  <pattern.report.4>De dcat:Resource heeft minimaal één trefwoord.</pattern.report.4>
+  <pattern.title.5>Minimaal één van vcard:hasEmail of vcard:hasURL is vereist voor een contactpunt.</pattern.title.5>
+  <pattern.assert.5>Een vcard:Organization heeft geen vcard:hasEmail of vcard:hasURL eigenschap.</pattern.assert.5>
+  <pattern.report.5>Een vcard:Organization heeft een vcard:hasEmail of vcard:hasURL eigenschap.</pattern.report.5>
   <pattern.title.6>Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.6>
   <pattern.assert.6>De range van naam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (foaf:name)</pattern.assert.6>
   <pattern.report.6>De range van naam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (foaf:name)</pattern.report.6>
   <pattern.title.7>v212. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.7>
-  <pattern.assert.7>Slechts 1 waarde voor elke taal toegelaten voor naam (foaf:name)</pattern.assert.7>
-  <pattern.report.7>Slechts 1 waarde voor elke taal toegelaten voor naam (foaf:name)</pattern.report.7>
+  <pattern.assert.7>Slechts één waarde voor elke taal toegestaan voor naam (foaf:name)</pattern.assert.7>
+  <pattern.report.7>Slechts één waarde voor elke taal toegestaan voor naam (foaf:name)</pattern.report.7>
   <pattern.title.8>v000. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.8>
-  <pattern.assert.8>Minimaal 1 waarden verwacht voor naam (foaf:name)</pattern.assert.8>
-  <pattern.report.8>Minimaal 1 waarden verwacht voor naam (foaf:name)</pattern.report.8>
+  <pattern.assert.8>Minimaal één waarde verwacht voor naam (foaf:name)</pattern.assert.8>
+  <pattern.report.8>Minimaal één waarde verwacht voor naam (foaf:name)</pattern.report.8>
   <pattern.title.9>1001. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</pattern.title.9>
   <pattern.assert.9>De range van contactpagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (foaf:page)</pattern.assert.9>
   <pattern.report.9>De range van contactpagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (foaf:page)</pattern.report.9>
   <pattern.title.10>1002. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</pattern.title.10>
-  <pattern.assert.10>Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</pattern.assert.10>
-  <pattern.report.10>Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</pattern.report.10>
+  <pattern.assert.10>Maximaal één waarde toegestaan voor contactpagina (foaf:page)</pattern.assert.10>
+  <pattern.report.10>Maximaal één waarde toegestaan voor contactpagina (foaf:page)</pattern.report.10>
   <pattern.title.11>413. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</pattern.title.11>
   <pattern.assert.11>De range van e-mail moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (vcard:hasEmail)</pattern.assert.11>
   <pattern.report.11>De range van e-mail moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (vcard:hasEmail)</pattern.report.11>
   <pattern.title.12>1004. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</pattern.title.12>
-  <pattern.assert.12>Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</pattern.assert.12>
-  <pattern.report.12>Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</pattern.report.12>
+  <pattern.assert.12>Maximaal één waarde toegestaan voor e-mail (vcard:hasEmail)</pattern.assert.12>
+  <pattern.report.12>Maximaal één waarde toegestaan voor e-mail (vcard:hasEmail)</pattern.report.12>
   <pattern.title.13>1201. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</pattern.title.13>
   <pattern.assert.13>De range van aanmaakdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</pattern.assert.13>
   <pattern.report.13>De range van aanmaakdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</pattern.report.13>
   <pattern.title.14>1202. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</pattern.title.14>
-  <pattern.assert.14>Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</pattern.assert.14>
-  <pattern.report.14>Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</pattern.report.14>
+  <pattern.assert.14>Maximaal één waarde toegestaan voor aanmaakdatum (dct:issued)</pattern.assert.14>
+  <pattern.report.14>Maximaal één waarde toegestaan voor aanmaakdatum (dct:issued)</pattern.report.14>
   <pattern.title.15>1204. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een record in de catalogus kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aalternatieve%20identificator)</pattern.title.15>
   <pattern.assert.15>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.15>
   <pattern.report.15>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.15>
   <pattern.title.16>1206. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.16>
-  <pattern.assert.16>Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</pattern.assert.16>
-  <pattern.report.16>Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</pattern.report.16>
+  <pattern.assert.16>Maximaal één waarde toegestaan voor hoofdonderwerp (foaf:primaryTopic)</pattern.assert.16>
+  <pattern.report.16>Maximaal één waarde toegestaan voor hoofdonderwerp (foaf:primaryTopic)</pattern.report.16>
   <pattern.title.17>1208. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.17>
   <pattern.assert.17>De range van hoofdonderwerp moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (foaf:primaryTopic)</pattern.assert.17>
   <pattern.report.17>De range van hoofdonderwerp moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (foaf:primaryTopic)</pattern.report.17>
   <pattern.title.18>1209. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.18>
-  <pattern.assert.18>Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</pattern.assert.18>
-  <pattern.report.18>Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</pattern.report.18>
+  <pattern.assert.18>Minimaal één waarde verwacht voor hoofdonderwerp (foaf:primaryTopic)</pattern.assert.18>
+  <pattern.report.18>Minimaal één waarde verwacht voor hoofdonderwerp (foaf:primaryTopic)</pattern.report.18>
   <pattern.title.19>1210. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.19>
   <pattern.assert.19>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.19>
   <pattern.report.19>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.19>
   <pattern.title.20>1211. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.20>
-  <pattern.assert.20>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.20>
-  <pattern.report.20>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.20>
+  <pattern.assert.20>Minimaal één waarde verwacht voor identificator (dct:identifier)</pattern.assert.20>
+  <pattern.report.20>Minimaal één waarde verwacht voor identificator (dct:identifier)</pattern.report.20>
   <pattern.title.21>1212. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.21>
-  <pattern.assert.21>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.21>
-  <pattern.report.21>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.21>
+  <pattern.assert.21>Maximaal één waarde toegestaan voor identificator (dct:identifier)</pattern.assert.21>
+  <pattern.report.21>Maximaal één waarde toegestaan voor identificator (dct:identifier)</pattern.report.21>
   <pattern.title.22>1215. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.22>
-  <pattern.assert.22>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.22>
-  <pattern.report.22>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.22>
+  <pattern.assert.22>Maximaal één waarde toegestaan voor titel (dct:title)</pattern.assert.22>
+  <pattern.report.22>Maximaal één waarde toegestaan voor titel (dct:title)</pattern.report.22>
   <pattern.title.23>1216. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.23>
-  <pattern.assert.23>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.23>
-  <pattern.report.23>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.23>
+  <pattern.assert.23>Slechts één waarde voor elke taal toegestaan voor titel (dct:title)</pattern.assert.23>
+  <pattern.report.23>Slechts één waarde voor elke taal toegestaan voor titel (dct:title)</pattern.report.23>
   <pattern.title.24>1217. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.24>
   <pattern.assert.24>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.24>
   <pattern.report.24>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.24>
   <pattern.title.25>1218. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.25>
-  <pattern.assert.25>Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</pattern.assert.25>
-  <pattern.report.25>Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</pattern.report.25>
+  <pattern.assert.25>Maximaal één waarde toegestaan voor wijzigingsdatum (dct:modified)</pattern.assert.25>
+  <pattern.report.25>Maximaal één waarde toegestaan voor wijzigingsdatum (dct:modified)</pattern.report.25>
   <pattern.title.26>1219. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.26>
-  <pattern.assert.26>Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</pattern.assert.26>
-  <pattern.report.26>Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</pattern.report.26>
+  <pattern.assert.26>Minimaal één waarde verwacht voor wijzigingsdatum (dct:modified)</pattern.assert.26>
+  <pattern.report.26>Minimaal één waarde verwacht voor wijzigingsdatum (dct:modified)</pattern.report.26>
   <pattern.title.27>1220. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.27>
   <pattern.assert.27>De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</pattern.assert.27>
   <pattern.report.27>De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</pattern.report.27>
@@ -89,11 +89,11 @@
   <pattern.assert.29>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.29>
   <pattern.report.29>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.29>
   <pattern.title.30>1305. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.30>
-  <pattern.assert.30>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.assert.30>
-  <pattern.report.30>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.report.30>
+  <pattern.assert.30>Maximaal één waarde toegestaan voor beschrijving (dct:description)</pattern.assert.30>
+  <pattern.report.30>Maximaal één waarde toegestaan voor beschrijving (dct:description)</pattern.report.30>
   <pattern.title.31>1306. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.31>
-  <pattern.assert.31>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.31>
-  <pattern.report.31>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.31>
+  <pattern.assert.31>Slechts één waarde voor elke taal toegestaan voor beschrijving (dct:description)</pattern.assert.31>
+  <pattern.report.31>Slechts één waarde voor elke taal toegestaan voor beschrijving (dct:description)</pattern.report.31>
   <pattern.title.32>1308. Biedt informatie aan over - De data die via deze dataservice worden aangeboden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abiedt%20informatie%20aan%20over)</pattern.title.32>
   <pattern.assert.32>De range van biedt informatie aan over moet van het type &lt;http://www.w3.org/ns/dcat#Dataset&gt; zijn. (dcat:servesdataset)</pattern.assert.32>
   <pattern.report.32>De range van biedt informatie aan over moet van het type &lt;http://www.w3.org/ns/dcat#Dataset&gt; zijn. (dcat:servesdataset)</pattern.report.32>
@@ -101,29 +101,29 @@
   <pattern.assert.33>De range van conform aan protocol moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.assert.33>
   <pattern.report.33>De range van conform aan protocol moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.report.33>
   <pattern.title.34>1312. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.34>
-  <pattern.assert.34>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.assert.34>
-  <pattern.report.34>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.report.34>
+  <pattern.assert.34>Maximaal één waarde toegestaan voor contactinformatie (dcat:contactPoint)</pattern.assert.34>
+  <pattern.report.34>Maximaal één waarde toegestaan voor contactinformatie (dcat:contactPoint)</pattern.report.34>
   <pattern.title.35>1313. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.35>
   <pattern.assert.35>De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</pattern.assert.35>
   <pattern.report.35>De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</pattern.report.35>
   <pattern.title.36>1314. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.36>
-  <pattern.assert.36>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.assert.36>
-  <pattern.report.36>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.report.36>
+  <pattern.assert.36>Minimaal één waarde verwacht voor contactinformatie (dcat:contactPoint)</pattern.assert.36>
+  <pattern.report.36>Minimaal één waarde verwacht voor contactinformatie (dcat:contactPoint)</pattern.report.36>
   <pattern.title.37>1315. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.37>
   <pattern.assert.37>De range van endpointURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointURL)</pattern.assert.37>
   <pattern.report.37>De range van endpointURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointURL)</pattern.report.37>
   <pattern.title.38>1317. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.38>
-  <pattern.assert.38>Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</pattern.assert.38>
-  <pattern.report.38>Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</pattern.report.38>
+  <pattern.assert.38>Maximaal één waarde toegestaan voor endpointURL (dcat:endpointURL)</pattern.assert.38>
+  <pattern.report.38>Maximaal één waarde toegestaan voor endpointURL (dcat:endpointURL)</pattern.report.38>
   <pattern.title.39>1318. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.39>
-  <pattern.assert.39>Minimaal 1 waarden verwacht voor endpointURL (dcat:endpointURL)</pattern.assert.39>
-  <pattern.report.39>Minimaal 1 waarden verwacht voor endpointURL (dcat:endpointURL)</pattern.report.39>
+  <pattern.assert.39>Minimaal één waarde verwacht voor endpointURL (dcat:endpointURL)</pattern.assert.39>
+  <pattern.report.39>Minimaal één waarde verwacht voor endpointURL (dcat:endpointURL)</pattern.report.39>
   <pattern.title.40>1320. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.40>
-  <pattern.assert.40>Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</pattern.assert.40>
-  <pattern.report.40>Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</pattern.report.40>
+  <pattern.assert.40>Maximaal één waarde toegestaan voor endpointbeschrijving (dcat:endpointDescription)</pattern.assert.40>
+  <pattern.report.40>Maximaal één waarde toegestaan voor endpointbeschrijving (dcat:endpointDescription)</pattern.report.40>
   <pattern.title.41>1321. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.41>
-  <pattern.assert.41>Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</pattern.assert.41>
-  <pattern.report.41>Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</pattern.report.41>
+  <pattern.assert.41>Minimaal één waarde verwacht voor endpointbeschrijving (dcat:endpointDescription)</pattern.assert.41>
+  <pattern.report.41>Minimaal één waarde verwacht voor endpointbeschrijving (dcat:endpointDescription)</pattern.report.41>
   <pattern.title.42>1322. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.42>
   <pattern.assert.42>De range van endpointbeschrijving moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointDescription)</pattern.assert.42>
   <pattern.report.42>De range van endpointbeschrijving moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointDescription)</pattern.report.42>
@@ -131,11 +131,11 @@
   <pattern.assert.43>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.43>
   <pattern.report.43>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.43>
   <pattern.title.44>1323. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.44>
-  <pattern.assert.44>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.44>
-  <pattern.report.44>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.44>
+  <pattern.assert.44>Minimaal één waarde verwacht voor identificator (dct:identifier)</pattern.assert.44>
+  <pattern.report.44>Minimaal één waarde verwacht voor identificator (dct:identifier)</pattern.report.44>
   <pattern.title.45>1324. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.45>
-  <pattern.assert.45>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.45>
-  <pattern.report.45>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.45>
+  <pattern.assert.45>Maximaal één waarde toegestaan voor identificator (dct:identifier)</pattern.assert.45>
+  <pattern.report.45>Maximaal één waarde toegestaan voor identificator (dct:identifier)</pattern.report.45>
   <pattern.title.46>1327. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene aanvullende informatie over de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina)</pattern.title.46>
   <pattern.assert.46>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.assert.46>
   <pattern.report.46>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.report.46>
@@ -143,11 +143,11 @@
   <pattern.assert.47>De range van landingspagina voor authenticatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorAuthenticatie)</pattern.assert.47>
   <pattern.report.47>De range van landingspagina voor authenticatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorAuthenticatie)</pattern.report.47>
   <pattern.title.48>1330. Landingspagina voor authenticatie - Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20authenticatie)</pattern.title.48>
-  <pattern.assert.48>Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</pattern.assert.48>
-  <pattern.report.48>Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</pattern.report.48>
+  <pattern.assert.48>Maximaal één waarde toegestaan voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</pattern.assert.48>
+  <pattern.report.48>Maximaal één waarde toegestaan voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</pattern.report.48>
   <pattern.title.49>1332. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</pattern.title.49>
-  <pattern.assert.49>Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.assert.49>
-  <pattern.report.49>Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.report.49>
+  <pattern.assert.49>Maximaal één waarde toegestaan voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.assert.49>
+  <pattern.report.49>Maximaal één waarde toegestaan voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.report.49>
   <pattern.title.50>1333. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</pattern.title.50>
   <pattern.assert.50>De range van landingspagina voor gebruiksinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.assert.50>
   <pattern.report.50>De range van landingspagina voor gebruiksinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.report.50>
@@ -155,29 +155,29 @@
   <pattern.assert.51>De range van landingspagina voor statusinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorStatusinformatie)</pattern.assert.51>
   <pattern.report.51>De range van landingspagina voor statusinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorStatusinformatie)</pattern.report.51>
   <pattern.title.52>1336. Landingspagina voor statusinformatie - Een verwijzing naar de statuspagina van de dataservice (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20statusinformatie)</pattern.title.52>
-  <pattern.assert.52>Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</pattern.assert.52>
-  <pattern.report.52>Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</pattern.report.52>
+  <pattern.assert.52>Maximaal één waarde toegestaan voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</pattern.assert.52>
+  <pattern.report.52>Maximaal één waarde toegestaan voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</pattern.report.52>
   <pattern.title.53>1338. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</pattern.title.53>
   <pattern.assert.53>De range van levensfase moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:levensfase)</pattern.assert.53>
   <pattern.report.53>De range van levensfase moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:levensfase)</pattern.report.53>
   <pattern.title.54>1340. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</pattern.title.54>
-  <pattern.assert.54>Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</pattern.assert.54>
-  <pattern.report.54>Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</pattern.report.54>
+  <pattern.assert.54>Maximaal één waarde toegestaan voor levensfase (mdcat:levensfase)</pattern.assert.54>
+  <pattern.report.54>Maximaal één waarde toegestaan voor levensfase (mdcat:levensfase)</pattern.report.54>
   <pattern.title.55>1341. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.55>
   <pattern.assert.55>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.assert.55>
   <pattern.report.55>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.report.55>
   <pattern.title.56>1342. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.56>
-  <pattern.assert.56>Minimaal 1 waarden verwacht voor licentie (dct:license)</pattern.assert.56>
-  <pattern.report.56>Minimaal 1 waarden verwacht voor licentie (dct:license)</pattern.report.56>
+  <pattern.assert.56>Minimaal één waarde verwacht voor licentie (dct:license)</pattern.assert.56>
+  <pattern.report.56>Minimaal één waarde verwacht voor licentie (dct:license)</pattern.report.56>
   <pattern.title.57>1343. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.57>
-  <pattern.assert.57>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.assert.57>
-  <pattern.report.57>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.report.57>
+  <pattern.assert.57>Maximaal één waarde toegestaan voor licentie (dct:license)</pattern.assert.57>
+  <pattern.report.57>Maximaal één waarde toegestaan voor licentie (dct:license)</pattern.report.57>
   <pattern.title.58>1345. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</pattern.title.58>
   <pattern.assert.58>De range van ontwikkelingstoestand moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:ontwikkelingstoestand)</pattern.assert.58>
   <pattern.report.58>De range van ontwikkelingstoestand moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:ontwikkelingstoestand)</pattern.report.58>
   <pattern.title.59>1346. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</pattern.title.59>
-  <pattern.assert.59>Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</pattern.assert.59>
-  <pattern.report.59>Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</pattern.report.59>
+  <pattern.assert.59>Maximaal één waarde toegestaan voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</pattern.assert.59>
+  <pattern.report.59>Maximaal één waarde toegestaan voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</pattern.report.59>
   <pattern.title.60>1349. Rechten - Bepalingen van juridische aard die gelden op de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Arechten)</pattern.title.60>
   <pattern.assert.60>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.assert.60>
   <pattern.report.60>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.report.60>
@@ -185,32 +185,32 @@
   <pattern.assert.61>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.assert.61>
   <pattern.report.61>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.report.61>
   <pattern.title.62>1354. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.62>
-  <pattern.assert.62>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.assert.62>
-  <pattern.report.62>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.report.62>
+  <pattern.assert.62>Minimaal één waarde verwacht voor titel (dct:title)</pattern.assert.62>
+  <pattern.report.62>Minimaal één waarde verwacht voor titel (dct:title)</pattern.report.62>
   <pattern.title.63>1356. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.63>
-  <pattern.assert.63>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.63>
-  <pattern.report.63>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.63>
+  <pattern.assert.63>Maximaal één waarde toegestaan voor titel (dct:title)</pattern.assert.63>
+  <pattern.report.63>Maximaal één waarde toegestaan voor titel (dct:title)</pattern.report.63>
   <pattern.title.64>1357. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.64>
-  <pattern.assert.64>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.64>
-  <pattern.report.64>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.64>
+  <pattern.assert.64>Slechts één waarde voor elke taal toegestaan voor titel (dct:title)</pattern.assert.64>
+  <pattern.report.64>Slechts één waarde voor elke taal toegestaan voor titel (dct:title)</pattern.report.64>
   <pattern.title.65>1358. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.65>
   <pattern.assert.65>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.65>
   <pattern.report.65>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.65>
   <pattern.title.66>1360. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.66>
-  <pattern.assert.66>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.assert.66>
-  <pattern.report.66>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.report.66>
+  <pattern.assert.66>Minimaal één waarde verwacht voor toegankelijkheid (dct:accessRights)</pattern.assert.66>
+  <pattern.report.66>Minimaal één waarde verwacht voor toegankelijkheid (dct:accessRights)</pattern.report.66>
   <pattern.title.67>1361. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.67>
   <pattern.assert.67>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.assert.67>
   <pattern.report.67>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.report.67>
   <pattern.title.68>1363. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.68>
-  <pattern.assert.68>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.assert.68>
-  <pattern.report.68>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.report.68>
+  <pattern.assert.68>Maximaal één waarde toegestaan voor toegankelijkheid (dct:accessRights)</pattern.assert.68>
+  <pattern.report.68>Maximaal één waarde toegestaan voor toegankelijkheid (dct:accessRights)</pattern.report.68>
   <pattern.title.69>1365. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atrefwoord)</pattern.title.69>
   <pattern.assert.69>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.assert.69>
   <pattern.report.69>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.report.69>
   <pattern.title.70>1667. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</pattern.title.70>
-  <pattern.assert.70>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.assert.70>
-  <pattern.report.70>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.report.70>
+  <pattern.assert.70>Maximaal één waarde toegestaan voor versie (owl:versionInfo)</pattern.assert.70>
+  <pattern.report.70>Maximaal één waarde toegestaan voor versie (owl:versionInfo)</pattern.report.70>
   <pattern.title.71>1668. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</pattern.title.71>
   <pattern.assert.71>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.assert.71>
   <pattern.report.71>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.report.71>
@@ -221,26 +221,26 @@
   <pattern.assert.73>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.73>
   <pattern.report.73>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.73>
   <pattern.title.74>1702. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.74>
-  <pattern.assert.74>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.assert.74>
-  <pattern.report.74>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.report.74>
+  <pattern.assert.74>Maximaal één waarde toegestaan voor beschrijving (dct:description)</pattern.assert.74>
+  <pattern.report.74>Maximaal één waarde toegestaan voor beschrijving (dct:description)</pattern.report.74>
   <pattern.title.75>v037. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.75>
-  <pattern.assert.75>Minimaal 1 waarden verwacht voor beschrijving (dct:description)</pattern.assert.75>
-  <pattern.report.75>Minimaal 1 waarden verwacht voor beschrijving (dct:description)</pattern.report.75>
+  <pattern.assert.75>Minimaal één waarde verwacht voor beschrijving (dct:description)</pattern.assert.75>
+  <pattern.report.75>Minimaal één waarde verwacht voor beschrijving (dct:description)</pattern.report.75>
   <pattern.title.76>v215. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.76>
-  <pattern.assert.76>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.76>
-  <pattern.report.76>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.76>
+  <pattern.assert.76>Slechts één waarde voor elke taal toegestaan voor beschrijving (dct:description)</pattern.assert.76>
+  <pattern.report.76>Slechts één waarde voor elke taal toegestaan voor beschrijving (dct:description)</pattern.report.76>
   <pattern.title.77>v056. Conform - Een standaard, schema, applicatieprofiel, vocabularium waaraan de dataset voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aconform)</pattern.title.77>
   <pattern.assert.77>De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.assert.77>
   <pattern.report.77>De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.report.77>
   <pattern.title.78>1705. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.78>
-  <pattern.assert.78>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.assert.78>
-  <pattern.report.78>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.report.78>
+  <pattern.assert.78>Maximaal één waarde toegestaan voor contactinformatie (dcat:contactPoint)</pattern.assert.78>
+  <pattern.report.78>Maximaal één waarde toegestaan voor contactinformatie (dcat:contactPoint)</pattern.report.78>
   <pattern.title.79>1706. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.79>
   <pattern.assert.79>De range van contactinformatie moet van het type &lt;http://schema.org/ContactPoint&gt; zijn. (dcat:contactPoint)</pattern.assert.79>
   <pattern.report.79>De range van contactinformatie moet van het type &lt;http://schema.org/ContactPoint&gt; zijn. (dcat:contactPoint)</pattern.report.79>
   <pattern.title.80>v041. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.80>
-  <pattern.assert.80>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.assert.80>
-  <pattern.report.80>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.report.80>
+  <pattern.assert.80>Minimaal één waarde verwacht voor contactinformatie (dcat:contactPoint)</pattern.assert.80>
+  <pattern.report.80>Minimaal één waarde verwacht voor contactinformatie (dcat:contactPoint)</pattern.report.80>
   <pattern.title.81>v046. Distributie - Een beschikbare distributie van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Adistributie)</pattern.title.81>
   <pattern.assert.81>De range van distributie moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (dcat:distribution)</pattern.assert.81>
   <pattern.report.81>De range van distributie moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (dcat:distribution)</pattern.report.81>
@@ -248,11 +248,11 @@
   <pattern.assert.82>De range van identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (dct:identifier)</pattern.assert.82>
   <pattern.report.82>De range van identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (dct:identifier)</pattern.report.82>
   <pattern.title.83>1708. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.83>
-  <pattern.assert.83>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.83>
-  <pattern.report.83>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.83>
+  <pattern.assert.83>Minimaal één waarde verwacht voor identificator (dct:identifier)</pattern.assert.83>
+  <pattern.report.83>Minimaal één waarde verwacht voor identificator (dct:identifier)</pattern.report.83>
   <pattern.title.84>1709. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.84>
-  <pattern.assert.84>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.84>
-  <pattern.report.84>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.84>
+  <pattern.assert.84>Maximaal één waarde toegestaan voor identificator (dct:identifier)</pattern.assert.84>
+  <pattern.report.84>Maximaal één waarde toegestaan voor identificator (dct:identifier)</pattern.report.84>
   <pattern.title.85>1712. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene informatie over de dataset, zijn distributies en/of aanvullende informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Alandingspagina)</pattern.title.85>
   <pattern.assert.85>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.assert.85>
   <pattern.report.85>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.report.85>
@@ -260,29 +260,29 @@
   <pattern.assert.86>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.assert.86>
   <pattern.report.86>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.report.86>
   <pattern.title.87>v039. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.87>
-  <pattern.assert.87>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.assert.87>
-  <pattern.report.87>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.report.87>
+  <pattern.assert.87>Minimaal één waarde verwacht voor titel (dct:title)</pattern.assert.87>
+  <pattern.report.87>Minimaal één waarde verwacht voor titel (dct:title)</pattern.report.87>
   <pattern.title.88>v214. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.88>
-  <pattern.assert.88>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.88>
-  <pattern.report.88>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.88>
+  <pattern.assert.88>Slechts één waarde voor elke taal toegestaan voor titel (dct:title)</pattern.assert.88>
+  <pattern.report.88>Slechts één waarde voor elke taal toegestaan voor titel (dct:title)</pattern.report.88>
   <pattern.title.89>v206. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.89>
   <pattern.assert.89>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.89>
   <pattern.report.89>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.89>
   <pattern.title.90>1716. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.90>
-  <pattern.assert.90>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.assert.90>
-  <pattern.report.90>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.report.90>
+  <pattern.assert.90>Minimaal één waarde verwacht voor toegankelijkheid (dct:accessRights)</pattern.assert.90>
+  <pattern.report.90>Minimaal één waarde verwacht voor toegankelijkheid (dct:accessRights)</pattern.report.90>
   <pattern.title.91>1717. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.91>
   <pattern.assert.91>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.assert.91>
   <pattern.report.91>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.report.91>
   <pattern.title.92>v100. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.92>
-  <pattern.assert.92>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.assert.92>
-  <pattern.report.92>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.report.92>
+  <pattern.assert.92>Maximaal één waarde toegestaan voor toegankelijkheid (dct:accessRights)</pattern.assert.92>
+  <pattern.report.92>Maximaal één waarde toegestaan voor toegankelijkheid (dct:accessRights)</pattern.report.92>
   <pattern.title.93>1720. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atrefwoord)</pattern.title.93>
   <pattern.assert.93>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.assert.93>
   <pattern.report.93>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.report.93>
   <pattern.title.94>v076. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</pattern.title.94>
-  <pattern.assert.94>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.assert.94>
-  <pattern.report.94>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.report.94>
+  <pattern.assert.94>Maximaal één waarde toegestaan voor versie (owl:versionInfo)</pattern.assert.94>
+  <pattern.report.94>Maximaal één waarde toegestaan voor versie (owl:versionInfo)</pattern.report.94>
   <pattern.title.95>v075. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</pattern.title.95>
   <pattern.assert.95>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.assert.95>
   <pattern.report.95>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.report.95>
@@ -293,66 +293,66 @@
   <pattern.assert.97>De range van downloadURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:downloadURL)</pattern.assert.97>
   <pattern.report.97>De range van downloadURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:downloadURL)</pattern.report.97>
   <pattern.title.98>v090. Downloadurl - De URL waar de data gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AdownloadURL)</pattern.title.98>
-  <pattern.assert.98>Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</pattern.assert.98>
-  <pattern.report.98>Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</pattern.report.98>
+  <pattern.assert.98>Maximaal één waarde toegestaan voor downloadURL (dcat:downloadURL)</pattern.assert.98>
+  <pattern.report.98>Maximaal één waarde toegestaan voor downloadURL (dcat:downloadURL)</pattern.report.98>
   <pattern.title.99>1902. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.99>
   <pattern.assert.99>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.99>
   <pattern.report.99>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.99>
   <pattern.title.100>1903. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.100>
-  <pattern.assert.100>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.100>
-  <pattern.report.100>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.100>
+  <pattern.assert.100>Minimaal één waarde verwacht voor identificator (dct:identifier)</pattern.assert.100>
+  <pattern.report.100>Minimaal één waarde verwacht voor identificator (dct:identifier)</pattern.report.100>
   <pattern.title.101>1904. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.101>
-  <pattern.assert.101>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.101>
-  <pattern.report.101>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.101>
+  <pattern.assert.101>Maximaal één waarde toegestaan voor identificator (dct:identifier)</pattern.assert.101>
+  <pattern.report.101>Maximaal één waarde toegestaan voor identificator (dct:identifier)</pattern.report.101>
   <pattern.title.102>v087. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</pattern.title.102>
   <pattern.assert.102>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.assert.102>
   <pattern.report.102>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.report.102>
   <pattern.title.103>v088. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</pattern.title.103>
-  <pattern.assert.103>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.assert.103>
-  <pattern.report.103>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.report.103>
+  <pattern.assert.103>Maximaal één waarde toegestaan voor licentie (dct:license)</pattern.assert.103>
+  <pattern.report.103>Maximaal één waarde toegestaan voor licentie (dct:license)</pattern.report.103>
   <pattern.title.104>1907. Rechten - Bepalingen van juridische aard die gelden op de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Arechten)</pattern.title.104>
   <pattern.assert.104>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.assert.104>
   <pattern.report.104>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.report.104>
   <pattern.title.105>1909. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.105>
-  <pattern.assert.105>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.105>
-  <pattern.report.105>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.105>
+  <pattern.assert.105>Maximaal één waarde toegestaan voor titel (dct:title)</pattern.assert.105>
+  <pattern.report.105>Maximaal één waarde toegestaan voor titel (dct:title)</pattern.report.105>
   <pattern.title.106>v216. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.106>
-  <pattern.assert.106>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.106>
-  <pattern.report.106>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.106>
+  <pattern.assert.106>Slechts één waarde voor elke taal toegestaan voor titel (dct:title)</pattern.assert.106>
+  <pattern.report.106>Slechts één waarde voor elke taal toegestaan voor titel (dct:title)</pattern.report.106>
   <pattern.title.107>v205. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.107>
   <pattern.assert.107>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.107>
   <pattern.report.107>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.107>
   <pattern.title.108>v220. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.108>
-  <pattern.assert.108>Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</pattern.assert.108>
-  <pattern.report.108>Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</pattern.report.108>
+  <pattern.assert.108>Maximaal één waarde toegestaan voor toegangsURL (dcat:accessURL)</pattern.assert.108>
+  <pattern.report.108>Maximaal één waarde toegestaan voor toegangsURL (dcat:accessURL)</pattern.report.108>
   <pattern.title.109>1910. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.109>
   <pattern.assert.109>De range van toegangsURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:accessURL)</pattern.assert.109>
   <pattern.report.109>De range van toegangsURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:accessURL)</pattern.report.109>
   <pattern.title.110>v079. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.110>
-  <pattern.assert.110>Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</pattern.assert.110>
-  <pattern.report.110>Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</pattern.report.110>
+  <pattern.assert.110>Minimaal één waarde verwacht voor toegangsURL (dcat:accessURL)</pattern.assert.110>
+  <pattern.report.110>Minimaal één waarde verwacht voor toegangsURL (dcat:accessURL)</pattern.report.110>
   <pattern.title.111>1912. Wordt aangeboden door - Een dataservice die deze distributie aanbiedt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Awordt%20aangeboden%20door)</pattern.title.111>
   <pattern.assert.111>De range van wordt aangeboden door moet van het type &lt;http://www.w3.org/ns/dcat#DataService&gt; zijn. (dcat:accessService)</pattern.assert.111>
   <pattern.report.111>De range van wordt aangeboden door moet van het type &lt;http://www.w3.org/ns/dcat#DataService&gt; zijn. (dcat:accessService)</pattern.report.111>
   <pattern.title.112>2005. Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</pattern.title.112>
-  <pattern.assert.112>Minimaal 1 waarden verwacht voor statuut (mdcat:statuut)</pattern.assert.112>
-  <pattern.report.112>Minimaal 1 waarden verwacht voor statuut (mdcat:statuut)</pattern.report.112>
+  <pattern.assert.112>Minimaal één waarde verwacht voor statuut (mdcat:statuut)</pattern.assert.112>
+  <pattern.report.112>Minimaal één waarde verwacht voor statuut (mdcat:statuut)</pattern.report.112>
   <pattern.title.113>2009. Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</pattern.title.113>
   <pattern.assert.113>De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</pattern.assert.113>
   <pattern.report.113>De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</pattern.report.113>
   <pattern.title.114>2002. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.114>
-  <pattern.assert.114>Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</pattern.assert.114>
-  <pattern.report.114>Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</pattern.report.114>
+  <pattern.assert.114>Maximaal één waarde toegestaan voor uitgever (dct:publisher)</pattern.assert.114>
+  <pattern.report.114>Maximaal één waarde toegestaan voor uitgever (dct:publisher)</pattern.report.114>
   <pattern.title.115>v052. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.115>
   <pattern.assert.115>De range van uitgever moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:publisher)</pattern.assert.115>
   <pattern.report.115>De range van uitgever moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:publisher)</pattern.report.115>
   <pattern.title.116>v049. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.116>
-  <pattern.assert.116>Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</pattern.assert.116>
-  <pattern.report.116>Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</pattern.report.116>
+  <pattern.assert.116>Minimaal één waarde verwacht voor uitgever (dct:publisher)</pattern.assert.116>
+  <pattern.report.116>Minimaal één waarde verwacht voor uitgever (dct:publisher)</pattern.report.116>
   <pattern.title.117>Beschrijving - Een bondige tekstuele omschrijving van de distributie.</pattern.title.117>
   <pattern.assert.117>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.117>
   <pattern.report.117>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.117>
   <pattern.title.118>Beschrijving - Een bondige tekstuele omschrijving van de distributie.</pattern.title.118>
-  <pattern.assert.118>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.118>
-  <pattern.report.118>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.118>
+  <pattern.assert.118>Slechts één waarde voor elke taal toegestaan voor beschrijving (dct:description)</pattern.assert.118>
+  <pattern.report.118>Slechts één waarde voor elke taal toegestaan voor beschrijving (dct:description)</pattern.report.118>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-vl.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-vl.xml
@@ -1,4 +1,358 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>DCAT-AP-Vlaanderen - Verplicht</schematron.title>
+  <pattern.title.1>vcard:hasEmail is a URI with the mailto protocol.</pattern.title.1>
+  <pattern.assert.1>vcard:hasEmail property is not a URI with the mailto: protocol.</pattern.assert.1>
+  <pattern.report.1>vcard:hasEmail property is a URI with the mailto: protocol.</pattern.report.1>
+  <pattern.title.2>dct:license is CC0</pattern.title.2>
+  <pattern.assert.2>The dcat:Catalog does not have a dct:license property with value 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0'.</pattern.assert.2>
+  <pattern.report.2>The dcat:Catalog has a dct:license property with value 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0'.</pattern.report.2>
+  <pattern.title.3>dct:accessRights must be public</pattern.title.3>
+  <pattern.assert.3>The dcat:Dataset does not have a dct:accessRights property with value 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'.</pattern.assert.3>
+  <pattern.report.3>The dcat:Dataset has a dct:accessRights property with value 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'.</pattern.report.3>
+  <pattern.title.4>At least one keyword is required.</pattern.title.4>
+  <pattern.assert.4>The dcat:Resource doesn't have any keyword.</pattern.assert.4>
+  <pattern.report.4>The dcat:Resource have at least one keyword.</pattern.report.4>
+  <pattern.title.5>At least one of vcard:hasEmail or vcard:hasURL is a required for a contactpoint.</pattern.title.5>
+  <pattern.assert.5>A vcard:Organization does not have a vcard:hasEmail or a vcard:hasURL property.</pattern.assert.5>
+  <pattern.report.5>A vcard:Organization has a vcard:hasEmail or a vcard:hasURL property.</pattern.report.5>
+  <pattern.title.6>Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.6>
+  <pattern.assert.6>De range van naam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (foaf:name)</pattern.assert.6>
+  <pattern.report.6>De range van naam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (foaf:name)</pattern.report.6>
+  <pattern.title.7>v212. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.7>
+  <pattern.assert.7>Slechts 1 waarde voor elke taal toegelaten voor naam (foaf:name)</pattern.assert.7>
+  <pattern.report.7>Slechts 1 waarde voor elke taal toegelaten voor naam (foaf:name)</pattern.report.7>
+  <pattern.title.8>v000. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.8>
+  <pattern.assert.8>Minimaal 1 waarden verwacht voor naam (foaf:name)</pattern.assert.8>
+  <pattern.report.8>Minimaal 1 waarden verwacht voor naam (foaf:name)</pattern.report.8>
+  <pattern.title.9>1001. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</pattern.title.9>
+  <pattern.assert.9>De range van contactpagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (foaf:page)</pattern.assert.9>
+  <pattern.report.9>De range van contactpagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (foaf:page)</pattern.report.9>
+  <pattern.title.10>1002. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</pattern.title.10>
+  <pattern.assert.10>Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</pattern.assert.10>
+  <pattern.report.10>Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</pattern.report.10>
+  <pattern.title.11>413. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</pattern.title.11>
+  <pattern.assert.11>De range van e-mail moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (vcard:hasEmail)</pattern.assert.11>
+  <pattern.report.11>De range van e-mail moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (vcard:hasEmail)</pattern.report.11>
+  <pattern.title.12>1004. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</pattern.title.12>
+  <pattern.assert.12>Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</pattern.assert.12>
+  <pattern.report.12>Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</pattern.report.12>
+  <pattern.title.13>1201. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</pattern.title.13>
+  <pattern.assert.13>De range van aanmaakdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</pattern.assert.13>
+  <pattern.report.13>De range van aanmaakdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</pattern.report.13>
+  <pattern.title.14>1202. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</pattern.title.14>
+  <pattern.assert.14>Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</pattern.assert.14>
+  <pattern.report.14>Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</pattern.report.14>
+  <pattern.title.15>1204. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een record in de catalogus kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aalternatieve%20identificator)</pattern.title.15>
+  <pattern.assert.15>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.15>
+  <pattern.report.15>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.15>
+  <pattern.title.16>1206. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.16>
+  <pattern.assert.16>Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</pattern.assert.16>
+  <pattern.report.16>Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</pattern.report.16>
+  <pattern.title.17>1208. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.17>
+  <pattern.assert.17>De range van hoofdonderwerp moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (foaf:primaryTopic)</pattern.assert.17>
+  <pattern.report.17>De range van hoofdonderwerp moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (foaf:primaryTopic)</pattern.report.17>
+  <pattern.title.18>1209. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.18>
+  <pattern.assert.18>Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</pattern.assert.18>
+  <pattern.report.18>Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</pattern.report.18>
+  <pattern.title.19>1210. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.19>
+  <pattern.assert.19>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.19>
+  <pattern.report.19>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.19>
+  <pattern.title.20>1211. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.20>
+  <pattern.assert.20>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.20>
+  <pattern.report.20>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.20>
+  <pattern.title.21>1212. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.21>
+  <pattern.assert.21>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.21>
+  <pattern.report.21>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.21>
+  <pattern.title.22>1215. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.22>
+  <pattern.assert.22>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.22>
+  <pattern.report.22>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.22>
+  <pattern.title.23>1216. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.23>
+  <pattern.assert.23>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.23>
+  <pattern.report.23>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.23>
+  <pattern.title.24>1217. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.24>
+  <pattern.assert.24>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.24>
+  <pattern.report.24>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.24>
+  <pattern.title.25>1218. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.25>
+  <pattern.assert.25>Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</pattern.assert.25>
+  <pattern.report.25>Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</pattern.report.25>
+  <pattern.title.26>1219. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.26>
+  <pattern.assert.26>Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</pattern.assert.26>
+  <pattern.report.26>Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</pattern.report.26>
+  <pattern.title.27>1220. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.27>
+  <pattern.assert.27>De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</pattern.assert.27>
+  <pattern.report.27>De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</pattern.report.27>
+  <pattern.title.28>1301. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een dataservice kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aalternatieve%20identificator)</pattern.title.28>
+  <pattern.assert.28>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.28>
+  <pattern.report.28>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.28>
+  <pattern.title.29>1303. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.29>
+  <pattern.assert.29>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.29>
+  <pattern.report.29>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.29>
+  <pattern.title.30>1305. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.30>
+  <pattern.assert.30>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.assert.30>
+  <pattern.report.30>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.report.30>
+  <pattern.title.31>1306. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.31>
+  <pattern.assert.31>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.31>
+  <pattern.report.31>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.31>
+  <pattern.title.32>1308. Biedt informatie aan over - De data die via deze dataservice worden aangeboden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abiedt%20informatie%20aan%20over)</pattern.title.32>
+  <pattern.assert.32>De range van biedt informatie aan over moet van het type &lt;http://www.w3.org/ns/dcat#Dataset&gt; zijn. (dcat:servesdataset)</pattern.assert.32>
+  <pattern.report.32>De range van biedt informatie aan over moet van het type &lt;http://www.w3.org/ns/dcat#Dataset&gt; zijn. (dcat:servesdataset)</pattern.report.32>
+  <pattern.title.33>1309. Conform aan protocol - Een protocol waaraan de dataservice voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aconform%20aan%20protocol)</pattern.title.33>
+  <pattern.assert.33>De range van conform aan protocol moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.assert.33>
+  <pattern.report.33>De range van conform aan protocol moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.report.33>
+  <pattern.title.34>1312. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.34>
+  <pattern.assert.34>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.assert.34>
+  <pattern.report.34>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.report.34>
+  <pattern.title.35>1313. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.35>
+  <pattern.assert.35>De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</pattern.assert.35>
+  <pattern.report.35>De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</pattern.report.35>
+  <pattern.title.36>1314. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.36>
+  <pattern.assert.36>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.assert.36>
+  <pattern.report.36>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.report.36>
+  <pattern.title.37>1315. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.37>
+  <pattern.assert.37>De range van endpointURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointURL)</pattern.assert.37>
+  <pattern.report.37>De range van endpointURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointURL)</pattern.report.37>
+  <pattern.title.38>1317. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.38>
+  <pattern.assert.38>Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</pattern.assert.38>
+  <pattern.report.38>Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</pattern.report.38>
+  <pattern.title.39>1318. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.39>
+  <pattern.assert.39>Minimaal 1 waarden verwacht voor endpointURL (dcat:endpointURL)</pattern.assert.39>
+  <pattern.report.39>Minimaal 1 waarden verwacht voor endpointURL (dcat:endpointURL)</pattern.report.39>
+  <pattern.title.40>1320. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.40>
+  <pattern.assert.40>Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</pattern.assert.40>
+  <pattern.report.40>Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</pattern.report.40>
+  <pattern.title.41>1321. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.41>
+  <pattern.assert.41>Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</pattern.assert.41>
+  <pattern.report.41>Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</pattern.report.41>
+  <pattern.title.42>1322. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.42>
+  <pattern.assert.42>De range van endpointbeschrijving moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointDescription)</pattern.assert.42>
+  <pattern.report.42>De range van endpointbeschrijving moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointDescription)</pattern.report.42>
+  <pattern.title.43>1323. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.43>
+  <pattern.assert.43>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.43>
+  <pattern.report.43>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.43>
+  <pattern.title.44>1323. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.44>
+  <pattern.assert.44>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.44>
+  <pattern.report.44>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.44>
+  <pattern.title.45>1324. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.45>
+  <pattern.assert.45>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.45>
+  <pattern.report.45>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.45>
+  <pattern.title.46>1327. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene aanvullende informatie over de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina)</pattern.title.46>
+  <pattern.assert.46>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.assert.46>
+  <pattern.report.46>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.report.46>
+  <pattern.title.47>1328. Landingspagina voor authenticatie - Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20authenticatie)</pattern.title.47>
+  <pattern.assert.47>De range van landingspagina voor authenticatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorAuthenticatie)</pattern.assert.47>
+  <pattern.report.47>De range van landingspagina voor authenticatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorAuthenticatie)</pattern.report.47>
+  <pattern.title.48>1330. Landingspagina voor authenticatie - Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20authenticatie)</pattern.title.48>
+  <pattern.assert.48>Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</pattern.assert.48>
+  <pattern.report.48>Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</pattern.report.48>
+  <pattern.title.49>1332. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</pattern.title.49>
+  <pattern.assert.49>Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.assert.49>
+  <pattern.report.49>Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.report.49>
+  <pattern.title.50>1333. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</pattern.title.50>
+  <pattern.assert.50>De range van landingspagina voor gebruiksinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.assert.50>
+  <pattern.report.50>De range van landingspagina voor gebruiksinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.report.50>
+  <pattern.title.51>1334. Landingspagina voor statusinformatie - Een verwijzing naar de statuspagina van de dataservice (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20statusinformatie)</pattern.title.51>
+  <pattern.assert.51>De range van landingspagina voor statusinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorStatusinformatie)</pattern.assert.51>
+  <pattern.report.51>De range van landingspagina voor statusinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorStatusinformatie)</pattern.report.51>
+  <pattern.title.52>1336. Landingspagina voor statusinformatie - Een verwijzing naar de statuspagina van de dataservice (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20statusinformatie)</pattern.title.52>
+  <pattern.assert.52>Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</pattern.assert.52>
+  <pattern.report.52>Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</pattern.report.52>
+  <pattern.title.53>1338. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</pattern.title.53>
+  <pattern.assert.53>De range van levensfase moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:levensfase)</pattern.assert.53>
+  <pattern.report.53>De range van levensfase moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:levensfase)</pattern.report.53>
+  <pattern.title.54>1340. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</pattern.title.54>
+  <pattern.assert.54>Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</pattern.assert.54>
+  <pattern.report.54>Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</pattern.report.54>
+  <pattern.title.55>1341. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.55>
+  <pattern.assert.55>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.assert.55>
+  <pattern.report.55>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.report.55>
+  <pattern.title.56>1342. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.56>
+  <pattern.assert.56>Minimaal 1 waarden verwacht voor licentie (dct:license)</pattern.assert.56>
+  <pattern.report.56>Minimaal 1 waarden verwacht voor licentie (dct:license)</pattern.report.56>
+  <pattern.title.57>1343. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.57>
+  <pattern.assert.57>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.assert.57>
+  <pattern.report.57>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.report.57>
+  <pattern.title.58>1345. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</pattern.title.58>
+  <pattern.assert.58>De range van ontwikkelingstoestand moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:ontwikkelingstoestand)</pattern.assert.58>
+  <pattern.report.58>De range van ontwikkelingstoestand moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:ontwikkelingstoestand)</pattern.report.58>
+  <pattern.title.59>1346. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</pattern.title.59>
+  <pattern.assert.59>Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</pattern.assert.59>
+  <pattern.report.59>Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</pattern.report.59>
+  <pattern.title.60>1349. Rechten - Bepalingen van juridische aard die gelden op de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Arechten)</pattern.title.60>
+  <pattern.assert.60>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.assert.60>
+  <pattern.report.60>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.report.60>
+  <pattern.title.61>1351. Thema - De hoofdcategorie waartoe de dataservice behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Athema)</pattern.title.61>
+  <pattern.assert.61>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.assert.61>
+  <pattern.report.61>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.report.61>
+  <pattern.title.62>1354. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.62>
+  <pattern.assert.62>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.assert.62>
+  <pattern.report.62>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.report.62>
+  <pattern.title.63>1356. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.63>
+  <pattern.assert.63>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.63>
+  <pattern.report.63>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.63>
+  <pattern.title.64>1357. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.64>
+  <pattern.assert.64>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.64>
+  <pattern.report.64>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.64>
+  <pattern.title.65>1358. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.65>
+  <pattern.assert.65>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.65>
+  <pattern.report.65>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.65>
+  <pattern.title.66>1360. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.66>
+  <pattern.assert.66>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.assert.66>
+  <pattern.report.66>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.report.66>
+  <pattern.title.67>1361. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.67>
+  <pattern.assert.67>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.assert.67>
+  <pattern.report.67>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.report.67>
+  <pattern.title.68>1363. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.68>
+  <pattern.assert.68>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.assert.68>
+  <pattern.report.68>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.report.68>
+  <pattern.title.69>1365. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atrefwoord)</pattern.title.69>
+  <pattern.assert.69>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.assert.69>
+  <pattern.report.69>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.report.69>
+  <pattern.title.70>1667. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</pattern.title.70>
+  <pattern.assert.70>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.assert.70>
+  <pattern.report.70>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.report.70>
+  <pattern.title.71>1668. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</pattern.title.71>
+  <pattern.assert.71>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.assert.71>
+  <pattern.report.71>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.report.71>
+  <pattern.title.72>v067. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een dataset kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aalternatieve%20identificator)</pattern.title.72>
+  <pattern.assert.72>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.72>
+  <pattern.report.72>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.72>
+  <pattern.title.73>v207. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.73>
+  <pattern.assert.73>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.73>
+  <pattern.report.73>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.73>
+  <pattern.title.74>1702. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.74>
+  <pattern.assert.74>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.assert.74>
+  <pattern.report.74>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.report.74>
+  <pattern.title.75>v037. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.75>
+  <pattern.assert.75>Minimaal 1 waarden verwacht voor beschrijving (dct:description)</pattern.assert.75>
+  <pattern.report.75>Minimaal 1 waarden verwacht voor beschrijving (dct:description)</pattern.report.75>
+  <pattern.title.76>v215. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.76>
+  <pattern.assert.76>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.76>
+  <pattern.report.76>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.76>
+  <pattern.title.77>v056. Conform - Een standaard, schema, applicatieprofiel, vocabularium waaraan de dataset voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aconform)</pattern.title.77>
+  <pattern.assert.77>De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.assert.77>
+  <pattern.report.77>De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.report.77>
+  <pattern.title.78>1705. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.78>
+  <pattern.assert.78>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.assert.78>
+  <pattern.report.78>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.report.78>
+  <pattern.title.79>1706. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.79>
+  <pattern.assert.79>De range van contactinformatie moet van het type &lt;http://schema.org/ContactPoint&gt; zijn. (dcat:contactPoint)</pattern.assert.79>
+  <pattern.report.79>De range van contactinformatie moet van het type &lt;http://schema.org/ContactPoint&gt; zijn. (dcat:contactPoint)</pattern.report.79>
+  <pattern.title.80>v041. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.80>
+  <pattern.assert.80>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.assert.80>
+  <pattern.report.80>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.report.80>
+  <pattern.title.81>v046. Distributie - Een beschikbare distributie van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Adistributie)</pattern.title.81>
+  <pattern.assert.81>De range van distributie moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (dcat:distribution)</pattern.assert.81>
+  <pattern.report.81>De range van distributie moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (dcat:distribution)</pattern.report.81>
+  <pattern.title.82>v060. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.82>
+  <pattern.assert.82>De range van identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (dct:identifier)</pattern.assert.82>
+  <pattern.report.82>De range van identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (dct:identifier)</pattern.report.82>
+  <pattern.title.83>1708. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.83>
+  <pattern.assert.83>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.83>
+  <pattern.report.83>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.83>
+  <pattern.title.84>1709. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.84>
+  <pattern.assert.84>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.84>
+  <pattern.report.84>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.84>
+  <pattern.title.85>1712. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene informatie over de dataset, zijn distributies en/of aanvullende informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Alandingspagina)</pattern.title.85>
+  <pattern.assert.85>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.assert.85>
+  <pattern.report.85>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.report.85>
+  <pattern.title.86>v115. Thema - De hoofdcategorie waartoe de dataset behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Athema)</pattern.title.86>
+  <pattern.assert.86>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.assert.86>
+  <pattern.report.86>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.report.86>
+  <pattern.title.87>v039. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.87>
+  <pattern.assert.87>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.assert.87>
+  <pattern.report.87>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.report.87>
+  <pattern.title.88>v214. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.88>
+  <pattern.assert.88>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.88>
+  <pattern.report.88>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.88>
+  <pattern.title.89>v206. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.89>
+  <pattern.assert.89>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.89>
+  <pattern.report.89>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.89>
+  <pattern.title.90>1716. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.90>
+  <pattern.assert.90>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.assert.90>
+  <pattern.report.90>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.report.90>
+  <pattern.title.91>1717. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.91>
+  <pattern.assert.91>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.assert.91>
+  <pattern.report.91>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.report.91>
+  <pattern.title.92>v100. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.92>
+  <pattern.assert.92>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.assert.92>
+  <pattern.report.92>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.report.92>
+  <pattern.title.93>1720. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atrefwoord)</pattern.title.93>
+  <pattern.assert.93>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.assert.93>
+  <pattern.report.93>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.report.93>
+  <pattern.title.94>v076. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</pattern.title.94>
+  <pattern.assert.94>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.assert.94>
+  <pattern.report.94>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.report.94>
+  <pattern.title.95>v075. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</pattern.title.95>
+  <pattern.assert.95>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.assert.95>
+  <pattern.report.95>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.report.95>
+  <pattern.title.96>1801. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een distributie kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aalternatieve%20identificator)</pattern.title.96>
+  <pattern.assert.96>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.96>
+  <pattern.report.96>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.96>
+  <pattern.title.97>v090. Downloadurl - De URL waar de data gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AdownloadURL)</pattern.title.97>
+  <pattern.assert.97>De range van downloadURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:downloadURL)</pattern.assert.97>
+  <pattern.report.97>De range van downloadURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:downloadURL)</pattern.report.97>
+  <pattern.title.98>v090. Downloadurl - De URL waar de data gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AdownloadURL)</pattern.title.98>
+  <pattern.assert.98>Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</pattern.assert.98>
+  <pattern.report.98>Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</pattern.report.98>
+  <pattern.title.99>1902. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.99>
+  <pattern.assert.99>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.99>
+  <pattern.report.99>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.99>
+  <pattern.title.100>1903. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.100>
+  <pattern.assert.100>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.100>
+  <pattern.report.100>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.100>
+  <pattern.title.101>1904. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.101>
+  <pattern.assert.101>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.101>
+  <pattern.report.101>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.101>
+  <pattern.title.102>v087. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</pattern.title.102>
+  <pattern.assert.102>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.assert.102>
+  <pattern.report.102>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.report.102>
+  <pattern.title.103>v088. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</pattern.title.103>
+  <pattern.assert.103>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.assert.103>
+  <pattern.report.103>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.report.103>
+  <pattern.title.104>1907. Rechten - Bepalingen van juridische aard die gelden op de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Arechten)</pattern.title.104>
+  <pattern.assert.104>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.assert.104>
+  <pattern.report.104>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.report.104>
+  <pattern.title.105>1909. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.105>
+  <pattern.assert.105>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.105>
+  <pattern.report.105>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.105>
+  <pattern.title.106>v216. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.106>
+  <pattern.assert.106>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.106>
+  <pattern.report.106>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.106>
+  <pattern.title.107>v205. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.107>
+  <pattern.assert.107>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.107>
+  <pattern.report.107>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.107>
+  <pattern.title.108>v220. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.108>
+  <pattern.assert.108>Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</pattern.assert.108>
+  <pattern.report.108>Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</pattern.report.108>
+  <pattern.title.109>1910. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.109>
+  <pattern.assert.109>De range van toegangsURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:accessURL)</pattern.assert.109>
+  <pattern.report.109>De range van toegangsURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:accessURL)</pattern.report.109>
+  <pattern.title.110>v079. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.110>
+  <pattern.assert.110>Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</pattern.assert.110>
+  <pattern.report.110>Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</pattern.report.110>
+  <pattern.title.111>1912. Wordt aangeboden door - Een dataservice die deze distributie aanbiedt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Awordt%20aangeboden%20door)</pattern.title.111>
+  <pattern.assert.111>De range van wordt aangeboden door moet van het type &lt;http://www.w3.org/ns/dcat#DataService&gt; zijn. (dcat:accessService)</pattern.assert.111>
+  <pattern.report.111>De range van wordt aangeboden door moet van het type &lt;http://www.w3.org/ns/dcat#DataService&gt; zijn. (dcat:accessService)</pattern.report.111>
+  <pattern.title.112>2005. Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</pattern.title.112>
+  <pattern.assert.112>Minimaal 1 waarden verwacht voor statuut (mdcat:statuut)</pattern.assert.112>
+  <pattern.report.112>Minimaal 1 waarden verwacht voor statuut (mdcat:statuut)</pattern.report.112>
+  <pattern.title.113>2009. Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</pattern.title.113>
+  <pattern.assert.113>De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</pattern.assert.113>
+  <pattern.report.113>De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</pattern.report.113>
+  <pattern.title.114>2002. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.114>
+  <pattern.assert.114>Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</pattern.assert.114>
+  <pattern.report.114>Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</pattern.report.114>
+  <pattern.title.115>v052. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.115>
+  <pattern.assert.115>De range van uitgever moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:publisher)</pattern.assert.115>
+  <pattern.report.115>De range van uitgever moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:publisher)</pattern.report.115>
+  <pattern.title.116>v049. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.116>
+  <pattern.assert.116>Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</pattern.assert.116>
+  <pattern.report.116>Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</pattern.report.116>
+  <pattern.title.117>Beschrijving - Een bondige tekstuele omschrijving van de distributie.</pattern.title.117>
+  <pattern.assert.117>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.117>
+  <pattern.report.117>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.117>
+  <pattern.title.118>Beschrijving - Een bondige tekstuele omschrijving van de distributie.</pattern.title.118>
+  <pattern.assert.118>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.118>
+  <pattern.report.118>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.118>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-vl-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-vl-rec.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>DCAT-AP-Vlaanderen - Recommended</schematron.title>
+  <required.datatheme.title>At least one theme from the data.gov.be vocabulary is expected</required.datatheme.title>
+  <required.datatheme.assert>The dcat:Resource doesn't have a data.gov.be theme</required.datatheme.assert>
+  <required.datatheme.report>The dcat:Resource have a data.gov.be theme</required.datatheme.report>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-vl.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-vl.xml
@@ -12,347 +12,347 @@
   <pattern.report.3>The dcat:Dataset has a dct:accessRights property with value 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'.</pattern.report.3>
   <pattern.title.4>At least one keyword is required.</pattern.title.4>
   <pattern.assert.4>The dcat:Resource doesn't have any keyword.</pattern.assert.4>
-  <pattern.report.4>The dcat:Resource have at least one keyword.</pattern.report.4>
-  <pattern.title.5>At least one of vcard:hasEmail or vcard:hasURL is a required for a contactpoint.</pattern.title.5>
+  <pattern.report.4>The dcat:Resource has at least one keyword.</pattern.report.4>
+  <pattern.title.5>At least one of vcard:hasEmail or vcard:hasURL is required for a contact point.</pattern.title.5>
   <pattern.assert.5>A vcard:Organization does not have a vcard:hasEmail or a vcard:hasURL property.</pattern.assert.5>
   <pattern.report.5>A vcard:Organization has a vcard:hasEmail or a vcard:hasURL property.</pattern.report.5>
-  <pattern.title.6>Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.6>
-  <pattern.assert.6>De range van naam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (foaf:name)</pattern.assert.6>
-  <pattern.report.6>De range van naam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (foaf:name)</pattern.report.6>
-  <pattern.title.7>v212. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.7>
-  <pattern.assert.7>Slechts 1 waarde voor elke taal toegelaten voor naam (foaf:name)</pattern.assert.7>
-  <pattern.report.7>Slechts 1 waarde voor elke taal toegelaten voor naam (foaf:name)</pattern.report.7>
-  <pattern.title.8>v000. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.8>
-  <pattern.assert.8>Minimaal 1 waarden verwacht voor naam (foaf:name)</pattern.assert.8>
-  <pattern.report.8>Minimaal 1 waarden verwacht voor naam (foaf:name)</pattern.report.8>
-  <pattern.title.9>1001. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</pattern.title.9>
-  <pattern.assert.9>De range van contactpagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (foaf:page)</pattern.assert.9>
-  <pattern.report.9>De range van contactpagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (foaf:page)</pattern.report.9>
-  <pattern.title.10>1002. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</pattern.title.10>
-  <pattern.assert.10>Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</pattern.assert.10>
-  <pattern.report.10>Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</pattern.report.10>
-  <pattern.title.11>413. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</pattern.title.11>
-  <pattern.assert.11>De range van e-mail moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (vcard:hasEmail)</pattern.assert.11>
-  <pattern.report.11>De range van e-mail moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (vcard:hasEmail)</pattern.report.11>
-  <pattern.title.12>1004. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</pattern.title.12>
-  <pattern.assert.12>Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</pattern.assert.12>
-  <pattern.report.12>Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</pattern.report.12>
-  <pattern.title.13>1201. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</pattern.title.13>
-  <pattern.assert.13>De range van aanmaakdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</pattern.assert.13>
-  <pattern.report.13>De range van aanmaakdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</pattern.report.13>
-  <pattern.title.14>1202. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</pattern.title.14>
-  <pattern.assert.14>Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</pattern.assert.14>
-  <pattern.report.14>Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</pattern.report.14>
-  <pattern.title.15>1204. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een record in de catalogus kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aalternatieve%20identificator)</pattern.title.15>
-  <pattern.assert.15>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.15>
-  <pattern.report.15>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.15>
-  <pattern.title.16>1206. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.16>
-  <pattern.assert.16>Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</pattern.assert.16>
-  <pattern.report.16>Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</pattern.report.16>
-  <pattern.title.17>1208. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.17>
-  <pattern.assert.17>De range van hoofdonderwerp moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (foaf:primaryTopic)</pattern.assert.17>
-  <pattern.report.17>De range van hoofdonderwerp moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (foaf:primaryTopic)</pattern.report.17>
-  <pattern.title.18>1209. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.18>
-  <pattern.assert.18>Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</pattern.assert.18>
-  <pattern.report.18>Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</pattern.report.18>
-  <pattern.title.19>1210. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.19>
-  <pattern.assert.19>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.19>
-  <pattern.report.19>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.19>
-  <pattern.title.20>1211. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.20>
-  <pattern.assert.20>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.20>
-  <pattern.report.20>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.20>
-  <pattern.title.21>1212. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.21>
-  <pattern.assert.21>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.21>
-  <pattern.report.21>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.21>
-  <pattern.title.22>1215. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.22>
-  <pattern.assert.22>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.22>
-  <pattern.report.22>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.22>
-  <pattern.title.23>1216. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.23>
-  <pattern.assert.23>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.23>
-  <pattern.report.23>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.23>
-  <pattern.title.24>1217. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.24>
-  <pattern.assert.24>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.24>
-  <pattern.report.24>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.24>
-  <pattern.title.25>1218. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.25>
-  <pattern.assert.25>Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</pattern.assert.25>
-  <pattern.report.25>Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</pattern.report.25>
-  <pattern.title.26>1219. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.26>
-  <pattern.assert.26>Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</pattern.assert.26>
-  <pattern.report.26>Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</pattern.report.26>
-  <pattern.title.27>1220. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.27>
-  <pattern.assert.27>De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</pattern.assert.27>
-  <pattern.report.27>De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</pattern.report.27>
-  <pattern.title.28>1301. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een dataservice kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aalternatieve%20identificator)</pattern.title.28>
-  <pattern.assert.28>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.28>
-  <pattern.report.28>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.28>
-  <pattern.title.29>1303. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.29>
-  <pattern.assert.29>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.29>
-  <pattern.report.29>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.29>
-  <pattern.title.30>1305. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.30>
-  <pattern.assert.30>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.assert.30>
-  <pattern.report.30>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.report.30>
-  <pattern.title.31>1306. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.31>
-  <pattern.assert.31>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.31>
-  <pattern.report.31>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.31>
-  <pattern.title.32>1308. Biedt informatie aan over - De data die via deze dataservice worden aangeboden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abiedt%20informatie%20aan%20over)</pattern.title.32>
-  <pattern.assert.32>De range van biedt informatie aan over moet van het type &lt;http://www.w3.org/ns/dcat#Dataset&gt; zijn. (dcat:servesdataset)</pattern.assert.32>
-  <pattern.report.32>De range van biedt informatie aan over moet van het type &lt;http://www.w3.org/ns/dcat#Dataset&gt; zijn. (dcat:servesdataset)</pattern.report.32>
-  <pattern.title.33>1309. Conform aan protocol - Een protocol waaraan de dataservice voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aconform%20aan%20protocol)</pattern.title.33>
-  <pattern.assert.33>De range van conform aan protocol moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.assert.33>
-  <pattern.report.33>De range van conform aan protocol moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.report.33>
-  <pattern.title.34>1312. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.34>
-  <pattern.assert.34>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.assert.34>
-  <pattern.report.34>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.report.34>
-  <pattern.title.35>1313. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.35>
-  <pattern.assert.35>De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</pattern.assert.35>
-  <pattern.report.35>De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</pattern.report.35>
-  <pattern.title.36>1314. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.36>
-  <pattern.assert.36>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.assert.36>
-  <pattern.report.36>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.report.36>
-  <pattern.title.37>1315. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.37>
-  <pattern.assert.37>De range van endpointURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointURL)</pattern.assert.37>
-  <pattern.report.37>De range van endpointURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointURL)</pattern.report.37>
-  <pattern.title.38>1317. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.38>
-  <pattern.assert.38>Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</pattern.assert.38>
-  <pattern.report.38>Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</pattern.report.38>
-  <pattern.title.39>1318. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.39>
-  <pattern.assert.39>Minimaal 1 waarden verwacht voor endpointURL (dcat:endpointURL)</pattern.assert.39>
-  <pattern.report.39>Minimaal 1 waarden verwacht voor endpointURL (dcat:endpointURL)</pattern.report.39>
-  <pattern.title.40>1320. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.40>
-  <pattern.assert.40>Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</pattern.assert.40>
-  <pattern.report.40>Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</pattern.report.40>
-  <pattern.title.41>1321. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.41>
-  <pattern.assert.41>Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</pattern.assert.41>
-  <pattern.report.41>Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</pattern.report.41>
-  <pattern.title.42>1322. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.42>
-  <pattern.assert.42>De range van endpointbeschrijving moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointDescription)</pattern.assert.42>
-  <pattern.report.42>De range van endpointbeschrijving moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointDescription)</pattern.report.42>
-  <pattern.title.43>1323. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.43>
-  <pattern.assert.43>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.43>
-  <pattern.report.43>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.43>
-  <pattern.title.44>1323. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.44>
-  <pattern.assert.44>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.44>
-  <pattern.report.44>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.44>
-  <pattern.title.45>1324. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.45>
-  <pattern.assert.45>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.45>
-  <pattern.report.45>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.45>
-  <pattern.title.46>1327. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene aanvullende informatie over de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina)</pattern.title.46>
-  <pattern.assert.46>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.assert.46>
-  <pattern.report.46>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.report.46>
-  <pattern.title.47>1328. Landingspagina voor authenticatie - Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20authenticatie)</pattern.title.47>
-  <pattern.assert.47>De range van landingspagina voor authenticatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorAuthenticatie)</pattern.assert.47>
-  <pattern.report.47>De range van landingspagina voor authenticatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorAuthenticatie)</pattern.report.47>
-  <pattern.title.48>1330. Landingspagina voor authenticatie - Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20authenticatie)</pattern.title.48>
-  <pattern.assert.48>Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</pattern.assert.48>
-  <pattern.report.48>Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</pattern.report.48>
-  <pattern.title.49>1332. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</pattern.title.49>
-  <pattern.assert.49>Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.assert.49>
-  <pattern.report.49>Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.report.49>
-  <pattern.title.50>1333. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</pattern.title.50>
-  <pattern.assert.50>De range van landingspagina voor gebruiksinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.assert.50>
-  <pattern.report.50>De range van landingspagina voor gebruiksinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.report.50>
-  <pattern.title.51>1334. Landingspagina voor statusinformatie - Een verwijzing naar de statuspagina van de dataservice (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20statusinformatie)</pattern.title.51>
-  <pattern.assert.51>De range van landingspagina voor statusinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorStatusinformatie)</pattern.assert.51>
-  <pattern.report.51>De range van landingspagina voor statusinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorStatusinformatie)</pattern.report.51>
-  <pattern.title.52>1336. Landingspagina voor statusinformatie - Een verwijzing naar de statuspagina van de dataservice (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20statusinformatie)</pattern.title.52>
-  <pattern.assert.52>Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</pattern.assert.52>
-  <pattern.report.52>Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</pattern.report.52>
-  <pattern.title.53>1338. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</pattern.title.53>
-  <pattern.assert.53>De range van levensfase moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:levensfase)</pattern.assert.53>
-  <pattern.report.53>De range van levensfase moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:levensfase)</pattern.report.53>
-  <pattern.title.54>1340. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</pattern.title.54>
-  <pattern.assert.54>Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</pattern.assert.54>
-  <pattern.report.54>Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</pattern.report.54>
-  <pattern.title.55>1341. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.55>
-  <pattern.assert.55>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.assert.55>
-  <pattern.report.55>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.report.55>
-  <pattern.title.56>1342. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.56>
-  <pattern.assert.56>Minimaal 1 waarden verwacht voor licentie (dct:license)</pattern.assert.56>
-  <pattern.report.56>Minimaal 1 waarden verwacht voor licentie (dct:license)</pattern.report.56>
-  <pattern.title.57>1343. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.57>
-  <pattern.assert.57>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.assert.57>
-  <pattern.report.57>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.report.57>
-  <pattern.title.58>1345. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</pattern.title.58>
-  <pattern.assert.58>De range van ontwikkelingstoestand moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:ontwikkelingstoestand)</pattern.assert.58>
-  <pattern.report.58>De range van ontwikkelingstoestand moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:ontwikkelingstoestand)</pattern.report.58>
-  <pattern.title.59>1346. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</pattern.title.59>
-  <pattern.assert.59>Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</pattern.assert.59>
-  <pattern.report.59>Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</pattern.report.59>
-  <pattern.title.60>1349. Rechten - Bepalingen van juridische aard die gelden op de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Arechten)</pattern.title.60>
-  <pattern.assert.60>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.assert.60>
-  <pattern.report.60>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.report.60>
-  <pattern.title.61>1351. Thema - De hoofdcategorie waartoe de dataservice behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Athema)</pattern.title.61>
-  <pattern.assert.61>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.assert.61>
-  <pattern.report.61>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.report.61>
-  <pattern.title.62>1354. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.62>
-  <pattern.assert.62>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.assert.62>
-  <pattern.report.62>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.report.62>
-  <pattern.title.63>1356. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.63>
-  <pattern.assert.63>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.63>
-  <pattern.report.63>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.63>
-  <pattern.title.64>1357. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.64>
-  <pattern.assert.64>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.64>
-  <pattern.report.64>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.64>
-  <pattern.title.65>1358. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.65>
-  <pattern.assert.65>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.65>
-  <pattern.report.65>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.65>
-  <pattern.title.66>1360. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.66>
-  <pattern.assert.66>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.assert.66>
-  <pattern.report.66>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.report.66>
-  <pattern.title.67>1361. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.67>
-  <pattern.assert.67>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.assert.67>
-  <pattern.report.67>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.report.67>
-  <pattern.title.68>1363. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.68>
-  <pattern.assert.68>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.assert.68>
-  <pattern.report.68>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.report.68>
-  <pattern.title.69>1365. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atrefwoord)</pattern.title.69>
-  <pattern.assert.69>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.assert.69>
-  <pattern.report.69>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.report.69>
-  <pattern.title.70>1667. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</pattern.title.70>
-  <pattern.assert.70>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.assert.70>
-  <pattern.report.70>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.report.70>
-  <pattern.title.71>1668. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</pattern.title.71>
-  <pattern.assert.71>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.assert.71>
-  <pattern.report.71>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.report.71>
-  <pattern.title.72>v067. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een dataset kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aalternatieve%20identificator)</pattern.title.72>
-  <pattern.assert.72>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.72>
-  <pattern.report.72>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.72>
-  <pattern.title.73>v207. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.73>
-  <pattern.assert.73>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.73>
-  <pattern.report.73>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.73>
-  <pattern.title.74>1702. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.74>
-  <pattern.assert.74>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.assert.74>
-  <pattern.report.74>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.report.74>
-  <pattern.title.75>v037. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.75>
-  <pattern.assert.75>Minimaal 1 waarden verwacht voor beschrijving (dct:description)</pattern.assert.75>
-  <pattern.report.75>Minimaal 1 waarden verwacht voor beschrijving (dct:description)</pattern.report.75>
-  <pattern.title.76>v215. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.76>
-  <pattern.assert.76>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.76>
-  <pattern.report.76>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.76>
-  <pattern.title.77>v056. Conform - Een standaard, schema, applicatieprofiel, vocabularium waaraan de dataset voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aconform)</pattern.title.77>
-  <pattern.assert.77>De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.assert.77>
-  <pattern.report.77>De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.report.77>
-  <pattern.title.78>1705. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.78>
-  <pattern.assert.78>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.assert.78>
-  <pattern.report.78>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.report.78>
-  <pattern.title.79>1706. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.79>
-  <pattern.assert.79>De range van contactinformatie moet van het type &lt;http://schema.org/ContactPoint&gt; zijn. (dcat:contactPoint)</pattern.assert.79>
-  <pattern.report.79>De range van contactinformatie moet van het type &lt;http://schema.org/ContactPoint&gt; zijn. (dcat:contactPoint)</pattern.report.79>
-  <pattern.title.80>v041. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.80>
-  <pattern.assert.80>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.assert.80>
-  <pattern.report.80>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.report.80>
-  <pattern.title.81>v046. Distributie - Een beschikbare distributie van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Adistributie)</pattern.title.81>
-  <pattern.assert.81>De range van distributie moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (dcat:distribution)</pattern.assert.81>
-  <pattern.report.81>De range van distributie moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (dcat:distribution)</pattern.report.81>
-  <pattern.title.82>v060. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.82>
-  <pattern.assert.82>De range van identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (dct:identifier)</pattern.assert.82>
-  <pattern.report.82>De range van identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (dct:identifier)</pattern.report.82>
-  <pattern.title.83>1708. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.83>
-  <pattern.assert.83>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.83>
-  <pattern.report.83>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.83>
-  <pattern.title.84>1709. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.84>
-  <pattern.assert.84>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.84>
-  <pattern.report.84>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.84>
-  <pattern.title.85>1712. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene informatie over de dataset, zijn distributies en/of aanvullende informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Alandingspagina)</pattern.title.85>
-  <pattern.assert.85>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.assert.85>
-  <pattern.report.85>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.report.85>
-  <pattern.title.86>v115. Thema - De hoofdcategorie waartoe de dataset behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Athema)</pattern.title.86>
-  <pattern.assert.86>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.assert.86>
-  <pattern.report.86>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.report.86>
-  <pattern.title.87>v039. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.87>
-  <pattern.assert.87>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.assert.87>
-  <pattern.report.87>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.report.87>
-  <pattern.title.88>v214. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.88>
-  <pattern.assert.88>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.88>
-  <pattern.report.88>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.88>
-  <pattern.title.89>v206. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.89>
-  <pattern.assert.89>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.89>
-  <pattern.report.89>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.89>
-  <pattern.title.90>1716. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.90>
-  <pattern.assert.90>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.assert.90>
-  <pattern.report.90>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.report.90>
-  <pattern.title.91>1717. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.91>
-  <pattern.assert.91>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.assert.91>
-  <pattern.report.91>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.report.91>
-  <pattern.title.92>v100. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.92>
-  <pattern.assert.92>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.assert.92>
-  <pattern.report.92>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.report.92>
-  <pattern.title.93>1720. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atrefwoord)</pattern.title.93>
-  <pattern.assert.93>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.assert.93>
-  <pattern.report.93>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.report.93>
-  <pattern.title.94>v076. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</pattern.title.94>
-  <pattern.assert.94>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.assert.94>
-  <pattern.report.94>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.report.94>
-  <pattern.title.95>v075. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</pattern.title.95>
-  <pattern.assert.95>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.assert.95>
-  <pattern.report.95>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.report.95>
-  <pattern.title.96>1801. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een distributie kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aalternatieve%20identificator)</pattern.title.96>
-  <pattern.assert.96>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.96>
-  <pattern.report.96>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.96>
-  <pattern.title.97>v090. Downloadurl - De URL waar de data gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AdownloadURL)</pattern.title.97>
-  <pattern.assert.97>De range van downloadURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:downloadURL)</pattern.assert.97>
-  <pattern.report.97>De range van downloadURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:downloadURL)</pattern.report.97>
-  <pattern.title.98>v090. Downloadurl - De URL waar de data gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AdownloadURL)</pattern.title.98>
-  <pattern.assert.98>Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</pattern.assert.98>
-  <pattern.report.98>Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</pattern.report.98>
-  <pattern.title.99>1902. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.99>
-  <pattern.assert.99>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.99>
-  <pattern.report.99>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.99>
-  <pattern.title.100>1903. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.100>
-  <pattern.assert.100>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.100>
-  <pattern.report.100>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.100>
-  <pattern.title.101>1904. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.101>
-  <pattern.assert.101>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.101>
-  <pattern.report.101>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.101>
-  <pattern.title.102>v087. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</pattern.title.102>
-  <pattern.assert.102>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.assert.102>
-  <pattern.report.102>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.report.102>
-  <pattern.title.103>v088. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</pattern.title.103>
-  <pattern.assert.103>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.assert.103>
-  <pattern.report.103>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.report.103>
-  <pattern.title.104>1907. Rechten - Bepalingen van juridische aard die gelden op de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Arechten)</pattern.title.104>
-  <pattern.assert.104>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.assert.104>
-  <pattern.report.104>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.report.104>
-  <pattern.title.105>1909. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.105>
-  <pattern.assert.105>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.105>
-  <pattern.report.105>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.105>
-  <pattern.title.106>v216. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.106>
-  <pattern.assert.106>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.106>
-  <pattern.report.106>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.106>
-  <pattern.title.107>v205. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.107>
-  <pattern.assert.107>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.107>
-  <pattern.report.107>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.107>
-  <pattern.title.108>v220. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.108>
-  <pattern.assert.108>Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</pattern.assert.108>
-  <pattern.report.108>Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</pattern.report.108>
-  <pattern.title.109>1910. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.109>
-  <pattern.assert.109>De range van toegangsURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:accessURL)</pattern.assert.109>
-  <pattern.report.109>De range van toegangsURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:accessURL)</pattern.report.109>
-  <pattern.title.110>v079. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.110>
-  <pattern.assert.110>Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</pattern.assert.110>
-  <pattern.report.110>Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</pattern.report.110>
-  <pattern.title.111>1912. Wordt aangeboden door - Een dataservice die deze distributie aanbiedt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Awordt%20aangeboden%20door)</pattern.title.111>
-  <pattern.assert.111>De range van wordt aangeboden door moet van het type &lt;http://www.w3.org/ns/dcat#DataService&gt; zijn. (dcat:accessService)</pattern.assert.111>
-  <pattern.report.111>De range van wordt aangeboden door moet van het type &lt;http://www.w3.org/ns/dcat#DataService&gt; zijn. (dcat:accessService)</pattern.report.111>
-  <pattern.title.112>2005. Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</pattern.title.112>
-  <pattern.assert.112>Minimaal 1 waarden verwacht voor statuut (mdcat:statuut)</pattern.assert.112>
-  <pattern.report.112>Minimaal 1 waarden verwacht voor statuut (mdcat:statuut)</pattern.report.112>
-  <pattern.title.113>2009. Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</pattern.title.113>
-  <pattern.assert.113>De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</pattern.assert.113>
-  <pattern.report.113>De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</pattern.report.113>
-  <pattern.title.114>2002. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.114>
-  <pattern.assert.114>Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</pattern.assert.114>
-  <pattern.report.114>Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</pattern.report.114>
-  <pattern.title.115>v052. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.115>
-  <pattern.assert.115>De range van uitgever moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:publisher)</pattern.assert.115>
-  <pattern.report.115>De range van uitgever moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:publisher)</pattern.report.115>
-  <pattern.title.116>v049. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.116>
-  <pattern.assert.116>Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</pattern.assert.116>
-  <pattern.report.116>Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</pattern.report.116>
-  <pattern.title.117>Beschrijving - Een bondige tekstuele omschrijving van de distributie.</pattern.title.117>
-  <pattern.assert.117>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.117>
-  <pattern.report.117>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.117>
-  <pattern.title.118>Beschrijving - Een bondige tekstuele omschrijving van de distributie.</pattern.title.118>
-  <pattern.assert.118>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.118>
-  <pattern.report.118>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.118>
+  <pattern.title.6>Name - The name of the agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.6>
+  <pattern.assert.6>The range of name must be of the type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (foaf:name)</pattern.assert.6>
+  <pattern.report.6>The range of name must be of the type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (foaf:name)</pattern.report.6>
+  <pattern.title.7>v212. Name - The name of the agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.7>
+  <pattern.assert.7>Only 1 value allowed for each language for name (foaf:name)</pattern.assert.7>
+  <pattern.report.7>Only 1 value allowed for each language for name (foaf:name)</pattern.report.7>
+  <pattern.title.8>v000. Name - The name of the agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.8>
+  <pattern.assert.8>At least 1 value expected for name (foaf:name)</pattern.assert.8>
+  <pattern.report.8>At least 1 value expected for name (foaf:name)</pattern.report.8>
+  <pattern.title.9>1001. Contact page - A web page that either allows contact (e.g., via a web form) or contains information on how to contact. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</pattern.title.9>
+  <pattern.assert.9>The range of contact page must be of the type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (foaf:page)</pattern.assert.9>
+  <pattern.report.9>The range of contact page must be of the type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (foaf:page)</pattern.report.9>
+  <pattern.title.10>1002. Contact page - A web page that either allows contact (e.g., via a web form) or contains information on how to contact. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</pattern.title.10>
+  <pattern.assert.10>Maximum 1 value allowed for contact page (foaf:page)</pattern.assert.10>
+  <pattern.report.10>Maximum 1 value allowed for contact page (foaf:page)</pattern.report.10>
+  <pattern.title.11>413. Email - The email address that a user can contact for information. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</pattern.title.11>
+  <pattern.assert.11>The range of email must be of the type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (vcard:hasEmail)</pattern.assert.11>
+  <pattern.report.11>The range of email must be of the type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (vcard:hasEmail)</pattern.report.11>
+  <pattern.title.12>1004. Email - The email address that a user can contact for information. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</pattern.title.12>
+  <pattern.assert.12>Maximum 1 value allowed for email (vcard:hasEmail)</pattern.assert.12>
+  <pattern.report.12>Maximum 1 value allowed for email (vcard:hasEmail)</pattern.report.12>
+  <pattern.title.13>1201. Creation date - The date of (formal) inclusion of the associated dataset or data service in the catalog. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</pattern.title.13>
+  <pattern.assert.13>The range of creation date must be of the type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt;. (dct:issued)</pattern.assert.13>
+  <pattern.report.13>The range of creation date must be of the type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt;. (dct:issued)</pattern.report.13>
+  <pattern.title.14>1202. Creation date - The date of (formal) inclusion of the associated dataset or data service in the catalog. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</pattern.title.14>
+  <pattern.assert.14>Maximum 1 value allowed for creation date (dct:issued)</pattern.assert.14>
+  <pattern.report.14>Maximum 1 value allowed for creation date (dct:issued)</pattern.report.14>
+  <pattern.title.15>1204. Alternative identifier - An alternative identifier (other than the unique identifier) for a record in the catalog can be described here. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aalternatieve%20identificator)</pattern.title.15>
+  <pattern.assert.15>The range of alternative identifier must be of the type &lt;http://www.w3.org/ns/adms#Identifier&gt;. (adms:identifier)</pattern.assert.15>
+  <pattern.report.15>The range of alternative identifier must be of the type &lt;http://www.w3.org/ns/adms#Identifier&gt;. (adms:identifier)</pattern.report.15>
+  <pattern.title.16>1206. Hoofdonderwerp - The resource (dataset or data service) described in the record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.16>
+  <pattern.assert.16>Maximum 1 value allowed for main subject (foaf:primaryTopic)</pattern.assert.16>
+  <pattern.report.16>Maximum 1 value allowed for main subject (foaf:primaryTopic)</pattern.report.16>
+  <pattern.title.17>1208. Hoofdonderwerp - The resource (dataset or data service) described in the record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.17>
+  <pattern.assert.17>The range of main subject must be of type &lt;http://www.w3.org/ns/dcat#Resource&gt;. (foaf:primaryTopic)</pattern.assert.17>
+  <pattern.report.17>The range of main subject must be of type &lt;http://www.w3.org/ns/dcat#Resource&gt;. (foaf:primaryTopic)</pattern.report.17>
+  <pattern.title.18>1209. Hoofdonderwerp - The resource (dataset or data service) described in the record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.18>
+  <pattern.assert.18>At least 1 value expected for main subject (foaf:primaryTopic)</pattern.assert.18>
+  <pattern.report.18>At least 1 value expected for main subject (foaf:primaryTopic)</pattern.report.18>
+  <pattern.title.19>1210. Identificator - The unique identifier of the record in the catalog. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.19>
+  <pattern.assert.19>The range of identifier must be of type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt;. (dct:identifier)</pattern.assert.19>
+  <pattern.report.19>The range of identifier must be of type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt;. (dct:identifier)</pattern.report.19>
+  <pattern.title.20>1211. Identificator - The unique identifier of the record in the catalog. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.20>
+  <pattern.assert.20>At least 1 value expected for identifier (dct:identifier)</pattern.assert.20>
+  <pattern.report.20>At least 1 value expected for identifier (dct:identifier)</pattern.report.20>
+  <pattern.title.21>1212. Identificator - The unique identifier of the record in the catalog. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.21>
+  <pattern.assert.21>Maximum 1 value allowed for identifier (dct:identifier)</pattern.assert.21>
+  <pattern.report.21>Maximum 1 value allowed for identifier (dct:identifier)</pattern.report.21>
+  <pattern.title.22>1215. Titel - The name of the record in the catalog. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.22>
+  <pattern.assert.22>Maximum 1 value allowed for title (dct:title)</pattern.assert.22>
+  <pattern.report.22>Maximum 1 value allowed for title (dct:title)</pattern.report.22>
+  <pattern.title.23>1216. Titel - The name of the record in the catalog. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.23>
+  <pattern.assert.23>Only 1 value allowed for each language for title (dct:title)</pattern.assert.23>
+  <pattern.report.23>Only 1 value allowed for each language for title (dct:title)</pattern.report.23>
+  <pattern.title.24>1217. Titel - The name of the record in the catalog. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.24>
+  <pattern.assert.24>The range of title must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:title)</pattern.assert.24>
+  <pattern.report.24>The range of title must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:title)</pattern.report.24>
+  <pattern.title.25>1218. Wijzigingsdatum - The most recent date on which the record in the catalog was changed, updated, or adjusted. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.25>
+  <pattern.assert.25>Maximum 1 value allowed for modification date (dct:modified)</pattern.assert.25>
+  <pattern.report.25>Maximum 1 value allowed for modification date (dct:modified)</pattern.report.25>
+  <pattern.title.26>1219. Wijzigingsdatum - The most recent date on which the record in the catalog was changed, updated, or adjusted. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.26>
+  <pattern.assert.26>At least 1 value expected for modification date (dct:modified)</pattern.assert.26>
+  <pattern.report.26>At least 1 value expected for modification date (dct:modified)</pattern.report.26>
+  <pattern.title.27>1220. Wijzigingsdatum - The most recent date on which the record in the catalog was changed, updated, or adjusted. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.27>
+  <pattern.assert.27>The range of modification date must be of type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt;. (dct:modified)</pattern.assert.27>
+  <pattern.report.27>The range of modification date must be of type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt;. (dct:modified)</pattern.report.27>
+  <pattern.title.28>1301. Alternatieve identificator - An alternative identifier (other than the unique identifier) for a data service can be described here. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aalternatieve%20identificator)</pattern.title.28>
+  <pattern.assert.28>The range of alternative identifier must be of type &lt;http://www.w3.org/ns/adms#Identifier&gt;. (adms:identifier)</pattern.assert.28>
+  <pattern.report.28>The range of alternative identifier must be of type &lt;http://www.w3.org/ns/adms#Identifier&gt;. (adms:identifier)</pattern.report.28>
+  <pattern.title.29>1303. Beschrijving - A concise textual description of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.29>
+  <pattern.assert.29>The range of description must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:description)</pattern.assert.29>
+  <pattern.report.29>The range of description must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:description)</pattern.report.29>
+  <pattern.title.30>1305. Beschrijving - A concise textual description of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.30>
+  <pattern.assert.30>Maximum 1 value allowed for description (dct:description)</pattern.assert.30>
+  <pattern.report.30>Maximum 1 value allowed for description (dct:description)</pattern.report.30>
+  <pattern.title.31>1306. Beschrijving - A concise textual description of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.31>
+  <pattern.assert.31>Only 1 value allowed for each language for description (dct:description)</pattern.assert.31>
+  <pattern.report.31>Only 1 value allowed for each language for description (dct:description)</pattern.report.31>
+  <pattern.title.32>1308. Biedt informatie aan over - The data offered via this data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abiedt%20informatie%20aan%20over)</pattern.title.32>
+  <pattern.assert.32>The range of servesdataset must be of type &lt;http://www.w3.org/ns/dcat#Dataset&gt;. (dcat:servesdataset)</pattern.assert.32>
+  <pattern.report.32>The range of servesdataset must be of type &lt;http://www.w3.org/ns/dcat#Dataset&gt;. (dcat:servesdataset)</pattern.report.32>
+  <pattern.title.33>1309. Conform aan protocol - A protocol to which the data service conforms. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aconform%20aan%20protocol)</pattern.title.33>
+  <pattern.assert.33>The range of conforms to protocol must be of type &lt;http://purl.org/dc/terms/Standard&gt;. (dct:conformsTo)</pattern.assert.33>
+  <pattern.report.33>The range of conforms to protocol must be of type &lt;http://purl.org/dc/terms/Standard&gt;. (dct:conformsTo)</pattern.report.33>
+  <pattern.title.34>1312. Contactinformatie - The relevant contact information with which an end user can contact the responsible parties of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.34>
+  <pattern.assert.34>Maximum 1 value allowed for contact information (dcat:contactPoint)</pattern.assert.34>
+  <pattern.report.34>Maximum 1 value allowed for contact information (dcat:contactPoint)</pattern.report.34>
+  <pattern.title.35>1313. Contactinformatie - The relevant contact information with which an end user can contact the responsible parties of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.35>
+  <pattern.assert.35>The range of contact information must be of type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt;. (dcat:contactPoint)</pattern.assert.35>
+  <pattern.report.35>The range of contact information must be of type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt;. (dcat:contactPoint)</pattern.report.35>
+  <pattern.title.36>1314. Contact information - The relevant contact information with which an end user can contact the responsible parties of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.36>
+  <pattern.assert.36>At least 1 value expected for contact information (dcat:contactPoint)</pattern.assert.36>
+  <pattern.report.36>At least 1 value expected for contact information (dcat:contactPoint)</pattern.report.36>
+  <pattern.title.37>1315. Endpointurl - The root location or primary endpoint of the service (a web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.37>
+  <pattern.assert.37>The range of endpointURL must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:endpointURL)</pattern.assert.37>
+  <pattern.report.37>The range of endpointURL must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:endpointURL)</pattern.report.37>
+  <pattern.title.38>1317. Endpointurl - The root location or primary endpoint of the service (a web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.38>
+  <pattern.assert.38>Maximum 1 value allowed for endpointURL (dcat:endpointURL)</pattern.assert.38>
+  <pattern.report.38>Maximum 1 value allowed for endpointURL (dcat:endpointURL)</pattern.report.38>
+  <pattern.title.39>1318. Endpointurl - The root location or primary endpoint of the service (a web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.39>
+  <pattern.assert.39>At least 1 value expected for endpointURL (dcat:endpointURL)</pattern.assert.39>
+  <pattern.report.39>At least 1 value expected for endpointURL (dcat:endpointURL)</pattern.report.39>
+  <pattern.title.40>1320. Endpointbeschrijving - A description of the services available via the endpoints, including their operations, parameters, etc. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.40>
+  <pattern.assert.40>Maximum 1 value allowed for endpoint description (dcat:endpointDescription)</pattern.assert.40>
+  <pattern.report.40>Maximum 1 value allowed for endpoint description (dcat:endpointDescription)</pattern.report.40>
+  <pattern.title.41>1321. Endpointbeschrijving - A description of the services available via the endpoints, including their operations, parameters, etc. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.41>
+  <pattern.assert.41>At least 1 value expected for endpoint description (dcat:endpointDescription)</pattern.assert.41>
+  <pattern.report.41>At least 1 value expected for endpoint description (dcat:endpointDescription)</pattern.report.41>
+  <pattern.title.42>1322. Endpointbeschrijving - A description of the services available via the endpoints, including their operations, parameters, etc. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.42>
+  <pattern.assert.42>The range of endpoint description must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:endpointDescription)</pattern.assert.42>
+  <pattern.report.42>The range of endpoint description must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:endpointDescription)</pattern.report.42>
+  <pattern.title.43>1323. Identificator - The unique identifier of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.43>
+  <pattern.assert.43>The range of identifier must be of type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt;. (dct:identifier)</pattern.assert.43>
+  <pattern.report.43>The range of identifier must be of type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt;. (dct:identifier)</pattern.report.43>
+  <pattern.title.44>1323. Identificator - The unique identifier of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.44>
+  <pattern.assert.44>At least 1 value expected for identifier (dct:identifier)</pattern.assert.44>
+  <pattern.report.44>At least 1 value expected for identifier (dct:identifier)</pattern.report.44>
+  <pattern.title.45>1324. Identificator - The unique identifier of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.45>
+  <pattern.assert.45>Maximum 1 value allowed for identifier (dct:identifier)</pattern.assert.45>
+  <pattern.report.45>Maximum 1 value allowed for identifier (dct:identifier)</pattern.report.45>
+  <pattern.title.46>1327. Landingspagina - A general webpage that can be navigated to in a web browser, with general additional information about the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina)</pattern.title.46>
+  <pattern.assert.46>The range of landingPage must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:landingPage)</pattern.assert.46>
+  <pattern.report.46>The range of landingPage must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:landingPage)</pattern.report.46>
+  <pattern.title.47>1328. Landingspagina voor authenticatie - A reference to the landing page with specific information about authentication for the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20authenticatie)</pattern.title.47>
+  <pattern.assert.47>The range of landing page for authentication must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (mdcat:landingspaginaVoorAuthenticatie)</pattern.assert.47>
+  <pattern.report.47>The range of landing page for authentication must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (mdcat:landingspaginaVoorAuthenticatie)</pattern.report.47>
+  <pattern.title.48>1330. Landingspagina voor authenticatie - A reference to the landing page with specific information about authentication for the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20authenticatie)</pattern.title.48>
+  <pattern.assert.48>Maximum 1 value allowed for landing page for authentication (mdcat:landingspaginaVoorAuthenticatie)</pattern.assert.48>
+  <pattern.report.48>Maximum 1 value allowed for landing page for authentication (mdcat:landingspaginaVoorAuthenticatie)</pattern.report.48>
+  <pattern.title.49>1332. Landingspagina voor gebruiksinformatie - A reference to the landing page with specific information about the use of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</pattern.title.49>
+  <pattern.assert.49>Maximum 1 value allowed for landing page for usage information (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.assert.49>
+  <pattern.report.49>Maximum 1 value allowed for landing page for usage information (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.report.49>
+  <pattern.title.50>1333. Landingspagina voor gebruiksinformatie - A reference to the landing page with specific information about the use of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</pattern.title.50>
+  <pattern.assert.50>The range of landing page for usage information must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.assert.50>
+  <pattern.report.50>The range of landing page for usage information must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.report.50>
+  <pattern.title.51>1334. Landingspagina voor statusinformatie - A reference to the status page of the data service (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20statusinformatie)</pattern.title.51>
+  <pattern.assert.51>The range of landing page for status information must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (mdcat:landingspaginaVoorStatusinformatie)</pattern.assert.51>
+  <pattern.report.51>The range of landing page for status information must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (mdcat:landingspaginaVoorStatusinformatie)</pattern.report.51>
+  <pattern.title.52>1336. Landingspagina voor statusinformatie - A reference to the status page of the data service (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20statusinformatie)</pattern.title.52>
+  <pattern.assert.52>Maximum 1 value allowed for landing page for status information (mdcat:landingspaginaVoorStatusinformatie)</pattern.assert.52>
+  <pattern.report.52>Maximum 1 value allowed for landing page for status information (mdcat:landingspaginaVoorStatusinformatie)</pattern.report.52>
+  <pattern.title.53>1338. Levensfase - The life phase in which the data service is deployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</pattern.title.53>
+  <pattern.assert.53>The range of life phase must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (mdcat:levensfase)</pattern.assert.53>
+  <pattern.report.53>The range of life phase must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (mdcat:levensfase)</pattern.report.53>
+  <pattern.title.54>1340. Levensfase - The life phase in which the data service is deployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</pattern.title.54>
+  <pattern.assert.54>Maximum 1 value allowed for life phase (mdcat:levensfase)</pattern.assert.54>
+  <pattern.report.54>Maximum 1 value allowed for life phase (mdcat:levensfase)</pattern.report.54>
+  <pattern.title.55>1341. Licentie - The license of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.55>
+  <pattern.assert.55>The range of license must be of type &lt;http://purl.org/dc/terms/LicenseDocument&gt;. (dct:license)</pattern.assert.55>
+  <pattern.report.55>The range of license must be of type &lt;http://purl.org/dc/terms/LicenseDocument&gt;. (dct:license)</pattern.report.55>
+  <pattern.title.56>1342. Licentie - The license of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.56>
+  <pattern.assert.56>At least 1 value expected for license (dct:license)</pattern.assert.56>
+  <pattern.report.56>At least 1 value expected for license (dct:license)</pattern.report.56>
+  <pattern.title.57>1343. Licentie - The license of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.57>
+  <pattern.assert.57>Maximum 1 value allowed for license (dct:license)</pattern.assert.57>
+  <pattern.report.57>Maximum 1 value allowed for license (dct:license)</pattern.report.57>
+  <pattern.title.58>1345. Ontwikkelingstoestand - The development state in which the data service is deployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</pattern.title.58>
+  <pattern.assert.58>The range of development state must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (mdcat:ontwikkelingstoestand)</pattern.assert.58>
+  <pattern.report.58>The range of development state must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (mdcat:ontwikkelingstoestand)</pattern.report.58>
+  <pattern.title.59>1346. Ontwikkelingstoestand - The development state in which the data service is deployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</pattern.title.59>
+  <pattern.assert.59>Maximum 1 value allowed for development state (mdcat:ontwikkelingstoestand)</pattern.assert.59>
+  <pattern.report.59>Maximum 1 value allowed for development state (mdcat:ontwikkelingstoestand)</pattern.report.59>
+  <pattern.title.60>1349. Rechten - Provisions of a legal nature that apply to the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Arechten)</pattern.title.60>
+  <pattern.assert.60>The range of rights must be of type &lt;http://purl.org/dc/terms/RightsStatement&gt;. (dct:rights)</pattern.assert.60>
+  <pattern.report.60>The range of rights must be of type &lt;http://purl.org/dc/terms/RightsStatement&gt;. (dct:rights)</pattern.report.60>
+  <pattern.title.61>1351. Thema - The main category to which the data service belongs. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Athema)</pattern.title.61>
+  <pattern.assert.61>The range of theme must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (dcat:theme)</pattern.assert.61>
+  <pattern.report.61>The range of theme must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (dcat:theme)</pattern.report.61>
+  <pattern.title.62>1354. Titel - The name of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.62>
+  <pattern.assert.62>At least 1 value expected for title (dct:title)</pattern.assert.62>
+  <pattern.report.62>At least 1 value expected for title (dct:title)</pattern.report.62>
+  <pattern.title.63>1356. Titel - The name of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.63>
+  <pattern.assert.63>Maximum 1 value allowed for title (dct:title)</pattern.assert.63>
+  <pattern.report.63>Maximum 1 value allowed for title (dct:title)</pattern.report.63>
+  <pattern.title.64>1357. Titel - The name of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.64>
+  <pattern.assert.64>Only 1 value allowed for each language for title (dct:title)</pattern.assert.64>
+  <pattern.report.64>Only 1 value allowed for each language for title (dct:title)</pattern.report.64>
+  <pattern.title.65>1358. Titel - The name of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.65>
+  <pattern.assert.65>The range of title must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:title)</pattern.assert.65>
+  <pattern.report.65>The range of title must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:title)</pattern.report.65>
+  <pattern.title.66>1360. Toegankelijkheid - The accessibility of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.66>
+  <pattern.assert.66>At least 1 value expected for accessibility (dct:accessRights)</pattern.assert.66>
+  <pattern.report.66>At least 1 value expected for accessibility (dct:accessRights)</pattern.report.66>
+  <pattern.title.67>1361. Toegankelijkheid - The accessibility of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.67>
+  <pattern.assert.67>The range of accessibility must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (dct:accessRights)</pattern.assert.67>
+  <pattern.report.67>The range of accessibility must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (dct:accessRights)</pattern.report.67>
+  <pattern.title.68>1363. Toegankelijkheid - The accessibility of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.68>
+  <pattern.assert.68>Maximum 1 value allowed for accessibility (dct:accessRights)</pattern.assert.68>
+  <pattern.report.68>Maximum 1 value allowed for accessibility (dct:accessRights)</pattern.report.68>
+  <pattern.title.69>1365. Trefwoord - A keyword or tag that describes the resource. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atrefwoord)</pattern.title.69>
+  <pattern.assert.69>The range of keyword must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dcat:keyword)</pattern.assert.69>
+  <pattern.report.69>The range of keyword must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dcat:keyword)</pattern.report.69>
+  <pattern.title.70>1667. Versie - A unique designation of a variant of the data service by means of a version number or name of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</pattern.title.70>
+  <pattern.assert.70>Maximum 1 value allowed for version (owl:versionInfo)</pattern.assert.70>
+  <pattern.report.70>Maximum 1 value allowed for version (owl:versionInfo)</pattern.report.70>
+  <pattern.title.71>1668. Versie - A unique designation of a variant of the data service by means of a version number or name of the data service. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</pattern.title.71>
+  <pattern.assert.71>The range of version must be of type &lt;http://www.w3.org/2001/XMLSchema#string&gt;. (owl:versionInfo)</pattern.assert.71>
+  <pattern.report.71>The range of version must be of type &lt;http://www.w3.org/2001/XMLSchema#string&gt;. (owl:versionInfo)</pattern.report.71>
+  <pattern.title.72>v067. Alternatieve identificator - An alternative identifier (other than the unique identifier) for a dataset can be described here. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aalternatieve%20identificator)</pattern.title.72>
+  <pattern.assert.72>The range of alternative identifier must be of type &lt;http://www.w3.org/ns/adms#Identifier&gt;. (adms:identifier)</pattern.assert.72>
+  <pattern.report.72>The range of alternative identifier must be of type &lt;http://www.w3.org/ns/adms#Identifier&gt;. (adms:identifier)</pattern.report.72>
+  <pattern.title.73>v207. Beschrijving - A concise textual description of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.73>
+  <pattern.assert.73>The range of description must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:description)</pattern.assert.73>
+  <pattern.report.73>The range of description must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:description)</pattern.report.73>
+  <pattern.title.74>1702. Beschrijving - A concise textual description of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.74>
+  <pattern.assert.74>Maximum 1 value allowed for description (dct:description)</pattern.assert.74>
+  <pattern.report.74>Maximum 1 value allowed for description (dct:description)</pattern.report.74>
+  <pattern.title.75>v037. Beschrijving - A concise textual description of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.75>
+  <pattern.assert.75>At least 1 value expected for description (dct:description)</pattern.assert.75>
+  <pattern.report.75>At least 1 value expected for description (dct:description)</pattern.report.75>
+  <pattern.title.76>v215. Beschrijving - A concise textual description of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.76>
+  <pattern.assert.76>Only 1 value allowed for each language for description (dct:description)</pattern.assert.76>
+  <pattern.report.76>Only 1 value allowed for each language for description (dct:description)</pattern.report.76>
+  <pattern.title.77>v056. Conform - A standard, schema, application profile, vocabulary to which the dataset conforms. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aconform)</pattern.title.77>
+  <pattern.assert.77>The range of conforms must be of type &lt;http://purl.org/dc/terms/Standard&gt;. (dct:conformsTo)</pattern.assert.77>
+  <pattern.report.77>The range of conforms must be of type &lt;http://purl.org/dc/terms/Standard&gt;. (dct:conformsTo)</pattern.report.77>
+  <pattern.title.78>1705. Contactinformatie - The relevant contact information with which an end user can contact the responsible parties of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.78>
+  <pattern.assert.78>Maximum 1 value allowed for contact information (dcat:contactPoint)</pattern.assert.78>
+  <pattern.report.78>Maximum 1 value allowed for contact information (dcat:contactPoint)</pattern.report.78>
+  <pattern.title.79>1706. Contactinformatie - The relevant contact information with which an end user can contact the responsible parties of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.79>
+  <pattern.assert.79>The range of contact information must be of type &lt;http://schema.org/ContactPoint&gt;. (dcat:contactPoint)</pattern.assert.79>
+  <pattern.report.79>The range of contact information must be of type &lt;http://schema.org/ContactPoint&gt;. (dcat:contactPoint)</pattern.report.79>
+  <pattern.title.80>v041. Contactinformatie - The relevant contact information with which an end user can contact the responsible parties of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.80>
+  <pattern.assert.80>At least 1 value expected for contact information (dcat:contactPoint)</pattern.assert.80>
+  <pattern.report.80>At least 1 value expected for contact information (dcat:contactPoint)</pattern.report.80>
+  <pattern.title.81>v046. Distributie - An available distribution of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Adistributie)</pattern.title.81>
+  <pattern.assert.81>The range of distribution must be of type &lt;http://www.w3.org/ns/dcat#Distribution&gt;. (dcat:distribution)</pattern.assert.81>
+  <pattern.report.81>The range of distribution must be of type &lt;http://www.w3.org/ns/dcat#Distribution&gt;. (dcat:distribution)</pattern.report.81>
+  <pattern.title.82>v060. Identificator - The unique identifier of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.82>
+  <pattern.assert.82>The range of identifier must be of type &lt;http://www.w3.org/ns/adms#Identifier&gt;. (dct:identifier)</pattern.assert.82>
+  <pattern.report.82>The range of identifier must be of type &lt;http://www.w3.org/ns/adms#Identifier&gt;. (dct:identifier)</pattern.report.82>
+  <pattern.title.83>1708. Identificator - The unique identifier of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.83>
+  <pattern.assert.83>At least 1 value expected for identifier (dct:identifier)</pattern.assert.83>
+  <pattern.report.83>At least 1 value expected for identifier (dct:identifier)</pattern.report.83>
+  <pattern.title.84>1709. Identificator - The unique identifier of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.84>
+  <pattern.assert.84>Maximum 1 value allowed for identifier (dct:identifier)</pattern.assert.84>
+  <pattern.report.84>Maximum 1 value allowed for identifier (dct:identifier)</pattern.report.84>
+  <pattern.title.85>1712. Landingspagina - A general webpage that can be navigated to in a web browser, with general information about the dataset, its distributions, and/or additional information. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Alandingspagina)</pattern.title.85>
+  <pattern.assert.85>The range of landing page must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:landingPage)</pattern.assert.85>
+  <pattern.report.85>The range of landing page must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:landingPage)</pattern.report.85>
+  <pattern.title.86>v115. Thema - The main category to which the dataset belongs. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Athema)</pattern.title.86>
+  <pattern.assert.86>The range of theme must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (dcat:theme)</pattern.assert.86>
+  <pattern.report.86>The range of theme must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (dcat:theme)</pattern.report.86>
+  <pattern.title.87>v039. Titel - The name of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.87>
+  <pattern.assert.87>At least 1 value expected for title (dct:title)</pattern.assert.87>
+  <pattern.report.87>At least 1 value expected for title (dct:title)</pattern.report.87>
+  <pattern.title.88>v214. Titel - The name of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.88>
+  <pattern.assert.88>Only 1 value allowed for each language for title (dct:title)</pattern.assert.88>
+  <pattern.report.88>Only 1 value allowed for each language for title (dct:title)</pattern.report.88>
+  <pattern.title.89>v206. Titel - The name of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.89>
+  <pattern.assert.89>The range of title must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:title)</pattern.assert.89>
+  <pattern.report.89>The range of title must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:title)</pattern.report.89>
+  <pattern.title.90>1716. Toegankelijkheid - The accessibility of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.90>
+  <pattern.assert.90>At least 1 value expected for accessibility (dct:accessRights)</pattern.assert.90>
+  <pattern.report.90>At least 1 value expected for accessibility (dct:accessRights)</pattern.report.90>
+  <pattern.title.91>1717. Toegankelijkheid - The accessibility of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.91>
+  <pattern.assert.91>The range of accessibility must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (dct:accessRights)</pattern.assert.91>
+  <pattern.report.91>The range of accessibility must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (dct:accessRights)</pattern.report.91>
+  <pattern.title.92>v100. Toegankelijkheid - The accessibility of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.92>
+  <pattern.assert.92>Maximum 1 value allowed for accessibility (dct:accessRights)</pattern.assert.92>
+  <pattern.report.92>Maximum 1 value allowed for accessibility (dct:accessRights)</pattern.report.92>
+  <pattern.title.93>1720. Trefwoord - A keyword or tag that describes the resource. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atrefwoord)</pattern.title.93>
+  <pattern.assert.93>The range of keyword must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dcat:keyword)</pattern.assert.93>
+  <pattern.report.93>The range of keyword must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dcat:keyword)</pattern.report.93>
+  <pattern.title.94>v076. Versie - A unique designation of a variant of the dataset by means of a version number or name of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</pattern.title.94>
+  <pattern.assert.94>Maximum 1 value allowed for version (owl:versionInfo)</pattern.assert.94>
+  <pattern.report.94>Maximum 1 value allowed for version (owl:versionInfo)</pattern.report.94>
+  <pattern.title.95>v075. Versie - A unique designation of a variant of the dataset by means of a version number or name of the dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</pattern.title.95>
+  <pattern.assert.95>The range of version must be of type &lt;http://www.w3.org/2001/XMLSchema#string&gt;. (owl:versionInfo)</pattern.assert.95>
+  <pattern.report.95>The range of version must be of type &lt;http://www.w3.org/2001/XMLSchema#string&gt;. (owl:versionInfo)</pattern.report.95>
+  <pattern.title.96>1801. Alternatieve identificator - An alternative identifier (other than the unique identifier) for a distribution can be described here. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aalternatieve%20identificator)</pattern.title.96>
+  <pattern.assert.96>The range of alternative identifier must be of type &lt;http://www.w3.org/ns/adms#Identifier&gt;. (adms:identifier)</pattern.assert.96>
+  <pattern.report.96>The range of alternative identifier must be of type &lt;http://www.w3.org/ns/adms#Identifier&gt;. (adms:identifier)</pattern.report.96>
+  <pattern.title.97>v090. Downloadurl - The URL where the data can be downloaded. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AdownloadURL)</pattern.title.97>
+  <pattern.assert.97>The range of downloadURL must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:downloadURL)</pattern.assert.97>
+  <pattern.report.97>The range of downloadURL must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:downloadURL)</pattern.report.97>
+  <pattern.title.98>v090. Downloadurl - The URL where the data can be downloaded. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AdownloadURL)</pattern.title.98>
+  <pattern.assert.98>Maximum 1 value allowed for downloadURL (dcat:downloadURL)</pattern.assert.98>
+  <pattern.report.98>Maximum 1 value allowed for downloadURL (dcat:downloadURL)</pattern.report.98>
+  <pattern.title.99>1902. Identificator - The unique identifier of the distribution. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.99>
+  <pattern.assert.99>The range of identifier must be of type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt;. (dct:identifier)</pattern.assert.99>
+  <pattern.report.99>The range of identifier must be of type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt;. (dct:identifier)</pattern.report.99>
+  <pattern.title.100>1903. Identificator - The unique identifier of the distribution. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.100>
+  <pattern.assert.100>At least 1 value expected for identifier (dct:identifier)</pattern.assert.100>
+  <pattern.report.100>At least 1 value expected for identifier (dct:identifier)</pattern.report.100>
+  <pattern.title.101>1904. Identificator - The unique identifier of the distribution. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.101>
+  <pattern.assert.101>Maximum 1 value allowed for identifier (dct:identifier)</pattern.assert.101>
+  <pattern.report.101>Maximum 1 value allowed for identifier (dct:identifier)</pattern.report.101>
+  <pattern.title.102>v087. Licentie - The license of the distribution. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</pattern.title.102>
+  <pattern.assert.102>The range of license must be of type &lt;http://purl.org/dc/terms/LicenseDocument&gt;. (dct:license)</pattern.assert.102>
+  <pattern.report.102>The range of license must be of type &lt;http://purl.org/dc/terms/LicenseDocument&gt;. (dct:license)</pattern.report.102>
+  <pattern.title.103>v088. Licentie - The license of the distribution. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</pattern.title.103>
+  <pattern.assert.103>Maximum 1 value allowed for license (dct:license)</pattern.assert.103>
+  <pattern.report.103>Maximum 1 value allowed for license (dct:license)</pattern.report.103>
+  <pattern.title.104>1907. Rechten - Provisions of a legal nature that apply to the distribution. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Arechten)</pattern.title.104>
+  <pattern.assert.104>The range of rights must be of type &lt;http://purl.org/dc/terms/RightsStatement&gt;. (dct:rights)</pattern.assert.104>
+  <pattern.report.104>The range of rights must be of type &lt;http://purl.org/dc/terms/RightsStatement&gt;. (dct:rights)</pattern.report.104>
+  <pattern.title.105>1909. Titel - The name of the distribution. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.105>
+  <pattern.assert.105>Maximum 1 value allowed for title (dct:title)</pattern.assert.105>
+  <pattern.report.105>Maximum 1 value allowed for title (dct:title)</pattern.report.105>
+  <pattern.title.106>v216. Titel - The name of the distribution. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.106>
+  <pattern.assert.106>Only 1 value allowed for each language for title (dct:title)</pattern.assert.106>
+  <pattern.report.106>Only 1 value allowed for each language for title (dct:title)</pattern.report.106>
+  <pattern.title.107>v205. Titel - The name of the distribution. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.107>
+  <pattern.assert.107>The range of title must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:title)</pattern.assert.107>
+  <pattern.report.107>The range of title must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:title)</pattern.report.107>
+  <pattern.title.108>v220. Toegangsurl - A URL where the data can be found. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.108>
+  <pattern.assert.108>Maximum 1 value allowed for accessURL (dcat:accessURL)</pattern.assert.108>
+  <pattern.report.108>Maximum 1 value allowed for accessURL (dcat:accessURL)</pattern.report.108>
+  <pattern.title.109>1910. Toegangsurl - A URL where the data can be found. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.109>
+  <pattern.assert.109>The range of accessURL must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:accessURL)</pattern.assert.109>
+  <pattern.report.109>The range of accessURL must be of type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt;. (dcat:accessURL)</pattern.report.109>
+  <pattern.title.110>v079. Toegangsurl - A URL where the data can be found. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.110>
+  <pattern.assert.110>At least 1 value expected for accessURL (dcat:accessURL)</pattern.assert.110>
+  <pattern.report.110>At least 1 value expected for accessURL (dcat:accessURL)</pattern.report.110>
+  <pattern.title.111>1912. Wordt aangeboden door - A data service that offers this distribution. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Awordt%20aangeboden%20door)</pattern.title.111>
+  <pattern.assert.111>The range of is offered by must be of type &lt;http://www.w3.org/ns/dcat#DataService&gt;. (dcat:accessService)</pattern.assert.111>
+  <pattern.report.111>The range of is offered by must be of type &lt;http://www.w3.org/ns/dcat#DataService&gt;. (dcat:accessService)</pattern.report.111>
+  <pattern.title.112>2005. Statuut - An indication of the basis on which the catalog resource is available. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</pattern.title.112>
+  <pattern.assert.112>At least 1 value expected for status (mdcat:statuut)</pattern.assert.112>
+  <pattern.report.112>At least 1 value expected for status (mdcat:statuut)</pattern.report.112>
+  <pattern.title.113>2009. Statuut - An indication of the basis on which the catalog resource is available. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</pattern.title.113>
+  <pattern.assert.113>The range of status must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (mdcat:statuut)</pattern.assert.113>
+  <pattern.report.113>The range of status must be of type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt;. (mdcat:statuut)</pattern.report.113>
+  <pattern.title.114>2002. Uitgever - The publisher, the entity responsible for making the resource available in the catalog. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.114>
+  <pattern.assert.114>Maximum 1 value allowed for publisher (dct:publisher)</pattern.assert.114>
+  <pattern.report.114>Maximum 1 value allowed for publisher (dct:publisher)</pattern.report.114>
+  <pattern.title.115>v052. Uitgever - The publisher, the entity responsible for making the resource available in the catalog. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.115>
+  <pattern.assert.115>The range of publisher must be of type &lt;http://purl.org/dc/terms/Agent&gt;. (dct:publisher)</pattern.assert.115>
+  <pattern.report.115>The range of publisher must be of type &lt;http://purl.org/dc/terms/Agent&gt;. (dct:publisher)</pattern.report.115>
+  <pattern.title.116>v049. Uitgever - The publisher, the entity responsible for making the resource available in the catalog. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.116>
+  <pattern.assert.116>At least 1 value expected for publisher (dct:publisher)</pattern.assert.116>
+  <pattern.report.116>At least 1 value expected for publisher (dct:publisher)</pattern.report.116>
+  <pattern.title.117>Beschrijving - A concise textual description of the distribution.</pattern.title.117>
+  <pattern.assert.117>The range of description must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:description)</pattern.assert.117>
+  <pattern.report.117>The range of description must be of type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt;. (dct:description)</pattern.report.117>
+  <pattern.title.118>Beschrijving - A concise textual description of the distribution.</pattern.title.118>
+  <pattern.assert.118>Only 1 value allowed for each language for description (dct:description)</pattern.assert.118>
+  <pattern.report.118>Only 1 value allowed for each language for description (dct:description)</pattern.report.118>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-vl.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-vl.xml
@@ -1,4 +1,358 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>DCAT-AP-Vlaanderen - Mandatory</schematron.title>
+  <pattern.title.1>vcard:hasEmail is a URI with the mailto protocol.</pattern.title.1>
+  <pattern.assert.1>vcard:hasEmail property is not a URI with the mailto: protocol.</pattern.assert.1>
+  <pattern.report.1>vcard:hasEmail property is a URI with the mailto: protocol.</pattern.report.1>
+  <pattern.title.2>dct:license is CC0</pattern.title.2>
+  <pattern.assert.2>The dcat:Catalog does not have a dct:license property with value 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0'.</pattern.assert.2>
+  <pattern.report.2>The dcat:Catalog has a dct:license property with value 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0'.</pattern.report.2>
+  <pattern.title.3>dct:accessRights must be public</pattern.title.3>
+  <pattern.assert.3>The dcat:Dataset does not have a dct:accessRights property with value 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'.</pattern.assert.3>
+  <pattern.report.3>The dcat:Dataset has a dct:accessRights property with value 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'.</pattern.report.3>
+  <pattern.title.4>At least one keyword is required.</pattern.title.4>
+  <pattern.assert.4>The dcat:Resource doesn't have any keyword.</pattern.assert.4>
+  <pattern.report.4>The dcat:Resource have at least one keyword.</pattern.report.4>
+  <pattern.title.5>At least one of vcard:hasEmail or vcard:hasURL is a required for a contactpoint.</pattern.title.5>
+  <pattern.assert.5>A vcard:Organization does not have a vcard:hasEmail or a vcard:hasURL property.</pattern.assert.5>
+  <pattern.report.5>A vcard:Organization has a vcard:hasEmail or a vcard:hasURL property.</pattern.report.5>
+  <pattern.title.6>Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.6>
+  <pattern.assert.6>De range van naam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (foaf:name)</pattern.assert.6>
+  <pattern.report.6>De range van naam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (foaf:name)</pattern.report.6>
+  <pattern.title.7>v212. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.7>
+  <pattern.assert.7>Slechts 1 waarde voor elke taal toegelaten voor naam (foaf:name)</pattern.assert.7>
+  <pattern.report.7>Slechts 1 waarde voor elke taal toegelaten voor naam (foaf:name)</pattern.report.7>
+  <pattern.title.8>v000. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</pattern.title.8>
+  <pattern.assert.8>Minimaal 1 waarden verwacht voor naam (foaf:name)</pattern.assert.8>
+  <pattern.report.8>Minimaal 1 waarden verwacht voor naam (foaf:name)</pattern.report.8>
+  <pattern.title.9>1001. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</pattern.title.9>
+  <pattern.assert.9>De range van contactpagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (foaf:page)</pattern.assert.9>
+  <pattern.report.9>De range van contactpagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (foaf:page)</pattern.report.9>
+  <pattern.title.10>1002. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</pattern.title.10>
+  <pattern.assert.10>Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</pattern.assert.10>
+  <pattern.report.10>Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</pattern.report.10>
+  <pattern.title.11>413. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</pattern.title.11>
+  <pattern.assert.11>De range van e-mail moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (vcard:hasEmail)</pattern.assert.11>
+  <pattern.report.11>De range van e-mail moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (vcard:hasEmail)</pattern.report.11>
+  <pattern.title.12>1004. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</pattern.title.12>
+  <pattern.assert.12>Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</pattern.assert.12>
+  <pattern.report.12>Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</pattern.report.12>
+  <pattern.title.13>1201. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</pattern.title.13>
+  <pattern.assert.13>De range van aanmaakdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</pattern.assert.13>
+  <pattern.report.13>De range van aanmaakdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</pattern.report.13>
+  <pattern.title.14>1202. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</pattern.title.14>
+  <pattern.assert.14>Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</pattern.assert.14>
+  <pattern.report.14>Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</pattern.report.14>
+  <pattern.title.15>1204. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een record in de catalogus kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aalternatieve%20identificator)</pattern.title.15>
+  <pattern.assert.15>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.15>
+  <pattern.report.15>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.15>
+  <pattern.title.16>1206. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.16>
+  <pattern.assert.16>Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</pattern.assert.16>
+  <pattern.report.16>Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</pattern.report.16>
+  <pattern.title.17>1208. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.17>
+  <pattern.assert.17>De range van hoofdonderwerp moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (foaf:primaryTopic)</pattern.assert.17>
+  <pattern.report.17>De range van hoofdonderwerp moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (foaf:primaryTopic)</pattern.report.17>
+  <pattern.title.18>1209. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</pattern.title.18>
+  <pattern.assert.18>Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</pattern.assert.18>
+  <pattern.report.18>Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</pattern.report.18>
+  <pattern.title.19>1210. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.19>
+  <pattern.assert.19>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.19>
+  <pattern.report.19>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.19>
+  <pattern.title.20>1211. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.20>
+  <pattern.assert.20>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.20>
+  <pattern.report.20>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.20>
+  <pattern.title.21>1212. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</pattern.title.21>
+  <pattern.assert.21>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.21>
+  <pattern.report.21>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.21>
+  <pattern.title.22>1215. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.22>
+  <pattern.assert.22>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.22>
+  <pattern.report.22>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.22>
+  <pattern.title.23>1216. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.23>
+  <pattern.assert.23>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.23>
+  <pattern.report.23>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.23>
+  <pattern.title.24>1217. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</pattern.title.24>
+  <pattern.assert.24>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.24>
+  <pattern.report.24>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.24>
+  <pattern.title.25>1218. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.25>
+  <pattern.assert.25>Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</pattern.assert.25>
+  <pattern.report.25>Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</pattern.report.25>
+  <pattern.title.26>1219. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.26>
+  <pattern.assert.26>Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</pattern.assert.26>
+  <pattern.report.26>Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</pattern.report.26>
+  <pattern.title.27>1220. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</pattern.title.27>
+  <pattern.assert.27>De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</pattern.assert.27>
+  <pattern.report.27>De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</pattern.report.27>
+  <pattern.title.28>1301. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een dataservice kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aalternatieve%20identificator)</pattern.title.28>
+  <pattern.assert.28>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.28>
+  <pattern.report.28>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.28>
+  <pattern.title.29>1303. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.29>
+  <pattern.assert.29>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.29>
+  <pattern.report.29>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.29>
+  <pattern.title.30>1305. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.30>
+  <pattern.assert.30>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.assert.30>
+  <pattern.report.30>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.report.30>
+  <pattern.title.31>1306. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</pattern.title.31>
+  <pattern.assert.31>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.31>
+  <pattern.report.31>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.31>
+  <pattern.title.32>1308. Biedt informatie aan over - De data die via deze dataservice worden aangeboden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abiedt%20informatie%20aan%20over)</pattern.title.32>
+  <pattern.assert.32>De range van biedt informatie aan over moet van het type &lt;http://www.w3.org/ns/dcat#Dataset&gt; zijn. (dcat:servesdataset)</pattern.assert.32>
+  <pattern.report.32>De range van biedt informatie aan over moet van het type &lt;http://www.w3.org/ns/dcat#Dataset&gt; zijn. (dcat:servesdataset)</pattern.report.32>
+  <pattern.title.33>1309. Conform aan protocol - Een protocol waaraan de dataservice voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aconform%20aan%20protocol)</pattern.title.33>
+  <pattern.assert.33>De range van conform aan protocol moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.assert.33>
+  <pattern.report.33>De range van conform aan protocol moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.report.33>
+  <pattern.title.34>1312. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.34>
+  <pattern.assert.34>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.assert.34>
+  <pattern.report.34>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.report.34>
+  <pattern.title.35>1313. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.35>
+  <pattern.assert.35>De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</pattern.assert.35>
+  <pattern.report.35>De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</pattern.report.35>
+  <pattern.title.36>1314. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</pattern.title.36>
+  <pattern.assert.36>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.assert.36>
+  <pattern.report.36>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.report.36>
+  <pattern.title.37>1315. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.37>
+  <pattern.assert.37>De range van endpointURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointURL)</pattern.assert.37>
+  <pattern.report.37>De range van endpointURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointURL)</pattern.report.37>
+  <pattern.title.38>1317. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.38>
+  <pattern.assert.38>Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</pattern.assert.38>
+  <pattern.report.38>Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</pattern.report.38>
+  <pattern.title.39>1318. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</pattern.title.39>
+  <pattern.assert.39>Minimaal 1 waarden verwacht voor endpointURL (dcat:endpointURL)</pattern.assert.39>
+  <pattern.report.39>Minimaal 1 waarden verwacht voor endpointURL (dcat:endpointURL)</pattern.report.39>
+  <pattern.title.40>1320. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.40>
+  <pattern.assert.40>Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</pattern.assert.40>
+  <pattern.report.40>Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</pattern.report.40>
+  <pattern.title.41>1321. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.41>
+  <pattern.assert.41>Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</pattern.assert.41>
+  <pattern.report.41>Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</pattern.report.41>
+  <pattern.title.42>1322. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</pattern.title.42>
+  <pattern.assert.42>De range van endpointbeschrijving moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointDescription)</pattern.assert.42>
+  <pattern.report.42>De range van endpointbeschrijving moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointDescription)</pattern.report.42>
+  <pattern.title.43>1323. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.43>
+  <pattern.assert.43>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.43>
+  <pattern.report.43>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.43>
+  <pattern.title.44>1323. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.44>
+  <pattern.assert.44>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.44>
+  <pattern.report.44>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.44>
+  <pattern.title.45>1324. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</pattern.title.45>
+  <pattern.assert.45>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.45>
+  <pattern.report.45>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.45>
+  <pattern.title.46>1327. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene aanvullende informatie over de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina)</pattern.title.46>
+  <pattern.assert.46>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.assert.46>
+  <pattern.report.46>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.report.46>
+  <pattern.title.47>1328. Landingspagina voor authenticatie - Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20authenticatie)</pattern.title.47>
+  <pattern.assert.47>De range van landingspagina voor authenticatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorAuthenticatie)</pattern.assert.47>
+  <pattern.report.47>De range van landingspagina voor authenticatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorAuthenticatie)</pattern.report.47>
+  <pattern.title.48>1330. Landingspagina voor authenticatie - Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20authenticatie)</pattern.title.48>
+  <pattern.assert.48>Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</pattern.assert.48>
+  <pattern.report.48>Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</pattern.report.48>
+  <pattern.title.49>1332. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</pattern.title.49>
+  <pattern.assert.49>Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.assert.49>
+  <pattern.report.49>Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.report.49>
+  <pattern.title.50>1333. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</pattern.title.50>
+  <pattern.assert.50>De range van landingspagina voor gebruiksinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.assert.50>
+  <pattern.report.50>De range van landingspagina voor gebruiksinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorGebruiksinformatie)</pattern.report.50>
+  <pattern.title.51>1334. Landingspagina voor statusinformatie - Een verwijzing naar de statuspagina van de dataservice (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20statusinformatie)</pattern.title.51>
+  <pattern.assert.51>De range van landingspagina voor statusinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorStatusinformatie)</pattern.assert.51>
+  <pattern.report.51>De range van landingspagina voor statusinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorStatusinformatie)</pattern.report.51>
+  <pattern.title.52>1336. Landingspagina voor statusinformatie - Een verwijzing naar de statuspagina van de dataservice (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20statusinformatie)</pattern.title.52>
+  <pattern.assert.52>Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</pattern.assert.52>
+  <pattern.report.52>Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</pattern.report.52>
+  <pattern.title.53>1338. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</pattern.title.53>
+  <pattern.assert.53>De range van levensfase moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:levensfase)</pattern.assert.53>
+  <pattern.report.53>De range van levensfase moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:levensfase)</pattern.report.53>
+  <pattern.title.54>1340. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</pattern.title.54>
+  <pattern.assert.54>Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</pattern.assert.54>
+  <pattern.report.54>Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</pattern.report.54>
+  <pattern.title.55>1341. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.55>
+  <pattern.assert.55>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.assert.55>
+  <pattern.report.55>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.report.55>
+  <pattern.title.56>1342. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.56>
+  <pattern.assert.56>Minimaal 1 waarden verwacht voor licentie (dct:license)</pattern.assert.56>
+  <pattern.report.56>Minimaal 1 waarden verwacht voor licentie (dct:license)</pattern.report.56>
+  <pattern.title.57>1343. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</pattern.title.57>
+  <pattern.assert.57>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.assert.57>
+  <pattern.report.57>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.report.57>
+  <pattern.title.58>1345. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</pattern.title.58>
+  <pattern.assert.58>De range van ontwikkelingstoestand moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:ontwikkelingstoestand)</pattern.assert.58>
+  <pattern.report.58>De range van ontwikkelingstoestand moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:ontwikkelingstoestand)</pattern.report.58>
+  <pattern.title.59>1346. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</pattern.title.59>
+  <pattern.assert.59>Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</pattern.assert.59>
+  <pattern.report.59>Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</pattern.report.59>
+  <pattern.title.60>1349. Rechten - Bepalingen van juridische aard die gelden op de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Arechten)</pattern.title.60>
+  <pattern.assert.60>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.assert.60>
+  <pattern.report.60>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.report.60>
+  <pattern.title.61>1351. Thema - De hoofdcategorie waartoe de dataservice behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Athema)</pattern.title.61>
+  <pattern.assert.61>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.assert.61>
+  <pattern.report.61>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.report.61>
+  <pattern.title.62>1354. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.62>
+  <pattern.assert.62>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.assert.62>
+  <pattern.report.62>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.report.62>
+  <pattern.title.63>1356. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.63>
+  <pattern.assert.63>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.63>
+  <pattern.report.63>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.63>
+  <pattern.title.64>1357. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.64>
+  <pattern.assert.64>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.64>
+  <pattern.report.64>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.64>
+  <pattern.title.65>1358. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</pattern.title.65>
+  <pattern.assert.65>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.65>
+  <pattern.report.65>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.65>
+  <pattern.title.66>1360. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.66>
+  <pattern.assert.66>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.assert.66>
+  <pattern.report.66>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.report.66>
+  <pattern.title.67>1361. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.67>
+  <pattern.assert.67>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.assert.67>
+  <pattern.report.67>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.report.67>
+  <pattern.title.68>1363. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</pattern.title.68>
+  <pattern.assert.68>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.assert.68>
+  <pattern.report.68>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.report.68>
+  <pattern.title.69>1365. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atrefwoord)</pattern.title.69>
+  <pattern.assert.69>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.assert.69>
+  <pattern.report.69>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.report.69>
+  <pattern.title.70>1667. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</pattern.title.70>
+  <pattern.assert.70>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.assert.70>
+  <pattern.report.70>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.report.70>
+  <pattern.title.71>1668. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</pattern.title.71>
+  <pattern.assert.71>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.assert.71>
+  <pattern.report.71>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.report.71>
+  <pattern.title.72>v067. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een dataset kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aalternatieve%20identificator)</pattern.title.72>
+  <pattern.assert.72>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.72>
+  <pattern.report.72>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.72>
+  <pattern.title.73>v207. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.73>
+  <pattern.assert.73>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.73>
+  <pattern.report.73>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.73>
+  <pattern.title.74>1702. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.74>
+  <pattern.assert.74>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.assert.74>
+  <pattern.report.74>Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</pattern.report.74>
+  <pattern.title.75>v037. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.75>
+  <pattern.assert.75>Minimaal 1 waarden verwacht voor beschrijving (dct:description)</pattern.assert.75>
+  <pattern.report.75>Minimaal 1 waarden verwacht voor beschrijving (dct:description)</pattern.report.75>
+  <pattern.title.76>v215. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</pattern.title.76>
+  <pattern.assert.76>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.76>
+  <pattern.report.76>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.76>
+  <pattern.title.77>v056. Conform - Een standaard, schema, applicatieprofiel, vocabularium waaraan de dataset voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aconform)</pattern.title.77>
+  <pattern.assert.77>De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.assert.77>
+  <pattern.report.77>De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</pattern.report.77>
+  <pattern.title.78>1705. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.78>
+  <pattern.assert.78>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.assert.78>
+  <pattern.report.78>Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</pattern.report.78>
+  <pattern.title.79>1706. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.79>
+  <pattern.assert.79>De range van contactinformatie moet van het type &lt;http://schema.org/ContactPoint&gt; zijn. (dcat:contactPoint)</pattern.assert.79>
+  <pattern.report.79>De range van contactinformatie moet van het type &lt;http://schema.org/ContactPoint&gt; zijn. (dcat:contactPoint)</pattern.report.79>
+  <pattern.title.80>v041. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</pattern.title.80>
+  <pattern.assert.80>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.assert.80>
+  <pattern.report.80>Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</pattern.report.80>
+  <pattern.title.81>v046. Distributie - Een beschikbare distributie van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Adistributie)</pattern.title.81>
+  <pattern.assert.81>De range van distributie moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (dcat:distribution)</pattern.assert.81>
+  <pattern.report.81>De range van distributie moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (dcat:distribution)</pattern.report.81>
+  <pattern.title.82>v060. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.82>
+  <pattern.assert.82>De range van identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (dct:identifier)</pattern.assert.82>
+  <pattern.report.82>De range van identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (dct:identifier)</pattern.report.82>
+  <pattern.title.83>1708. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.83>
+  <pattern.assert.83>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.83>
+  <pattern.report.83>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.83>
+  <pattern.title.84>1709. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</pattern.title.84>
+  <pattern.assert.84>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.84>
+  <pattern.report.84>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.84>
+  <pattern.title.85>1712. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene informatie over de dataset, zijn distributies en/of aanvullende informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Alandingspagina)</pattern.title.85>
+  <pattern.assert.85>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.assert.85>
+  <pattern.report.85>De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</pattern.report.85>
+  <pattern.title.86>v115. Thema - De hoofdcategorie waartoe de dataset behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Athema)</pattern.title.86>
+  <pattern.assert.86>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.assert.86>
+  <pattern.report.86>De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</pattern.report.86>
+  <pattern.title.87>v039. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.87>
+  <pattern.assert.87>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.assert.87>
+  <pattern.report.87>Minimaal 1 waarden verwacht voor titel (dct:title)</pattern.report.87>
+  <pattern.title.88>v214. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.88>
+  <pattern.assert.88>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.88>
+  <pattern.report.88>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.88>
+  <pattern.title.89>v206. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</pattern.title.89>
+  <pattern.assert.89>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.89>
+  <pattern.report.89>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.89>
+  <pattern.title.90>1716. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.90>
+  <pattern.assert.90>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.assert.90>
+  <pattern.report.90>Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</pattern.report.90>
+  <pattern.title.91>1717. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.91>
+  <pattern.assert.91>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.assert.91>
+  <pattern.report.91>De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</pattern.report.91>
+  <pattern.title.92>v100. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</pattern.title.92>
+  <pattern.assert.92>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.assert.92>
+  <pattern.report.92>Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</pattern.report.92>
+  <pattern.title.93>1720. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atrefwoord)</pattern.title.93>
+  <pattern.assert.93>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.assert.93>
+  <pattern.report.93>De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</pattern.report.93>
+  <pattern.title.94>v076. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</pattern.title.94>
+  <pattern.assert.94>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.assert.94>
+  <pattern.report.94>Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</pattern.report.94>
+  <pattern.title.95>v075. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</pattern.title.95>
+  <pattern.assert.95>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.assert.95>
+  <pattern.report.95>De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</pattern.report.95>
+  <pattern.title.96>1801. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een distributie kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aalternatieve%20identificator)</pattern.title.96>
+  <pattern.assert.96>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.assert.96>
+  <pattern.report.96>De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</pattern.report.96>
+  <pattern.title.97>v090. Downloadurl - De URL waar de data gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AdownloadURL)</pattern.title.97>
+  <pattern.assert.97>De range van downloadURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:downloadURL)</pattern.assert.97>
+  <pattern.report.97>De range van downloadURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:downloadURL)</pattern.report.97>
+  <pattern.title.98>v090. Downloadurl - De URL waar de data gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AdownloadURL)</pattern.title.98>
+  <pattern.assert.98>Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</pattern.assert.98>
+  <pattern.report.98>Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</pattern.report.98>
+  <pattern.title.99>1902. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.99>
+  <pattern.assert.99>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.assert.99>
+  <pattern.report.99>De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</pattern.report.99>
+  <pattern.title.100>1903. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.100>
+  <pattern.assert.100>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.assert.100>
+  <pattern.report.100>Minimaal 1 waarden verwacht voor identificator (dct:identifier)</pattern.report.100>
+  <pattern.title.101>1904. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</pattern.title.101>
+  <pattern.assert.101>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.assert.101>
+  <pattern.report.101>Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</pattern.report.101>
+  <pattern.title.102>v087. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</pattern.title.102>
+  <pattern.assert.102>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.assert.102>
+  <pattern.report.102>De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</pattern.report.102>
+  <pattern.title.103>v088. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</pattern.title.103>
+  <pattern.assert.103>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.assert.103>
+  <pattern.report.103>Maximaal 1 waarden toegelaten voor licentie (dct:license)</pattern.report.103>
+  <pattern.title.104>1907. Rechten - Bepalingen van juridische aard die gelden op de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Arechten)</pattern.title.104>
+  <pattern.assert.104>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.assert.104>
+  <pattern.report.104>De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</pattern.report.104>
+  <pattern.title.105>1909. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.105>
+  <pattern.assert.105>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.assert.105>
+  <pattern.report.105>Maximaal 1 waarden toegelaten voor titel (dct:title)</pattern.report.105>
+  <pattern.title.106>v216. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.106>
+  <pattern.assert.106>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.assert.106>
+  <pattern.report.106>Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</pattern.report.106>
+  <pattern.title.107>v205. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</pattern.title.107>
+  <pattern.assert.107>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.assert.107>
+  <pattern.report.107>De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</pattern.report.107>
+  <pattern.title.108>v220. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.108>
+  <pattern.assert.108>Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</pattern.assert.108>
+  <pattern.report.108>Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</pattern.report.108>
+  <pattern.title.109>1910. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.109>
+  <pattern.assert.109>De range van toegangsURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:accessURL)</pattern.assert.109>
+  <pattern.report.109>De range van toegangsURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:accessURL)</pattern.report.109>
+  <pattern.title.110>v079. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</pattern.title.110>
+  <pattern.assert.110>Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</pattern.assert.110>
+  <pattern.report.110>Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</pattern.report.110>
+  <pattern.title.111>1912. Wordt aangeboden door - Een dataservice die deze distributie aanbiedt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Awordt%20aangeboden%20door)</pattern.title.111>
+  <pattern.assert.111>De range van wordt aangeboden door moet van het type &lt;http://www.w3.org/ns/dcat#DataService&gt; zijn. (dcat:accessService)</pattern.assert.111>
+  <pattern.report.111>De range van wordt aangeboden door moet van het type &lt;http://www.w3.org/ns/dcat#DataService&gt; zijn. (dcat:accessService)</pattern.report.111>
+  <pattern.title.112>2005. Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</pattern.title.112>
+  <pattern.assert.112>Minimaal 1 waarden verwacht voor statuut (mdcat:statuut)</pattern.assert.112>
+  <pattern.report.112>Minimaal 1 waarden verwacht voor statuut (mdcat:statuut)</pattern.report.112>
+  <pattern.title.113>2009. Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</pattern.title.113>
+  <pattern.assert.113>De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</pattern.assert.113>
+  <pattern.report.113>De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</pattern.report.113>
+  <pattern.title.114>2002. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.114>
+  <pattern.assert.114>Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</pattern.assert.114>
+  <pattern.report.114>Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</pattern.report.114>
+  <pattern.title.115>v052. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.115>
+  <pattern.assert.115>De range van uitgever moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:publisher)</pattern.assert.115>
+  <pattern.report.115>De range van uitgever moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:publisher)</pattern.report.115>
+  <pattern.title.116>v049. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</pattern.title.116>
+  <pattern.assert.116>Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</pattern.assert.116>
+  <pattern.report.116>Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</pattern.report.116>
+  <pattern.title.117>Beschrijving - Een bondige tekstuele omschrijving van de distributie.</pattern.title.117>
+  <pattern.assert.117>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.assert.117>
+  <pattern.report.117>De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</pattern.report.117>
+  <pattern.title.118>Beschrijving - Een bondige tekstuele omschrijving van de distributie.</pattern.title.118>
+  <pattern.assert.118>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.assert.118>
+  <pattern.report.118>Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</pattern.report.118>
 </strings>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-vl-rec.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-vl-rec.sch
@@ -26,11 +26,11 @@
 
   <sch:let name="profile" value="boolean(/*[starts-with(//dcat:CatalogRecord//dct:Standard/@rdf:about, 'https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL')])"/>
   <sch:pattern>
-    <sch:title>At least one theme from the data.gov.be vocabulary is required</sch:title>
+    <sch:title>$loc/strings/required.datatheme.title</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]|//dcat:DataService[$profile]">
       <sch:let name="dataThemes" value="count(dcat:theme[starts-with(skos:Concept/@rdf:about, 'http://vocab.belgif.be/auth/datatheme')])"/>
-      <sch:assert test="$dataThemes &gt; 0">The dcat:Resource doesn't have a data.gov.be theme</sch:assert>
-      <sch:report test="$dataThemes &gt; 0">The dcat:Resource have a data.gov.be theme</sch:report>
+      <sch:assert test="$dataThemes &gt; 0">$loc/strings/required.language.assert</sch:assert>
+      <sch:report test="$dataThemes &gt; 0">$loc/strings/required.language.report</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="levensfase" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/0aea9e8a54457ca50f1b00c07872cb7c7b39e8ba">

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-vl.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-vl.sch
@@ -21,1008 +21,1006 @@
   <sch:ns prefix="geodcat" uri="http://data.europa.eu/930/"/>
   <sch:ns prefix="generiek" uri="https://data.vlaanderen.be/ns/generiek#"/>
   <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
-
   <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
-
   <sch:let name="profile" value="boolean(/*[starts-with(//dcat:CatalogRecord//dct:Standard/@rdf:about, 'https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL')])"/>
   <sch:pattern>
-    <sch:title>vcard:hasEmail is a URI with the mailto protocol.</sch:title>
+    <sch:title>$loc/strings/pattern.title.1</sch:title>
     <sch:rule context="//vcard:hasEmail[$profile]">
       <sch:let name="mailto" value="starts-with(@rdf:resource,'mailto:')"/>
-      <sch:assert test="$mailto = true()">vcard:hasEmail property is not a URI with the mailto: protocol.</sch:assert>
-      <sch:report test="$mailto = true()">vcard:hasEmail property is a URI with the mailto: protocol.</sch:report>
+      <sch:assert test="$mailto = true()">$loc/strings/pattern.assert.1</sch:assert>
+      <sch:report test="$mailto = true()">$loc/strings/pattern.report.1</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern>
-    <sch:title>dct:license is CC0</sch:title>
+    <sch:title>$loc/strings/pattern.title.2</sch:title>
     <sch:rule context="//dcat:Catalog/dct:license[$profile]">
       <sch:let name="cc0" value="./@rdf:resource = 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0' or ./dct:LicenseDocument/@rdf:about = 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0'"/>
-      <sch:assert test="$cc0 = true()">The dcat:Catalog does not have a dct:license property with value 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0'.</sch:assert>
-      <sch:report test="$cc0 = true()">The dcat:Catalog has a dct:license property with value 'https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0'.</sch:report>
+      <sch:assert test="$cc0 = true()">$loc/strings/pattern.assert.2</sch:assert>
+      <sch:report test="$cc0 = true()">$loc/strings/pattern.report.2</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern>
-    <sch:title>dct:accessRights must be public</sch:title>
+    <sch:title>$loc/strings/pattern.title.3</sch:title>
     <sch:rule context="//dcat:Dataset/dct:accessRights[$profile]|//dcat:DataService/dct:accessRights[$profile]">
       <sch:let name="public" value="*/@rdf:about = 'http://publications.europa.eu/resource/authority/access-right/PUBLIC' or ./@rdf:resource = 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'"/>
-      <sch:assert test="$public = true()">The dcat:Dataset does not have a dct:accessRights property with value 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'.</sch:assert>
-      <sch:report test="$public = true()">The dcat:Dataset has a dct:accessRights property with value 'http://publications.europa.eu/resource/authority/access-right/PUBLIC'.</sch:report>
+      <sch:assert test="$public = true()">$loc/strings/pattern.assert.3</sch:assert>
+      <sch:report test="$public = true()">$loc/strings/pattern.report.3</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern>
-    <sch:title>At least one keyword is required.</sch:title>
+    <sch:title>$loc/strings/pattern.title.4</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]|//dcat:DataService[$profile]">
       <sch:let name="hasKeyword" value="count(dcat:keyword[normalize-space(.) != '']) &gt; 0"/>
-      <sch:assert test="$hasKeyword">The dcat:Resource doesn't have any keyword.</sch:assert>
-      <sch:report test="$hasKeyword">The dcat:Resource have at least one keyword.</sch:report>
+      <sch:assert test="$hasKeyword">$loc/strings/pattern.assert.4</sch:assert>
+      <sch:report test="$hasKeyword">$loc/strings/pattern.report.4</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern>
-    <sch:title>At least one of vcard:hasEmail or vcard:hasURL is a required for a contactpoint.</sch:title>
+    <sch:title>$loc/strings/pattern.title.5</sch:title>
     <sch:rule context="//dcat:contactPoint[$profile]">
       <sch:let name="hasEmail" value="normalize-space(vcard:Organization/vcard:hasEmail/@rdf:resource) != ''"/>
       <sch:let name="hasUrl" value="normalize-space(vcard:Organization/vcard:hasURL/@rdf:resource) != ''"/>
-      <sch:assert test="$hasEmail or $hasUrl">A vcard:Organization does not have a vcard:hasEmail or a vcard:hasURL property.</sch:assert>
-      <sch:report test="$hasEmail or $hasUrl">A vcard:Organization has a vcard:hasEmail or a vcard:hasURL property.</sch:report>
+      <sch:assert test="$hasEmail or $hasUrl">$loc/strings/pattern.assert.5</sch:assert>
+      <sch:report test="$hasEmail or $hasUrl">$loc/strings/pattern.report.5</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="naam" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#AgentShape/1399bd400d4637b15d5fe38202d6572f82150aac">
-    <sch:title>Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</sch:title>
+    <sch:title>$loc/strings/pattern.title.6</sch:title>
     <sch:rule context="//foaf:Agent/foaf:name[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
-      <sch:assert test="$isLiteral and $hasLang">De range van naam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (foaf:name)</sch:assert>
-      <sch:report test="$isLiteral and $hasLang">De range van naam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (foaf:name)</sch:report>
+      <sch:assert test="$isLiteral and $hasLang">$loc/strings/pattern.assert.6</sch:assert>
+      <sch:report test="$isLiteral and $hasLang">$loc/strings/pattern.report.6</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="naam" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#AgentShape/b96a7391d2808d207ce4e3c269dec2c6efad55c3">
-    <sch:title>v212. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</sch:title>
+    <sch:title>$loc/strings/pattern.title.7</sch:title>
     <sch:rule context="//foaf:Agent/foaf:name[$profile]">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::foaf:name[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
-      <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor naam (foaf:name)</sch:assert>
-      <sch:report test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor naam (foaf:name)</sch:report>
+      <sch:assert test="$isUniqueLang">$loc/strings/pattern.assert.7</sch:assert>
+      <sch:report test="$isUniqueLang">$loc/strings/pattern.report.7</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="naam" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#AgentShape/e9d8e42e8041e72c4534134d5a9044b03bed7ec5">
-    <sch:title>v000. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Agent%3Anaam)</sch:title>
+    <sch:title>$loc/strings/pattern.title.8</sch:title>
     <sch:rule context="//foaf:Agent[$profile]">
       <sch:let name="validMin" value="count(foaf:name) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor naam (foaf:name)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor naam (foaf:name)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.8</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.8</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="contactpagina" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#ContactinfoShape/0d43849949c290efe2f3d4ad1d010cdb7f0505bf">
-    <sch:title>1001. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</sch:title>
+    <sch:title>$loc/strings/pattern.title.9</sch:title>
     <sch:rule context="//vcard:Organization/foaf:page[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(@rdf:resource) != ''"/>
       <sch:let name="isURI" value="matches(@rdf:resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$isNotEmpty and $isURI">De range van contactpagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (foaf:page)</sch:assert>
-      <sch:report test="$isNotEmpty and $isURI">De range van contactpagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (foaf:page)</sch:report>
+      <sch:assert test="$isNotEmpty and $isURI">$loc/strings/pattern.assert.9</sch:assert>
+      <sch:report test="$isNotEmpty and $isURI">$loc/strings/pattern.report.9</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="contactpagina" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#ContactinfoShape/376ba2894840068d71059e7be03bfaf8995aee90">
-    <sch:title>1002. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Acontactpagina)</sch:title>
+    <sch:title>$loc/strings/pattern.title.10</sch:title>
     <sch:rule context="//vcard:Organization[$profile]">
       <sch:let name="validMax" value="count(foaf:page) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.10</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.10</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="e-mail" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#ContactinfoShape/2cf221c2b6f9a619b0515c507ddd2bbb40fbb285">
-    <sch:title>413. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</sch:title>
+    <sch:title>$loc/strings/pattern.title.11</sch:title>
     <sch:rule context="//vcard:Organization/vcard:hasEmail[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(@rdf:resource) != ''"/>
       <sch:let name="isURI" value="matches(@rdf:resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$isNotEmpty and $isURI">De range van e-mail moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (vcard:hasEmail)</sch:assert>
-      <sch:report test="$isNotEmpty and $isURI">De range van e-mail moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (vcard:hasEmail)</sch:report>
+      <sch:assert test="$isNotEmpty and $isURI">$loc/strings/pattern.assert.11</sch:assert>
+      <sch:report test="$isNotEmpty and $isURI">$loc/strings/pattern.report.11</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="e-mail" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#ContactinfoShape/42ad698554950cda0098f1f04803fac8470af8ad">
-    <sch:title>1004. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Contactinfo%3Ae-mail)</sch:title>
+    <sch:title>$loc/strings/pattern.title.12</sch:title>
     <sch:rule context="//vcard:Organization[$profile]">
       <sch:let name="validMax" value="count(vcard:hasEmail) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.12</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.12</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="aanmaakdatum" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/73a4bdd8cd7b0472b3b38dc9f56b0f32b8239284">
-    <sch:title>1201. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</sch:title>
+    <sch:title>$loc/strings/pattern.title.13</sch:title>
     <sch:rule context="//dcat:CatalogRecord/dct:issued[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
-      <sch:assert test="$isNotEmpty and $isDate">De range van aanmaakdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</sch:assert>
-      <sch:report test="$isNotEmpty and $isDate">De range van aanmaakdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</sch:report>
+      <sch:assert test="$isNotEmpty and $isDate">$loc/strings/pattern.assert.13</sch:assert>
+      <sch:report test="$isNotEmpty and $isDate">$loc/strings/pattern.report.13</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="aanmaakdatum" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/8172f8df2a73384c65fdb3332d8ee0c9ef574804">
-    <sch:title>1202. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aaanmaakdatum)</sch:title>
+    <sch:title>$loc/strings/pattern.title.14</sch:title>
     <sch:rule context="//dcat:CatalogRecord[$profile]">
       <sch:let name="validMax" value="count(dct:issued) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.14</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.14</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="alternatieve identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/39607ae8317e4f99846f57f713d51b19528e5764">
-    <sch:title>1204. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een record in de catalogus kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aalternatieve%20identificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.15</sch:title>
     <sch:rule context="//dcat:CatalogRecord/adms:identifier[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(adms:Identifier) = 1 or count(//adms:Identifier[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:assert>
-      <sch:report test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.15</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.15</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="hoofdonderwerp" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/2a7abc3b7d6df32e4a340775a9e1522a0ac1c669">
-    <sch:title>1206. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</sch:title>
+    <sch:title>$loc/strings/pattern.title.16</sch:title>
     <sch:rule context="//dcat:CatalogRecord[$profile]">
       <sch:let name="validMax" value="count(foaf:primaryTopic) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.16</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.16</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="hoofdonderwerp" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/e7d5497a1597fc6c5856517ab46c01bae413001b">
-    <sch:title>1208. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</sch:title>
+    <sch:title>$loc/strings/pattern.title.17</sch:title>
     <sch:rule context="//dcat:CatalogRecord/foaf:primaryTopic[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dcat:Dataset|dcat:DataService) = 1 or count((//dcat:Dataset|//dcat:DataService)[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van hoofdonderwerp moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (foaf:primaryTopic)</sch:assert>
-      <sch:report test="$validClass">De range van hoofdonderwerp moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (foaf:primaryTopic)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.17</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.17</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="hoofdonderwerp" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/f806d2d1fd264df77aee55564a0a70eecd47ee2e">
-    <sch:title>1209. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Ahoofdonderwerp)</sch:title>
+    <sch:title>$loc/strings/pattern.title.18</sch:title>
     <sch:rule context="//dcat:CatalogRecord[$profile]">
       <sch:let name="validMin" value="count(foaf:primaryTopic) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.18</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.18</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/05134c4e7c34157d6f7ac1128713a08418e0fe7d">
-    <sch:title>1210. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.19</sch:title>
     <sch:rule context="//dcat:CatalogRecord/dct:identifier[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
-      <sch:assert test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:assert>
-      <sch:report test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:report>
+      <sch:assert test="$isLiteral">$loc/strings/pattern.assert.19</sch:assert>
+      <sch:report test="$isLiteral">$loc/strings/pattern.report.19</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/972d73e7a13100b66c0c2f44466edac47aa1ab28">
-    <sch:title>1211. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.20</sch:title>
     <sch:rule context="//dcat:CatalogRecord[$profile]">
       <sch:let name="validMin" value="count(dct:identifier) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.20</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.20</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/bb43a48c77e7d98609af3d3bb1b1648370465308">
-    <sch:title>1212. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.21</sch:title>
     <sch:rule context="//dcat:CatalogRecord[$profile]">
       <sch:let name="validMax" value="count(dct:identifier) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.21</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.21</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/5c245f65e6c2294cd7079eb566de6fd4e4adb829">
-    <sch:title>1215. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.22</sch:title>
     <sch:rule context="//dcat:CatalogRecord[$profile]">
       <sch:let name="validMax" value="count(dct:title) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor titel (dct:title)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor titel (dct:title)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.22</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.22</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/8041fe094c27b123422bd03a4e13ff0641087607">
-    <sch:title>1216. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.23</sch:title>
     <sch:rule context="//dcat:CatalogRecord/dct:title[$profile]">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:title[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
-      <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:assert>
-      <sch:report test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:report>
+      <sch:assert test="$isUniqueLang">$loc/strings/pattern.assert.23</sch:assert>
+      <sch:report test="$isUniqueLang">$loc/strings/pattern.report.23</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/f28ce523c4b4fcb15d8c7d4f279da195ba7403ab">
-    <sch:title>1217. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.24</sch:title>
     <sch:rule context="//dcat:CatalogRecord/dct:title[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
-      <sch:assert test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:assert>
-      <sch:report test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:report>
+      <sch:assert test="$isLiteral and $hasLang">$loc/strings/pattern.assert.24</sch:assert>
+      <sch:report test="$isLiteral and $hasLang">$loc/strings/pattern.report.24</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="wijzigingsdatum" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/29906bf16cadf6d568c4da3e161ef38ba2f726fd">
-    <sch:title>1218. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</sch:title>
+    <sch:title>$loc/strings/pattern.title.25</sch:title>
     <sch:rule context="//dcat:CatalogRecord[$profile]">
       <sch:let name="validMax" value="count(dct:modified) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.25</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.25</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="wijzigingsdatum" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/6a51b2354ea38a815d6131b4e05f8587791de4e0">
-    <sch:title>1219. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</sch:title>
+    <sch:title>$loc/strings/pattern.title.26</sch:title>
     <sch:rule context="//dcat:CatalogRecord[$profile]">
       <sch:let name="validMin" value="count(dct:modified) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.26</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.26</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="wijzigingsdatum" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusRecordShape/9e7585433d0896bc44cb41cdd8189793bd115cd0">
-    <sch:title>1220. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusRecord%3Awijzigingsdatum)</sch:title>
+    <sch:title>$loc/strings/pattern.title.27</sch:title>
     <sch:rule context="//dcat:CatalogRecord/dct:modified[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
-      <sch:assert test="$isNotEmpty and $isDate">De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</sch:assert>
-      <sch:report test="$isNotEmpty and $isDate">De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</sch:report>
+      <sch:assert test="$isNotEmpty and $isDate">$loc/strings/pattern.assert.27</sch:assert>
+      <sch:report test="$isNotEmpty and $isDate">$loc/strings/pattern.report.27</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="alternatieve identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/39607ae8317e4f99846f57f713d51b19528e5764">
-    <sch:title>1301. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een dataservice kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aalternatieve%20identificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.28</sch:title>
     <sch:rule context="//dcat:DataService/adms:identifier[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(adms:Identifier) = 1 or count(//adms:Identifier[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:assert>
-      <sch:report test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.28</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.28</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/0e9a7d4dbf6ec19568d474169ad717f71e882319">
-    <sch:title>1303. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</sch:title>
+    <sch:title>$loc/strings/pattern.title.29</sch:title>
     <sch:rule context="//dcat:DataService/dct:description[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
-      <sch:assert test="$isLiteral and $hasLang">De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</sch:assert>
-      <sch:report test="$isLiteral and $hasLang">De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</sch:report>
+      <sch:assert test="$isLiteral and $hasLang">$loc/strings/pattern.assert.29</sch:assert>
+      <sch:report test="$isLiteral and $hasLang">$loc/strings/pattern.report.29</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/4a16176c26d8d5526c76974a1530f1ffdd596e93">
-    <sch:title>1305. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</sch:title>
+    <sch:title>$loc/strings/pattern.title.30</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(dct:description) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.30</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.30</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/da05d674f29a225a7115411e9f7ca442a25f2c88">
-    <sch:title>1306. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abeschrijving)</sch:title>
+    <sch:title>$loc/strings/pattern.title.31</sch:title>
     <sch:rule context="//dcat:DataService/dct:description[$profile]">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:description[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
-      <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</sch:assert>
-      <sch:report test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</sch:report>
+      <sch:assert test="$isUniqueLang">$loc/strings/pattern.assert.31</sch:assert>
+      <sch:report test="$isUniqueLang">$loc/strings/pattern.report.31</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="biedt informatie aan over" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/5ed2c890f2c7588313cc9f93b35524bdb2d6328d">
-    <sch:title>1308. Biedt informatie aan over - De data die via deze dataservice worden aangeboden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Abiedt%20informatie%20aan%20over)</sch:title>
+    <sch:title>$loc/strings/pattern.title.32</sch:title>
     <sch:rule context="//dcat:DataService/dcat:servesdataset[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$validClass">De range van biedt informatie aan over moet van het type &lt;http://www.w3.org/ns/dcat#Dataset&gt; zijn. (dcat:servesdataset)</sch:assert>
-      <sch:report test="$validClass">De range van biedt informatie aan over moet van het type &lt;http://www.w3.org/ns/dcat#Dataset&gt; zijn. (dcat:servesdataset)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.32</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.32</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="conform aan protocol" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/80a839685f13d2584ebe2f9b5d9a93ae2c1b21a0">
-    <sch:title>1309. Conform aan protocol - Een protocol waaraan de dataservice voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aconform%20aan%20protocol)</sch:title>
+    <sch:title>$loc/strings/pattern.title.33</sch:title>
     <sch:rule context="//dcat:DataService/dct:conformsTo[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:Standard) = 1 or count(//dct:Standard[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van conform aan protocol moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</sch:assert>
-      <sch:report test="$validClass">De range van conform aan protocol moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.33</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.33</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/19ee039173472235e539aea2aa961ff7d3b89f5a">
-    <sch:title>1312. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.34</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(dcat:contactPoint) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.34</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.34</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/458062b0ae03c559426b85df3dd28e1c785acb0b">
-    <sch:title>1313. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.35</sch:title>
     <sch:rule context="//dcat:DataService/dcat:contactPoint[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(vcard:Organization) = 1 or count(//vcard:Organization[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</sch:assert>
-      <sch:report test="$validClass">De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.35</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.35</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/e332dbce5947de4314c3ed3fe5862f26d70a15c4">
-    <sch:title>1314. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Acontactinformatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.36</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMin" value="count(dcat:contactPoint) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.36</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.36</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="endpointURL" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/67c89165b0f38567bf099862ffdef88f25e68714">
-    <sch:title>1315. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</sch:title>
+    <sch:title>$loc/strings/pattern.title.37</sch:title>
     <sch:rule context="//dcat:DataService/dcat:endpointURL[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(@rdf:resource) != ''"/>
       <sch:let name="isURI" value="matches(@rdf:resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$isNotEmpty and $isURI">De range van endpointURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointURL)</sch:assert>
-      <sch:report test="$isNotEmpty and $isURI">De range van endpointURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointURL)</sch:report>
+      <sch:assert test="$isNotEmpty and $isURI">$loc/strings/pattern.assert.37</sch:assert>
+      <sch:report test="$isNotEmpty and $isURI">$loc/strings/pattern.report.37</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="endpointURL" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/9978564bd5823785ddace8934e848c68e6e813e3">
-    <sch:title>1317. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</sch:title>
+    <sch:title>$loc/strings/pattern.title.38</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(dcat:endpointURL) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.38</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.38</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="endpointURL" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/bc15a30c5a91fb01a98d4b0969c268df7f6ff717">
-    <sch:title>1318. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3AendpointURL)</sch:title>
+    <sch:title>$loc/strings/pattern.title.39</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMin" value="count(dcat:endpointURL) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor endpointURL (dcat:endpointURL)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor endpointURL (dcat:endpointURL)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.39</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.39</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="endpointbeschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/66883b2795f003760d4bb617bd1f472da1e1524f">
-    <sch:title>1320. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</sch:title>
+    <sch:title>$loc/strings/pattern.title.40</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(dcat:endpointDescription) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.40</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.40</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="endpointbeschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/bd44e3e6c4317f226cd1124fbaf1d72e94e8f15e">
-    <sch:title>1321. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</sch:title>
+    <sch:title>$loc/strings/pattern.title.41</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMin" value="count(dcat:endpointDescription) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.41</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.41</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="endpointbeschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/dbc2548616486a154002cfba6a3bc2cbc554a682">
-    <sch:title>1322. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aendpointbeschrijving)</sch:title>
+    <sch:title>$loc/strings/pattern.title.42</sch:title>
     <sch:rule context="//dcat:DataService/dcat:endpointDescription[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(@rdf:resource) != ''"/>
       <sch:let name="isURI" value="matches(@rdf:resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$isNotEmpty and $isURI">De range van endpointbeschrijving moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointDescription)</sch:assert>
-      <sch:report test="$isNotEmpty and $isURI">De range van endpointbeschrijving moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointDescription)</sch:report>
+      <sch:assert test="$isNotEmpty and $isURI">$loc/strings/pattern.assert.42</sch:assert>
+      <sch:report test="$isNotEmpty and $isURI">$loc/strings/pattern.report.42</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/05134c4e7c34157d6f7ac1128713a08418e0fe7d">
-    <sch:title>1323. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.43</sch:title>
     <sch:rule context="//dcat:DataService/dct:identifier[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
-      <sch:assert test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:assert>
-      <sch:report test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:report>
+      <sch:assert test="$isLiteral">$loc/strings/pattern.assert.43</sch:assert>
+      <sch:report test="$isLiteral">$loc/strings/pattern.report.43</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/972d73e7a13100b66c0c2f44466edac47aa1ab28">
-    <sch:title>1323. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.44</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMin" value="count(dct:identifier) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.44</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.44</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/bb43a48c77e7d98609af3d3bb1b1648370465308">
-    <sch:title>1324. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.45</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(dct:identifier) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.45</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.45</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="landingspagina" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/fe1a78c9169da2469a23fd783cf9a69060bfe198">
-    <sch:title>1327. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene aanvullende informatie over de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina)</sch:title>
+    <sch:title>$loc/strings/pattern.title.46</sch:title>
     <sch:rule context="//dcat:DataService/dcat:landingPage[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(@rdf:resource) != ''"/>
       <sch:let name="isURI" value="matches(@rdf:resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$isNotEmpty and $isURI">De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</sch:assert>
-      <sch:report test="$isNotEmpty and $isURI">De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</sch:report>
+      <sch:assert test="$isNotEmpty and $isURI">$loc/strings/pattern.assert.46</sch:assert>
+      <sch:report test="$isNotEmpty and $isURI">$loc/strings/pattern.report.46</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="landingspagina voor authenticatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/2be8f764879c3f2218306704a430503d286c30e9">
-    <sch:title>1328. Landingspagina voor authenticatie - Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20authenticatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.47</sch:title>
     <sch:rule context="//dcat:DataService/mdcat:landingspaginaVoorAuthenticatie[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(@rdf:resource) != ''"/>
       <sch:let name="isURI" value="matches(@rdf:resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$isNotEmpty and $isURI">De range van landingspagina voor authenticatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorAuthenticatie)</sch:assert>
-      <sch:report test="$isNotEmpty and $isURI">De range van landingspagina voor authenticatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorAuthenticatie)</sch:report>
+      <sch:assert test="$isNotEmpty and $isURI">$loc/strings/pattern.assert.47</sch:assert>
+      <sch:report test="$isNotEmpty and $isURI">$loc/strings/pattern.report.47</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="landingspagina voor authenticatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/e9bf439f5272396af4486645c4dd4ae47c27c030">
-    <sch:title>1330. Landingspagina voor authenticatie - Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20authenticatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.48</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(mdcat:landingspaginaVoorAuthenticatie) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.48</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.48</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="landingspagina voor gebruiksinformatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/b643cb8952d752ef63a2b25c7fcebd89d08fb015">
-    <sch:title>1332. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.49</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(mdcat:landingspaginaVoorGebruiksinformatie) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.49</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.49</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="landingspagina voor gebruiksinformatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/c4eb7e771a95c6c3e5c04255458173a2b0b40f43">
-    <sch:title>1333. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.50</sch:title>
     <sch:rule context="//dcat:DataService/mdcat:landingspaginaVoorGebruiksinformatie[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(@rdf:resource) != ''"/>
       <sch:let name="isURI" value="matches(@rdf:resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$isNotEmpty and $isURI">De range van landingspagina voor gebruiksinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorGebruiksinformatie)</sch:assert>
-      <sch:report test="$isNotEmpty and $isURI">De range van landingspagina voor gebruiksinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorGebruiksinformatie)</sch:report>
+      <sch:assert test="$isNotEmpty and $isURI">$loc/strings/pattern.assert.50</sch:assert>
+      <sch:report test="$isNotEmpty and $isURI">$loc/strings/pattern.report.50</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="landingspagina voor statusinformatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/0cdcfe2387440711ebbe94a2fcc93a29377956c5">
-    <sch:title>1334. Landingspagina voor statusinformatie - Een verwijzing naar de statuspagina van de dataservice (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20statusinformatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.51</sch:title>
     <sch:rule context="//dcat:DataService/mdcat:landingspaginaVoorStatusinformatie[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(@rdf:resource) != ''"/>
       <sch:let name="isURI" value="matches(@rdf:resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$isNotEmpty and $isURI">De range van landingspagina voor statusinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorStatusinformatie)</sch:assert>
-      <sch:report test="$isNotEmpty and $isURI">De range van landingspagina voor statusinformatie moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (mdcat:landingspaginaVoorStatusinformatie)</sch:report>
+      <sch:assert test="$isNotEmpty and $isURI">$loc/strings/pattern.assert.51</sch:assert>
+      <sch:report test="$isNotEmpty and $isURI">$loc/strings/pattern.report.51</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="landingspagina voor statusinformatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/82e4f4e38a285ebeffb0f14c036b491b71a26200">
-    <sch:title>1336. Landingspagina voor statusinformatie - Een verwijzing naar de statuspagina van de dataservice (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alandingspagina%20voor%20statusinformatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.52</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(mdcat:landingspaginaVoorStatusinformatie) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.52</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.52</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="levensfase" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/13afabc6c35a0042403bd3a9f50222200152231a">
-    <sch:title>1338. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</sch:title>
+    <sch:title>$loc/strings/pattern.title.53</sch:title>
     <sch:rule context="//dcat:DataService/mdcat:levensfase[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van levensfase moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:levensfase)</sch:assert>
-      <sch:report test="$validClass">De range van levensfase moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:levensfase)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.53</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.53</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="levensfase" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/8a32a3e6b5ca4b68f8846b184e7faa4f48a0ee1d">
-    <sch:title>1340. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alevensfase)</sch:title>
+    <sch:title>$loc/strings/pattern.title.54</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(mdcat:levensfase) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.54</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.54</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="licentie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/509740cc7b3c86ebee90dc6303c11c40e2b08212">
-    <sch:title>1341. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.55</sch:title>
     <sch:rule context="//dcat:DataService/dct:license[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:LicenseDocument) = 1 or count(//dct:LicenseDocument[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</sch:assert>
-      <sch:report test="$validClass">De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.55</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.55</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="licentie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/a42564b7be6f290f20410a7d087232aece0c058e">
-    <sch:title>1342. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.56</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMin" value="count(dct:license) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor licentie (dct:license)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor licentie (dct:license)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.56</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.56</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="licentie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/cafd2e3e66044d8ba2c435a9353e6880952086c5">
-    <sch:title>1343. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Alicentie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.57</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(dct:license) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor licentie (dct:license)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor licentie (dct:license)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.57</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.57</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="ontwikkelingstoestand" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/4523d6e75f8993d15c9332b0aae5dbbe64a85b5a">
-    <sch:title>1345. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</sch:title>
+    <sch:title>$loc/strings/pattern.title.58</sch:title>
     <sch:rule context="//dcat:DataService/mdcat:ontwikkelingstoestand[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van ontwikkelingstoestand moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:ontwikkelingstoestand)</sch:assert>
-      <sch:report test="$validClass">De range van ontwikkelingstoestand moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:ontwikkelingstoestand)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.58</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.58</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="ontwikkelingstoestand" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/76f6cfca9a1964a539a879c911777c741a37cff0">
-    <sch:title>1346. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aontwikkelingstoestand)</sch:title>
+    <sch:title>$loc/strings/pattern.title.59</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(mdcat:ontwikkelingstoestand) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.59</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.59</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="rechten" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/62bb7a143add01ac0956709b58850f4f5e5a0e47">
-    <sch:title>1349. Rechten - Bepalingen van juridische aard die gelden op de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Arechten)</sch:title>
+    <sch:title>$loc/strings/pattern.title.60</sch:title>
     <sch:rule context="//dcat:DataService/dct:rights[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:RightsStatement) = 1 or count(//dct:RightsStatement[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</sch:assert>
-      <sch:report test="$validClass">De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.60</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.60</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="thema" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/1712ef1b325d7d2807bc601d6409b70a42eaff10">
-    <sch:title>1351. Thema - De hoofdcategorie waartoe de dataservice behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Athema)</sch:title>
+    <sch:title>$loc/strings/pattern.title.61</sch:title>
     <sch:rule context="//dcat:DataService/dcat:theme[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</sch:assert>
-      <sch:report test="$validClass">De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.61</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.61</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/25d18a6e2598024ea186cc7be4391bdfd1bca21f">
-    <sch:title>1354. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.62</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMin" value="count(dct:title) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor titel (dct:title)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor titel (dct:title)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.62</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.62</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/5c245f65e6c2294cd7079eb566de6fd4e4adb829">
-    <sch:title>1356. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.63</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(dct:title) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor titel (dct:title)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor titel (dct:title)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.63</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.63</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/8041fe094c27b123422bd03a4e13ff0641087607">
-    <sch:title>1357. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.64</sch:title>
     <sch:rule context="//dcat:DataService/dct:title[$profile]">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:title[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
-      <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:assert>
-      <sch:report test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:report>
+      <sch:assert test="$isUniqueLang">$loc/strings/pattern.assert.64</sch:assert>
+      <sch:report test="$isUniqueLang">$loc/strings/pattern.report.64</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/f28ce523c4b4fcb15d8c7d4f279da195ba7403ab">
-    <sch:title>1358. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.65</sch:title>
     <sch:rule context="//dcat:DataService/dct:title[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
-      <sch:assert test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:assert>
-      <sch:report test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:report>
+      <sch:assert test="$isLiteral and $hasLang">$loc/strings/pattern.assert.65</sch:assert>
+      <sch:report test="$isLiteral and $hasLang">$loc/strings/pattern.report.65</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/7463895a2bb9e7e4c96cd9a2e7f83ce2cf787098">
-    <sch:title>1360. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</sch:title>
+    <sch:title>$loc/strings/pattern.title.66</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMin" value="count(dct:accessRights) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.66</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.66</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/a81035a5dbbdae24651c34e5602a1fe6fe5427a3">
-    <sch:title>1361. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</sch:title>
+    <sch:title>$loc/strings/pattern.title.67</sch:title>
     <sch:rule context="//dcat:DataService/dct:accessRights[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</sch:assert>
-      <sch:report test="$validClass">De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.67</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.67</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/f9524ba86e28981345a2b84aea788460ad4e805e">
-    <sch:title>1363. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atoegankelijkheid)</sch:title>
+    <sch:title>$loc/strings/pattern.title.68</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(dct:accessRights) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.68</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.68</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="trefwoord" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/44f6426e2306c5bc0421823eb4a1a034b615f715">
-    <sch:title>1365. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Atrefwoord)</sch:title>
+    <sch:title>$loc/strings/pattern.title.69</sch:title>
     <sch:rule context="//dcat:DataService/dcat:keyword[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
-      <sch:assert test="$isLiteral and $hasLang">De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</sch:assert>
-      <sch:report test="$isLiteral and $hasLang">De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</sch:report>
+      <sch:assert test="$isLiteral and $hasLang">$loc/strings/pattern.assert.69</sch:assert>
+      <sch:report test="$isLiteral and $hasLang">$loc/strings/pattern.report.69</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="versie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/302090a90a5755780bc8fe09be4bcd29193cfd6d">
-    <sch:title>1667. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.70</sch:title>
     <sch:rule context="//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(owl:versionInfo) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.70</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.70</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="versie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DataServiceShape/587f313308111b587d1bd2440a56622e64624864">
-    <sch:title>1668. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#DataService%3Aversie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.71</sch:title>
     <sch:rule context="//dcat:DataService/owl:versionInfo[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
-      <sch:assert test="$isLiteral">De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</sch:assert>
-      <sch:report test="$isLiteral">De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</sch:report>
+      <sch:assert test="$isLiteral">$loc/strings/pattern.assert.71</sch:assert>
+      <sch:report test="$isLiteral">$loc/strings/pattern.report.71</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="alternatieve identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/39607ae8317e4f99846f57f713d51b19528e5764">
-    <sch:title>v067. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een dataset kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aalternatieve%20identificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.72</sch:title>
     <sch:rule context="//dcat:Dataset/adms:identifier[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(adms:Identifier) = 1 or count(//adms:Identifier[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:assert>
-      <sch:report test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.72</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.72</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/0e9a7d4dbf6ec19568d474169ad717f71e882319">
-    <sch:title>v207. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</sch:title>
+    <sch:title>$loc/strings/pattern.title.73</sch:title>
     <sch:rule context="//dcat:Dataset/dct:description[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
-      <sch:assert test="$isLiteral and $hasLang">De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</sch:assert>
-      <sch:report test="$isLiteral and $hasLang">De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</sch:report>
+      <sch:assert test="$isLiteral and $hasLang">$loc/strings/pattern.assert.73</sch:assert>
+      <sch:report test="$isLiteral and $hasLang">$loc/strings/pattern.report.73</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/4a16176c26d8d5526c76974a1530f1ffdd596e93">
-    <sch:title>1702. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</sch:title>
+    <sch:title>$loc/strings/pattern.title.74</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]">
       <sch:let name="validMax" value="count(dct:description) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor beschrijving (dct:description)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.74</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.74</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/7521953addc62cf367ab3c8ec0dc63cb5981ea23">
-    <sch:title>v037. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</sch:title>
+    <sch:title>$loc/strings/pattern.title.75</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]">
       <sch:let name="validMin" value="count(dct:description) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor beschrijving (dct:description)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor beschrijving (dct:description)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.75</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.75</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/da05d674f29a225a7115411e9f7ca442a25f2c88">
-    <sch:title>v215. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Abeschrijving)</sch:title>
+    <sch:title>$loc/strings/pattern.title.76</sch:title>
     <sch:rule context="//dcat:Dataset/dct:description[$profile]">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:description[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
-      <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</sch:assert>
-      <sch:report test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</sch:report>
+      <sch:assert test="$isUniqueLang">$loc/strings/pattern.assert.76</sch:assert>
+      <sch:report test="$isUniqueLang">$loc/strings/pattern.report.76</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="conform" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/dd5cf5b162b3f92600a391f44660bf2b255693ac">
-    <sch:title>v056. Conform - Een standaard, schema, applicatieprofiel, vocabularium waaraan de dataset voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aconform)</sch:title>
+    <sch:title>$loc/strings/pattern.title.77</sch:title>
     <sch:rule context="//dcat:Dataset/dct:conformsTo[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:Standard) = 1 or count(//dct:Standard[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</sch:assert>
-      <sch:report test="$validClass">De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.77</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.77</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/19ee039173472235e539aea2aa961ff7d3b89f5a">
-    <sch:title>1705. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.78</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]">
       <sch:let name="validMax" value="count(dcat:contactPoint) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.78</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.78</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/458062b0ae03c559426b85df3dd28e1c785acb0b">
-    <sch:title>1706. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.79</sch:title>
     <sch:rule context="//dcat:Dataset/dcat:contactPoint[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(vcard:Organization) = 1 or count(//vcard:Organization[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van contactinformatie moet van het type &lt;http://schema.org/ContactPoint&gt; zijn. (dcat:contactPoint)</sch:assert>
-      <sch:report test="$validClass">De range van contactinformatie moet van het type &lt;http://schema.org/ContactPoint&gt; zijn. (dcat:contactPoint)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.79</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.79</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/e332dbce5947de4314c3ed3fe5862f26d70a15c4">
-    <sch:title>v041. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Acontactinformatie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.80</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]">
       <sch:let name="validMin" value="count(dcat:contactPoint) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.80</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.80</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="distributie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/cfbe0a11423fe15e990c3cbd5209404c26dbef0f">
-    <sch:title>v046. Distributie - Een beschikbare distributie van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Adistributie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.81</sch:title>
     <sch:rule context="//dcat:Dataset/dcat:distribution[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dcat:Distribution) = 1 or count(//dcat:Distribution[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van distributie moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (dcat:distribution)</sch:assert>
-      <sch:report test="$validClass">De range van distributie moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (dcat:distribution)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.81</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.81</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/05134c4e7c34157d6f7ac1128713a08418e0fe7d">
-    <sch:title>v060. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.82</sch:title>
     <sch:rule context="//dcat:Dataset/dct:identifier[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
-      <sch:assert test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (dct:identifier)</sch:assert>
-      <sch:report test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (dct:identifier)</sch:report>
+      <sch:assert test="$isLiteral">$loc/strings/pattern.assert.82</sch:assert>
+      <sch:report test="$isLiteral">$loc/strings/pattern.report.82</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/972d73e7a13100b66c0c2f44466edac47aa1ab28">
-    <sch:title>1708. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.83</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]">
       <sch:let name="validMin" value="count(dct:identifier) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.83</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.83</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/bb43a48c77e7d98609af3d3bb1b1648370465308">
-    <sch:title>1709. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.84</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]">
       <sch:let name="validMax" value="count(dct:identifier) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.84</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.84</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="landingspagina" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/fe1a78c9169da2469a23fd783cf9a69060bfe198">
-    <sch:title>1712. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene informatie over de dataset, zijn distributies en/of aanvullende informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Alandingspagina)</sch:title>
+    <sch:title>$loc/strings/pattern.title.85</sch:title>
     <sch:rule context="//dcat:Dataset/dcat:landingPage[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(@rdf:resource) != ''"/>
       <sch:let name="isURI" value="matches(@rdf:resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$isNotEmpty and $isURI">De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</sch:assert>
-      <sch:report test="$isNotEmpty and $isURI">De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</sch:report>
+      <sch:assert test="$isNotEmpty and $isURI">$loc/strings/pattern.assert.85</sch:assert>
+      <sch:report test="$isNotEmpty and $isURI">$loc/strings/pattern.report.85</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="thema" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/1712ef1b325d7d2807bc601d6409b70a42eaff10">
-    <sch:title>v115. Thema - De hoofdcategorie waartoe de dataset behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Athema)</sch:title>
+    <sch:title>$loc/strings/pattern.title.86</sch:title>
     <sch:rule context="//dcat:Dataset/dcat:theme[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</sch:assert>
-      <sch:report test="$validClass">De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.86</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.86</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/25d18a6e2598024ea186cc7be4391bdfd1bca21f">
-    <sch:title>v039. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.87</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]">
       <sch:let name="validMin" value="count(dct:title) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor titel (dct:title)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor titel (dct:title)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.87</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.87</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/8041fe094c27b123422bd03a4e13ff0641087607">
-    <sch:title>v214. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.88</sch:title>
     <sch:rule context="//dcat:Dataset/dct:title[$profile]">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:title[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
-      <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:assert>
-      <sch:report test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:report>
+      <sch:assert test="$isUniqueLang">$loc/strings/pattern.assert.88</sch:assert>
+      <sch:report test="$isUniqueLang">$loc/strings/pattern.report.88</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/f28ce523c4b4fcb15d8c7d4f279da195ba7403ab">
-    <sch:title>v206. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.89</sch:title>
     <sch:rule context="//dcat:Dataset/dct:title[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
-      <sch:assert test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:assert>
-      <sch:report test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:report>
+      <sch:assert test="$isLiteral and $hasLang">$loc/strings/pattern.assert.89</sch:assert>
+      <sch:report test="$isLiteral and $hasLang">$loc/strings/pattern.report.89</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/7463895a2bb9e7e4c96cd9a2e7f83ce2cf787098">
-    <sch:title>1716. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</sch:title>
+    <sch:title>$loc/strings/pattern.title.90</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]">
       <sch:let name="validMin" value="count(dct:accessRights) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.90</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.90</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/a81035a5dbbdae24651c34e5602a1fe6fe5427a3">
-    <sch:title>1717. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</sch:title>
+    <sch:title>$loc/strings/pattern.title.91</sch:title>
     <sch:rule context="//dcat:Dataset/dct:accessRights[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</sch:assert>
-      <sch:report test="$validClass">De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.91</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.91</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/f9524ba86e28981345a2b84aea788460ad4e805e">
-    <sch:title>v100. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atoegankelijkheid)</sch:title>
+    <sch:title>$loc/strings/pattern.title.92</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]">
       <sch:let name="validMax" value="count(dct:accessRights) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.92</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.92</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="trefwoord" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/44f6426e2306c5bc0421823eb4a1a034b615f715">
-    <sch:title>1720. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Atrefwoord)</sch:title>
+    <sch:title>$loc/strings/pattern.title.93</sch:title>
     <sch:rule context="//dcat:Dataset/dcat:keyword[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
-      <sch:assert test="$isLiteral and $hasLang">De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</sch:assert>
-      <sch:report test="$isLiteral and $hasLang">De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</sch:report>
+      <sch:assert test="$isLiteral and $hasLang">$loc/strings/pattern.assert.93</sch:assert>
+      <sch:report test="$isLiteral and $hasLang">$loc/strings/pattern.report.93</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="versie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/302090a90a5755780bc8fe09be4bcd29193cfd6d">
-    <sch:title>v076. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.94</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]">
       <sch:let name="validMax" value="count(owl:versionInfo) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.94</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.94</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="versie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/587f313308111b587d1bd2440a56622e64624864">
-    <sch:title>v075. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aversie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.95</sch:title>
     <sch:rule context="//dcat:Dataset/owl:versionInfo[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
-      <sch:assert test="$isLiteral">De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</sch:assert>
-      <sch:report test="$isLiteral">De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</sch:report>
+      <sch:assert test="$isLiteral">$loc/strings/pattern.assert.95</sch:assert>
+      <sch:report test="$isLiteral">$loc/strings/pattern.report.95</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="alternatieve identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/39607ae8317e4f99846f57f713d51b19528e5764">
-    <sch:title>1801. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een distributie kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aalternatieve%20identificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.96</sch:title>
     <sch:rule context="//dcat:Distribution/adms:identifier[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(adms:Identifier) = 1 or count(//adms:Identifier[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:assert>
-      <sch:report test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.96</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.96</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="downloadURL" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/0e61107f343f202ee672ef465cfcdbbcd746e21d">
-    <sch:title>v090. Downloadurl - De URL waar de data gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AdownloadURL)</sch:title>
+    <sch:title>$loc/strings/pattern.title.97</sch:title>
     <sch:rule context="//dcat:Distribution/dcat:downloadURL[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(@rdf:resource) != ''"/>
       <sch:let name="isURI" value="matches(@rdf:resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$isNotEmpty and $isURI">De range van downloadURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:downloadURL)</sch:assert>
-      <sch:report test="$isNotEmpty and $isURI">De range van downloadURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:downloadURL)</sch:report>
+      <sch:assert test="$isNotEmpty and $isURI">$loc/strings/pattern.assert.97</sch:assert>
+      <sch:report test="$isNotEmpty and $isURI">$loc/strings/pattern.report.97</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="downloadURL" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/1ff94e5c0d35c7d1a7f2c4bd160a8c8e4eee6f97">
-    <sch:title>v090. Downloadurl - De URL waar de data gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AdownloadURL)</sch:title>
+    <sch:title>$loc/strings/pattern.title.98</sch:title>
     <sch:rule context="//dcat:Distribution[$profile]">
       <sch:let name="validMax" value="count(dcat:downloadURL) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.98</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.98</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/05134c4e7c34157d6f7ac1128713a08418e0fe7d">
-    <sch:title>1902. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.99</sch:title>
     <sch:rule context="//dcat:Distribution/dct:identifier[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
-      <sch:assert test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:assert>
-      <sch:report test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:report>
+      <sch:assert test="$isLiteral">$loc/strings/pattern.assert.99</sch:assert>
+      <sch:report test="$isLiteral">$loc/strings/pattern.report.99</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/972d73e7a13100b66c0c2f44466edac47aa1ab28">
-    <sch:title>1903. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.100</sch:title>
     <sch:rule context="//dcat:Distribution[$profile]">
       <sch:let name="validMin" value="count(dct:identifier) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.100</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.100</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/bb43a48c77e7d98609af3d3bb1b1648370465308">
-    <sch:title>1904. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Aidentificator)</sch:title>
+    <sch:title>$loc/strings/pattern.title.101</sch:title>
     <sch:rule context="//dcat:Distribution[$profile]">
       <sch:let name="validMax" value="count(dct:identifier) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.101</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.101</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="licentie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/509740cc7b3c86ebee90dc6303c11c40e2b08212">
-    <sch:title>v087. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.102</sch:title>
     <sch:rule context="//dcat:Distribution/dct:license[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:LicenseDocument) = 1 or count(//dct:LicenseDocument[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</sch:assert>
-      <sch:report test="$validClass">De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.102</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.102</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="licentie" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/cafd2e3e66044d8ba2c435a9353e6880952086c5">
-    <sch:title>v088. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Alicentie)</sch:title>
+    <sch:title>$loc/strings/pattern.title.103</sch:title>
     <sch:rule context="//dcat:Distribution[$profile]">
       <sch:let name="validMax" value="count(dct:license) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor licentie (dct:license)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor licentie (dct:license)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.103</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.103</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="rechten" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/62bb7a143add01ac0956709b58850f4f5e5a0e47">
-    <sch:title>1907. Rechten - Bepalingen van juridische aard die gelden op de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Arechten)</sch:title>
+    <sch:title>$loc/strings/pattern.title.104</sch:title>
     <sch:rule context="//dcat:Distribution/dct:rights[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:RightsStatement) = 1 or count(//dct:RightsStatement[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</sch:assert>
-      <sch:report test="$validClass">De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.104</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.104</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/5c245f65e6c2294cd7079eb566de6fd4e4adb829">
-    <sch:title>1909. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.105</sch:title>
     <sch:rule context="//dcat:Distribution[$profile]">
       <sch:let name="validMax" value="count(dct:title) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor titel (dct:title)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor titel (dct:title)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.105</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.105</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/8041fe094c27b123422bd03a4e13ff0641087607">
-    <sch:title>v216. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.106</sch:title>
     <sch:rule context="//dcat:Distribution/dct:title[$profile]">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:title[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
-      <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:assert>
-      <sch:report test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:report>
+      <sch:assert test="$isUniqueLang">$loc/strings/pattern.assert.106</sch:assert>
+      <sch:report test="$isUniqueLang">$loc/strings/pattern.report.106</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/f28ce523c4b4fcb15d8c7d4f279da195ba7403ab">
-    <sch:title>v205. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Atitel)</sch:title>
+    <sch:title>$loc/strings/pattern.title.107</sch:title>
     <sch:rule context="//dcat:Distribution/dct:title[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
-      <sch:assert test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:assert>
-      <sch:report test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:report>
+      <sch:assert test="$isLiteral and $hasLang">$loc/strings/pattern.assert.107</sch:assert>
+      <sch:report test="$isLiteral and $hasLang">$loc/strings/pattern.report.107</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="toegangsURL" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/28a9b5a610271b2ad2cd6917763075560213ca20">
-    <sch:title>v220. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</sch:title>
+    <sch:title>$loc/strings/pattern.title.108</sch:title>
     <sch:rule context="//dcat:Distribution[$profile]">
       <sch:let name="validMax" value="count(dcat:accessURL) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.108</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.108</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="toegangsURL" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/3d0e850677d211050dd9e93ec6496e6af9908da6">
-    <sch:title>1910. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</sch:title>
+    <sch:title>$loc/strings/pattern.title.109</sch:title>
     <sch:rule context="//dcat:Distribution/dcat:accessURL[$profile]">
       <sch:let name="isNotEmpty" value="normalize-space(@rdf:resource) != ''"/>
       <sch:let name="isURI" value="matches(@rdf:resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$isNotEmpty and $isURI">De range van toegangsURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:accessURL)</sch:assert>
-      <sch:report test="$isNotEmpty and $isURI">De range van toegangsURL moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:accessURL)</sch:report>
+      <sch:assert test="$isNotEmpty and $isURI">$loc/strings/pattern.assert.109</sch:assert>
+      <sch:report test="$isNotEmpty and $isURI">$loc/strings/pattern.report.109</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="toegangsURL" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/bf4475984ce7d0eb4bade6e749e672a8efa7dd2d">
-    <sch:title>v079. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3AtoegangsURL)</sch:title>
+    <sch:title>$loc/strings/pattern.title.110</sch:title>
     <sch:rule context="//dcat:Distribution[$profile]">
       <sch:let name="validMin" value="count(dcat:accessURL) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.110</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.110</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="wordt aangeboden door" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#DistributieShape/c612c1f62d45c84405f45260ab0737a10f5b0a18">
-    <sch:title>1912. Wordt aangeboden door - Een dataservice die deze distributie aanbiedt. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Distributie%3Awordt%20aangeboden%20door)</sch:title>
+    <sch:title>$loc/strings/pattern.title.111</sch:title>
     <sch:rule context="//dcat:Distribution/dcat:accessService[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
-      <sch:assert test="$validClass">De range van wordt aangeboden door moet van het type &lt;http://www.w3.org/ns/dcat#DataService&gt; zijn. (dcat:accessService)</sch:assert>
-      <sch:report test="$validClass">De range van wordt aangeboden door moet van het type &lt;http://www.w3.org/ns/dcat#DataService&gt; zijn. (dcat:accessService)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.111</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.111</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="statuut" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusResourceShape/2ea1d293b25f05ec202dd2dcf8924e8518262c91">
-    <sch:title>2005. Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</sch:title>
+    <sch:title>$loc/strings/pattern.title.112</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]|//dcat:DataService[$profile]">
       <sch:let name="validMin" value="count(mdcat:statuut) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor statuut (mdcat:statuut)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor statuut (mdcat:statuut)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.112</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.112</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="statuut" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusResourceShape/f96c5f798f9e9c00220a293bd11f37e83616d33b">
-    <sch:title>2009. Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Astatuut)</sch:title>
+    <sch:title>$loc/strings/pattern.title.113</sch:title>
     <sch:rule context="//dcat:Dataset/mdcat:statuut[$profile]|//dcat:DataService/mdcat:statuut[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</sch:assert>
-      <sch:report test="$validClass">De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.113</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.113</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="uitgever" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusResourceShape/5334cf8edf5cc07e349524728fe4c9b076e4c45e">
-    <sch:title>2002. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</sch:title>
+    <sch:title>$loc/strings/pattern.title.114</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]|//dcat:DataService[$profile]">
       <sch:let name="validMax" value="count(dct:publisher) &lt;= 1"/>
-      <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</sch:assert>
-      <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</sch:report>
+      <sch:assert test="$validMax">$loc/strings/pattern.assert.114</sch:assert>
+      <sch:report test="$validMax">$loc/strings/pattern.report.114</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="uitgever" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusResourceShape/aabe67e6a56c5e2fc5695716e8f7b66edd525085">
-    <sch:title>v052. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</sch:title>
+    <sch:title>$loc/strings/pattern.title.115</sch:title>
     <sch:rule context="//dcat:Dataset/dct:publisher[$profile]|//dcat:DataService/dct:publisher[$profile]">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(foaf:Agent) = 1 or count(//foaf:Agent[@rdf:about = $resource]) = 1"/>
-      <sch:assert test="$validClass">De range van uitgever moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:publisher)</sch:assert>
-      <sch:report test="$validClass">De range van uitgever moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:publisher)</sch:report>
+      <sch:assert test="$validClass">$loc/strings/pattern.assert.115</sch:assert>
+      <sch:report test="$validClass">$loc/strings/pattern.report.115</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="uitgever" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#CatalogusResourceShape/e2d4034a0a398701f4257641ebcbc85e8683b29d">
-    <sch:title>v049. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#CatalogusResource%3Auitgever)</sch:title>
+    <sch:title>$loc/strings/pattern.title.116</sch:title>
     <sch:rule context="//dcat:Dataset[$profile]|//dcat:DataService[$profile]">
       <sch:let name="validMin" value="count(dct:publisher) &gt;= 1"/>
-      <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</sch:assert>
-      <sch:report test="$validMin">Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</sch:report>
+      <sch:assert test="$validMin">$loc/strings/pattern.assert.116</sch:assert>
+      <sch:report test="$validMin">$loc/strings/pattern.report.116</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#UsageNoteDistributieShape/1">
-    <sch:title>Beschrijving - Een bondige tekstuele omschrijving van de distributie.</sch:title>
+    <sch:title>$loc/strings/pattern.title.117</sch:title>
     <sch:rule context="//dcat:Distribution/dct:description[$profile]">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
-      <sch:assert test="$isLiteral and $hasLang">De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</sch:assert>
-      <sch:report test="$isLiteral and $hasLang">De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</sch:report>
+      <sch:assert test="$isLiteral and $hasLang">$loc/strings/pattern.assert.117</sch:assert>
+      <sch:report test="$isLiteral and $hasLang">$loc/strings/pattern.report.117</sch:report>
     </sch:rule>
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/DCAT-AP-VL#UsageNoteDistributieShape/4">
-    <sch:title>Beschrijving - Een bondige tekstuele omschrijving van de distributie.</sch:title>
+    <sch:title>$loc/strings/pattern.title.118</sch:title>
     <sch:rule context="//dcat:Distribution/dct:description[$profile]">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:description[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
-      <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</sch:assert>
-      <sch:report test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</sch:report>
+      <sch:assert test="$isUniqueLang">$loc/strings/pattern.assert.118</sch:assert>
+      <sch:report test="$isUniqueLang">$loc/strings/pattern.report.118</sch:report>
     </sch:rule>
   </sch:pattern>
 </sch:schema>


### PR DESCRIPTION
Generated localisation files based on existing schematron files. All Dutch / English should now be present and correctly used in the validation output. Missing translations (dutch to english and english to dutch, depending on where you look) were generated by CoPilot and manually checked.