### PR TITLE
Editor / Thesaurus / Add possibility to override configuration.

### DIFF
--- a/src/main/plugin/dcat-ap/convert/thesaurus-transformation.xsl
+++ b/src/main/plugin/dcat-ap/convert/thesaurus-transformation.xsl
@@ -99,6 +99,7 @@
         </xsl:for-each>
       </gn_replace_all>
     </xsl:variable>
+
     <xsl:copy-of select="$response"/>
   </xsl:template>
 

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -643,7 +643,8 @@
           <!--              <skos:inScheme rdf:resource="http://vocab.belgif.be/auth/datatheme"/>-->
           <!--            </skos:Concept>-->
           <!--          </dcat:theme>-->
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme[skos:Concept/skos:inScheme/@rdf:resource = 'http://vocab.belgif.be/auth/datatheme']"
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme"
+                 name="dcat:theme"
                  or="theme"
                  use="data-gn-keyword-picker"
                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
@@ -1031,7 +1032,7 @@
               </snippet>
             </template>
           </action>
-          
+
           <action type="associatedResource" name="linkToDataset" process="dataset">
             <directiveAttributes>{"sources": {
               "metadataStore": {"params": {

--- a/src/main/plugin/dcat-ap/layout/dispatcher.xsl
+++ b/src/main/plugin/dcat-ap/layout/dispatcher.xsl
@@ -45,11 +45,14 @@
   <!-- Dispatching to the profile mode  -->
   <xsl:template name="dispatch-dcat-ap">
     <xsl:param name="base" as="node()"/>
-    <xsl:param name="overrideLabel" as="xs:string" required="no" select="''"/>
+    <xsl:param name="overrideLabel" as="xs:string?" required="no" select="''"/>
     <xsl:param name="refToDelete" as="node()?" required="no"/>
+    <xsl:param name="config" as="node()?" required="no"/>
+
     <xsl:apply-templates mode="mode-dcat-ap" select="$base">
       <xsl:with-param name="overrideLabel" select="$overrideLabel"/>
       <xsl:with-param name="refToDelete" select="$refToDelete"/>
+      <xsl:with-param name="config" select="$config"/>
     </xsl:apply-templates>
   </xsl:template>
 


### PR DESCRIPTION
When a field is using a thesaurus, it has to be configured in the `config-editor.xml` file in the `editor/fields/for` section

eg.
```xml
<editor>...
  <fields>...
    <for name="dcat:theme" use="thesaurus-list-picker">
      <directiveAttributes
        thesaurus="external.theme.datatheme"
        xpath="/dcat:theme"
        max=""
        labelKey="dcat.addThemes"/>
    </for>
```

User may want to configure thesaurus to be used on a per view basis (eg. when a view is specific to a profile). In such case, the field configuration can be overriden a field element.

eg.
```xml
<field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme"
       name="dcat:theme"
       or="theme"
       use="data-gn-keyword-picker"
       in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
  <directiveAttributes
    thesaurus="external.theme.vl-datatheme"
    xpath="/dcat:theme"
    max=""
    labelKey="dcat-addThemes"/>
</field>
```