### PR TITLE
Overwriting the pom version for VL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>gn-schemas</artifactId>
     <groupId>org.geonetwork-opensource.schemas</groupId>
-    <version>4.4.7-SNAPSHOT</version>
+    <version>4.4.6-0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
From now on, rebasing main onto vl/main should result in clean upgrade. VL is not running the `pom.xml` version of `core/main`, it needs to be kept separate.