### PR TITLE
Editor / dct:created is not a multilingual field

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -478,6 +478,7 @@
       <name>dct:identifier</name>
       <name>dct:language</name>
       <name>dct:format</name>
+      <name>dct:created</name>
       <name>dct:modified</name>
       <name>dct:issued</name>
       <name>dct:hasPart</name>


### PR DESCRIPTION
A validation error was triggered due to `xml:lang` attribute.