### PR TITLE
Added sortLabel as an override for sorting when applicable

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -2156,7 +2156,7 @@
           </dct:Standard>
         </dct:conformsTo>
       </snippet>
-      <snippet label="protocol-51">
+      <snippet label="protocol-51" sortLabel="ZZZZ">
         <dct:conformsTo>
           <dct:Standard xmlns:dct="http://purl.org/dc/terms/">
             <dct:identifier/>


### PR DESCRIPTION
Necessary core change for this to work: https://github.com/geonetwork/core-geonetwork/pull/8685
Allows forcing the "fill in your own option..." to the end of the list and sort the rest alphabetically.

![image](https://github.com/user-attachments/assets/8d62fabe-3213-4551-96b9-02f19bfd7c1c)
