### PR TITLE
VL - Feature/schematronrules fixes

### DIFF
--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-rec.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
-  <schematron.title>DCAT-AP-Vlaanderen - Aanbevolen</schematron.title>
+  <schematron.title>DCAT-AP - Aanbevolen</schematron.title>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-rec.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
-  <schematron.title>DCAT-AP-Vlaanderen - Recommended</schematron.title>
+  <schematron.title>DCAT-AP - Recommended</schematron.title>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-hvd-rec.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
-  <schematron.title>High Value Datasets - Recommendé</schematron.title>
+  <schematron.title>High Value Datasets - Recommandé</schematron.title>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-rec.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
-  <schematron.title>DCAT-AP-Vlaanderen - Recommendé</schematron.title>
+  <schematron.title>DCAT-AP - Recommandé</schematron.title>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-vl-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-vl-rec.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
-  <schematron.title>DCAT-AP-Vlaanderen - Recommendé</schematron.title>
+  <schematron.title>DCAT-AP-Vlaanderen - Recommandé</schematron.title>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-mdcat-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-mdcat-rec.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
-  <schematron.title>Metadata DCAT - Recommendé</schematron.title>
+  <schematron.title>Metadata DCAT - Recommandé</schematron.title>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-rec.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
-  <schematron.title>DCAT-AP-Vlaanderen - Empfohlen</schematron.title>
+  <schematron.title>DCAT-AP - Empfohlen</schematron.title>
 </strings>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-mdcat-rec.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-mdcat-rec.sch
@@ -24,10 +24,9 @@
 
   <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
 
-  <sch:let name="profile" value="boolean(/*[starts-with(//dcat:CatalogRecord//dct:Standard/@rdf:about, 'https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat')])"/>
   <sch:pattern name="conform aan protocol" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/c394e1e5ae80a00d2aa307d647168d0c6733df26">
     <sch:title>Conform aan protocol - Een protocol waaraan de dataservice voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aconform%20aan%20protocol)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:conformsTo[$profile]">
+    <sch:rule context="//dcat:DataService/dct:conformsTo">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'https://data.vlaanderen.be/id/conceptscheme/dataserviceprotocol'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;https://data.vlaanderen.be/id/conceptscheme/dataserviceprotocol&gt; verwacht voor conform aan protocol (dct:conformsTo)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;https://data.vlaanderen.be/id/conceptscheme/dataserviceprotocol&gt; verwacht voor conform aan protocol (dct:conformsTo)</sch:report>
@@ -35,7 +34,7 @@
   </sch:pattern>
   <sch:pattern name="levensfase" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/0aea9e8a54457ca50f1b00c07872cb7c7b39e8ba">
     <sch:title>1337. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alevensfase)</sch:title>
-    <sch:rule context="//dcat:DataService/mdcat:levensfase[$profile]">
+    <sch:rule context="//dcat:DataService/mdcat:levensfase">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'https://data.vlaanderen.be/id/conceptscheme/levensfase'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;https://data.vlaanderen.be/id/conceptscheme/levensfase&gt; verwacht voor levensfase (mdcat:levensfase)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;https://data.vlaanderen.be/id/conceptscheme/levensfase&gt; verwacht voor levensfase (mdcat:levensfase)</sch:report>
@@ -43,7 +42,7 @@
   </sch:pattern>
   <sch:pattern name="ontwikkelingstoestand" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/f9862087b9d1ec8465f46ee21e166c45776cf8bd">
     <sch:title>1348. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aontwikkelingstoestand)</sch:title>
-    <sch:rule context="//dcat:DataService/mdcat:ontwikkelingstoestand[$profile]">
+    <sch:rule context="//dcat:DataService/mdcat:ontwikkelingstoestand">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'https://data.vlaanderen.be/id/conceptscheme/ontwikkelingstoestand'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;https://data.vlaanderen.be/id/conceptscheme/ontwikkelingstoestand&gt; verwacht voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;https://data.vlaanderen.be/id/conceptscheme/ontwikkelingstoestand&gt; verwacht voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</sch:report>
@@ -51,7 +50,7 @@
   </sch:pattern>
   <sch:pattern name="statuut" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/67325124afc7d6eac4402056620665f7348ef62a">
     <sch:title>Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Astatuut)</sch:title>
-    <sch:rule context="//dcat:DataService/mdcat:statuut[$profile]">
+    <sch:rule context="//dcat:DataService/mdcat:statuut">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden&gt; verwacht voor statuut (mdcat:statuut)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden&gt; verwacht voor statuut (mdcat:statuut)</sch:report>
@@ -59,7 +58,7 @@
   </sch:pattern>
   <sch:pattern name="thema" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/48290800138d735a1909018da1426a5d120eedf0">
     <sch:title>1352. Thema - De hoofdcategorie waartoe de dataservice behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Athema)</sch:title>
-    <sch:rule context="//dcat:DataService/dcat:theme[$profile]">
+    <sch:rule context="//dcat:DataService/dcat:theme">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'http://vocab.belgif.be/auth/datatheme'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;https://vocab.belgif.be/auth/datatheme&gt; verwacht voor thema (dcat:theme)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;https://vocab.belgif.be/auth/datatheme&gt; verwacht voor thema (dcat:theme)</sch:report>
@@ -67,7 +66,7 @@
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/c5f6c428a4ae32239d9662d58fa65ae4f0cf49e6">
     <sch:title>1362. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Atoegankelijkheid)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:accessRights[$profile]">
+    <sch:rule context="//dcat:DataService/dct:accessRights">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'http://publications.europa.eu/resource/authority/access-right'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;http://publications.europa.eu/resource/authority/access-right&gt; verwacht voor toegankelijkheid (dct:accessRights)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;http://publications.europa.eu/resource/authority/access-right&gt; verwacht voor toegankelijkheid (dct:accessRights)</sch:report>
@@ -75,7 +74,7 @@
   </sch:pattern>
   <sch:pattern name="statuut" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/67325124afc7d6eac4402056620665f7348ef62a">
     <sch:title>Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Astatuut)</sch:title>
-    <sch:rule context="//dcat:Dataset/mdcat:statuut[$profile]">
+    <sch:rule context="//dcat:Dataset/mdcat:statuut">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden&gt; verwacht voor statuut (mdcat:statuut)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden&gt; verwacht voor statuut (mdcat:statuut)</sch:report>
@@ -83,7 +82,7 @@
   </sch:pattern>
   <sch:pattern name="thema" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/48290800138d735a1909018da1426a5d120eedf0">
     <sch:title>1713. Thema - De hoofdcategorie waartoe de dataset behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Athema)</sch:title>
-    <sch:rule context="//dcat:Dataset/dcat:theme[$profile]">
+    <sch:rule context="//dcat:Dataset/dcat:theme">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'http://vocab.belgif.be/auth/datatheme'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;https://vocab.belgif.be/auth/datatheme&gt; verwacht voor thema (dcat:theme)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;https://vocab.belgif.be/auth/datatheme&gt; verwacht voor thema (dcat:theme)</sch:report>
@@ -91,7 +90,7 @@
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/c5f6c428a4ae32239d9662d58fa65ae4f0cf49e6">
     <sch:title>1718. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Atoegankelijkheid)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:accessRights[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:accessRights">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'http://publications.europa.eu/resource/authority/access-right'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;http://publications.europa.eu/resource/authority/access-right&gt; verwacht voor toegankelijkheid (dct:accessRights)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;http://publications.europa.eu/resource/authority/access-right&gt; verwacht voor toegankelijkheid (dct:accessRights)</sch:report>
@@ -99,7 +98,7 @@
   </sch:pattern>
   <sch:pattern name="formaat" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/6700896d1cda0a52b587461e48a50c4d221f043b">
     <sch:title>Formaat - Het bestandsformaat waarin de data wordt gedeeld. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Aformaat)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:format[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:format">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'http://publications.europa.eu/resource/authority/file-type'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;http://publications.europa.eu/resource/authority/file-type&gt; verwacht voor formaat (dct:format)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;http://publications.europa.eu/resource/authority/file-type&gt; verwacht voor formaat (dct:format)</sch:report>
@@ -107,7 +106,7 @@
   </sch:pattern>
   <sch:pattern name="mediatype" id="https://data.vlaanderen.be/shacl/metadata_dcat#VoorbeeldWeergaveShape/91e8d1bb173f793bde16cb8a3dc8fde7844b5204">
     <sch:title>Mediatype - Het voorstellingsvorm van de afbeelding (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#VoorbeeldWeergave%3Amediatype)</sch:title>
-    <sch:rule context="//dcat:Distribution/dcat:mediatype[$profile]">
+    <sch:rule context="//dcat:Distribution/dcat:mediatype">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'https://www.iana.org/assignments/media-types/media-types.xhtml'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;https://www.iana.org/assignments/media-types/media-types.xhtml&gt; verwacht voor mediatype (dcat:mediatype)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;https://www.iana.org/assignments/media-types/media-types.xhtml&gt; verwacht voor mediatype (dcat:mediatype)</sch:report>
@@ -115,7 +114,7 @@
   </sch:pattern>
   <sch:pattern name="rol" id="https://data.vlaanderen.be/shacl/metadata_dcat#RelatieQualificatieShape/110bcc4a81256c6b4b080feb1fd85186147a7841">
     <sch:title>Rol - De functie hoe de entiteiten zich tot elkaar verhouden.  (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#RelatieQualificatie%3Arol)</sch:title>
-    <sch:rule context="//dcat:Relationship/dcat:hadRole[$profile]">
+    <sch:rule context="//dcat:Relationship/dcat:hadRole">
       <sch:let name="hasValue" value="skos:Concept/skos:inScheme/@rdf:resource = 'http://inspire.ec.europa.eu/metadata-codelist/SpatialRepresentationType'"/>
       <sch:assert test="$hasValue">Enkel waarden uit codelijst &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialRepresentationType&gt; verwacht voor rol (dcat:hadRole)</sch:assert>
       <sch:report test="$hasValue">Enkel waarden uit codelijst &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialRepresentationType&gt; verwacht voor rol (dcat:hadRole)</sch:report>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-mdcat.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-mdcat.sch
@@ -24,10 +24,9 @@
 
   <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
 
-  <sch:let name="profile" value="boolean(/*[starts-with(//dcat:CatalogRecord//dct:Standard/@rdf:about, 'https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat')])"/>
   <sch:pattern>
     <sch:title>vcard:hasEmail is a URI with the mailto protocol.</sch:title>
-    <sch:rule context="//vcard:hasEmail[$profile]">
+    <sch:rule context="//vcard:hasEmail">
       <sch:let name="mailto" value="starts-with(@rdf:resource,'mailto:')"/>
       <sch:assert test="$mailto = true()">vcard:hasEmail property is not a URI with the mailto: protocol.</sch:assert>
       <sch:report test="$mailto = true()">vcard:hasEmail property is a URI with the mailto: protocol.</sch:report>
@@ -35,7 +34,7 @@
   </sch:pattern>
   <sch:pattern>
     <sch:title>At least one of vcard:hasEmail or vcard:hasURL is a required for a contactpoint.</sch:title>
-    <sch:rule context="//dcat:contactPoint[$profile]">
+    <sch:rule context="//dcat:contactPoint">
       <sch:let name="hasEmail" value="normalize-space(vcard:Organization/vcard:hasEmail/@rdf:resource) != ''"/>
       <sch:let name="hasUrl" value="normalize-space(vcard:Organization/vcard:hasURL/@rdf:resource) != ''"/>
       <sch:assert test="$hasEmail or $hasUrl">A vcard:Organization does not have a vcard:hasEmail or a vcard:hasURL property.</sch:assert>
@@ -44,7 +43,7 @@
   </sch:pattern>
   <sch:pattern name="naam" id="https://data.vlaanderen.be/shacl/metadata_dcat#AgentShape/1399bd400d4637b15d5fe38202d6572f82150aac">
     <sch:title>v901. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Agent%3Anaam)</sch:title>
-    <sch:rule context="//foaf:Agent/foaf:name[$profile]">
+    <sch:rule context="//foaf:Agent/foaf:name">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van naam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (foaf:name)</sch:assert>
@@ -53,7 +52,7 @@
   </sch:pattern>
   <sch:pattern name="naam" id="https://data.vlaanderen.be/shacl/metadata_dcat#AgentShape/b96a7391d2808d207ce4e3c269dec2c6efad55c3">
     <sch:title>v212. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Agent%3Anaam)</sch:title>
-    <sch:rule context="//foaf:Agent/foaf:name[$profile]">
+    <sch:rule context="//foaf:Agent/foaf:name">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::foaf:name[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor naam (foaf:name)</sch:assert>
@@ -62,7 +61,7 @@
   </sch:pattern>
   <sch:pattern name="naam" id="https://data.vlaanderen.be/shacl/metadata_dcat#AgentShape/e9d8e42e8041e72c4534134d5a9044b03bed7ec5">
     <sch:title>v000. Naam - De naam van de agent. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Agent%3Anaam)</sch:title>
-    <sch:rule context="//foaf:Agent[$profile]">
+    <sch:rule context="//foaf:Agent">
       <sch:let name="validMin" value="count(foaf:name) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor naam (foaf:name)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor naam (foaf:name)</sch:report>
@@ -70,7 +69,7 @@
   </sch:pattern>
   <sch:pattern name="bounding box" id="https://data.vlaanderen.be/shacl/metadata_dcat#PlaatsShape/02f937f793dda13f6197e578a4f0f2ee6c9a5570">
     <sch:title>Bounding box - de afgrenzing van een plaats als een geografische rechthoek (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Plaats%3Abounding%20box)</sch:title>
-    <sch:rule context="//dct:Location/dcat:bbox[$profile]">
+    <sch:rule context="//dct:Location/dcat:bbox">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van bounding box moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dcat:bbox)</sch:assert>
       <sch:report test="$isLiteral">De range van bounding box moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dcat:bbox)</sch:report>
@@ -78,7 +77,7 @@
   </sch:pattern>
   <sch:pattern name="centroïde" id="https://data.vlaanderen.be/shacl/metadata_dcat#PlaatsShape/2545f2b443edf700f1be24a7ac0d790faddfc7d3">
     <sch:title>Centroïde - het geografische middelpunt van een plaats (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Plaats%3Acentro%C3%AFde)</sch:title>
-    <sch:rule context="//dct:Location/dcat:centroid[$profile]">
+    <sch:rule context="//dct:Location/dcat:centroid">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van centroïde moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dcat:centroid)</sch:assert>
       <sch:report test="$isLiteral">De range van centroïde moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dcat:centroid)</sch:report>
@@ -86,7 +85,7 @@
   </sch:pattern>
   <sch:pattern name="geometrie" id="https://data.vlaanderen.be/shacl/metadata_dcat#PlaatsShape/722a1f18cabb107c684fe4ca857876ade00b0d01">
     <sch:title>Geometrie - de geografische beschrijving van een plaats (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Plaats%3Ageometrie)</sch:title>
-    <sch:rule context="//dct:Location/locn:geometry[$profile]">
+    <sch:rule context="//dct:Location/locn:geometry">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van geometrie moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (locn:geometry)</sch:assert>
       <sch:report test="$isLiteral">De range van geometrie moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (locn:geometry)</sch:report>
@@ -94,7 +93,7 @@
   </sch:pattern>
   <sch:pattern name="plaatsnaam" id="https://data.vlaanderen.be/shacl/metadata_dcat#PlaatsShape/3562937fd68e5b9b91210d2e17383e28b6a7a53b">
     <sch:title>Plaatsnaam - een eenduidige, beknopte beschrijving die de plaats benoemt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Plaats%3Aplaatsnaam)</sch:title>
-    <sch:rule context="//dct:Location/rdfs:label[$profile]">
+    <sch:rule context="//dct:Location/rdfs:label">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van plaatsnaam moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (rdfs:label)</sch:assert>
@@ -103,7 +102,7 @@
   </sch:pattern>
   <sch:pattern name="plaatsnaam" id="https://data.vlaanderen.be/shacl/metadata_dcat#PlaatsShape/eb63b1d3337e467fc4c15bc345f46548d91d7d37">
     <sch:title>Plaatsnaam - een eenduidige, beknopte beschrijving die de plaats benoemt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Plaats%3Aplaatsnaam)</sch:title>
-    <sch:rule context="//dct:Location/rdfs:label[$profile]">
+    <sch:rule context="//dct:Location/rdfs:label">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::rdfs:label[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor plaatsnaam (rdfs:label)</sch:assert>
@@ -113,7 +112,7 @@
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/0e9a7d4dbf6ec19568d474169ad717f71e882319">
     <sch:title>Beschrijving - Een bondige tekstuele omschrijving van de
 standaard (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Abeschrijving)</sch:title>
-    <sch:rule context="//dct:Standard/dct:description[$profile]">
+    <sch:rule context="//dct:Standard/dct:description">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</sch:assert>
@@ -123,7 +122,7 @@ standaard (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkend
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/da05d674f29a225a7115411e9f7ca442a25f2c88">
     <sch:title>Beschrijving - Een bondige tekstuele omschrijving van de
 standaard (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Abeschrijving)</sch:title>
-    <sch:rule context="//dct:Standard/dct:description[$profile]">
+    <sch:rule context="//dct:Standard/dct:description">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:description[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</sch:assert>
@@ -133,7 +132,7 @@ standaard (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkend
   <sch:pattern name="publicatiedatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/0e54e6660eb6bc0ea08ebfce3dbbf188c3e400d8">
     <sch:title>Publicatiedatum - De datum waarop de standaard werd
 gepubliceerd (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Apublicatiedatum)</sch:title>
-    <sch:rule context="//dct:Standard/dct:issued[$profile]">
+    <sch:rule context="//dct:Standard/dct:issued">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
       <sch:assert test="$isNotEmpty and $isDate">De range van publicatiedatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</sch:assert>
@@ -143,7 +142,7 @@ gepubliceerd (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erk
   <sch:pattern name="publicatiedatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/fe9c62143da275c7458e0e71dedeb277670a016b">
     <sch:title>Publicatiedatum - De datum waarop de standaard werd
 gepubliceerd (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Apublicatiedatum)</sch:title>
-    <sch:rule context="//dct:Standard[$profile]">
+    <sch:rule context="//dct:Standard">
       <sch:let name="validMax" value="count(dct:issued) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor publicatiedatum (dct:issued)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor publicatiedatum (dct:issued)</sch:report>
@@ -152,7 +151,7 @@ gepubliceerd (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erk
   <sch:pattern name="specificatie URL" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/817c38a73348ef5623204d13efbf44e68a4612e8">
     <sch:title>Specificatie url - Een URL waarop men de specificatie kan
 vinden (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Aspecificatie%20URL)</sch:title>
-    <sch:rule context="//dct:Standard/rdfs:seeAlso[$profile]">
+    <sch:rule context="//dct:Standard/rdfs:seeAlso">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van specificatie URL moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (rdfs:seeAlso)</sch:assert>
@@ -162,7 +161,7 @@ vinden (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   <sch:pattern name="specificatie URL" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/db7c74598f8807ba1cfdb8f62f771fb27d4dbbe7">
     <sch:title>Specificatie url - Een URL waarop men de specificatie kan
 vinden (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Aspecificatie%20URL)</sch:title>
-    <sch:rule context="//dct:Standard[$profile]">
+    <sch:rule context="//dct:Standard">
       <sch:let name="validMax" value="count(rdfs:seeAlso) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor specificatie URL (rdfs:seeAlso)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor specificatie URL (rdfs:seeAlso)</sch:report>
@@ -170,7 +169,7 @@ vinden (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/8041fe094c27b123422bd03a4e13ff0641087607">
     <sch:title>Titel - naam van de standaard (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Atitel)</sch:title>
-    <sch:rule context="//dct:Standard/dct:title[$profile]">
+    <sch:rule context="//dct:Standard/dct:title">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:title[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:assert>
@@ -179,7 +178,7 @@ vinden (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="type" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/322371a77364a50f049d46180f6192532eea26dc">
     <sch:title>Type - Een categorisatie van de standaard (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Atype)</sch:title>
-    <sch:rule context="//dct:Standard/dct:type[$profile]">
+    <sch:rule context="//dct:Standard/dct:type">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van type moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:type)</sch:assert>
@@ -188,7 +187,7 @@ vinden (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="versie" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/302090a90a5755780bc8fe09be4bcd29193cfd6d">
     <sch:title>Versie - De versie van de standaard (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Aversie)</sch:title>
-    <sch:rule context="//dct:Standard[$profile]">
+    <sch:rule context="//dct:Standard">
       <sch:let name="validMax" value="count(owl:versionInfo) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</sch:report>
@@ -196,7 +195,7 @@ vinden (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="versie" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/587f313308111b587d1bd2440a56622e64624864">
     <sch:title>Versie - De versie van de standaard (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Aversie)</sch:title>
-    <sch:rule context="//dct:Standard/owl:versionInfo[$profile]">
+    <sch:rule context="//dct:Standard/owl:versionInfo">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</sch:assert>
       <sch:report test="$isLiteral">De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</sch:report>
@@ -205,7 +204,7 @@ vinden (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   <sch:pattern name="voorkeurslabel" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/dec1490408b1bea457bc40436431406882288252">
     <sch:title>Voorkeurslabel - Een afkorting, of notatie waaronder de
 standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Avoorkeurslabel)</sch:title>
-    <sch:rule context="//dct:Standard[$profile]">
+    <sch:rule context="//dct:Standard">
       <sch:let name="validMax" value="count(skos:prefLabel) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor voorkeurslabel (skos:prefLabel)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor voorkeurslabel (skos:prefLabel)</sch:report>
@@ -214,7 +213,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   <sch:pattern name="voorkeurslabel" id="https://data.vlaanderen.be/shacl/metadata_dcat#StandaardShape/f8712dd0e04b5c6b79d939432a639019c7295c6f">
     <sch:title>Voorkeurslabel - Een afkorting, of notatie waaronder de
 standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Standaard%3Avoorkeurslabel)</sch:title>
-    <sch:rule context="//dct:Standard/skos:prefLabel[$profile]">
+    <sch:rule context="//dct:Standard/skos:prefLabel">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van voorkeurslabel moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (skos:prefLabel)</sch:assert>
       <sch:report test="$isLiteral">De range van voorkeurslabel moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (skos:prefLabel)</sch:report>
@@ -222,7 +221,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="contactpagina" id="https://data.vlaanderen.be/shacl/metadata_dcat#ContactinfoShape/0d43849949c290efe2f3d4ad1d010cdb7f0505bf">
     <sch:title>1001. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Contactinfo%3Acontactpagina)</sch:title>
-    <sch:rule context="//vcard:Organization/foaf:page[$profile]">
+    <sch:rule context="//vcard:Organization/foaf:page">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van contactpagina moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (foaf:page)</sch:assert>
@@ -231,7 +230,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="contactpagina" id="https://data.vlaanderen.be/shacl/metadata_dcat#ContactinfoShape/376ba2894840068d71059e7be03bfaf8995aee90">
     <sch:title>1002. Contactpagina - Een webpagina die ofwel toelaat om contact op te nemen (via b.v. een webformulier) of die informatie bevat hoe men contact kan opnemen. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Contactinfo%3Acontactpagina)</sch:title>
-    <sch:rule context="//vcard:Organization[$profile]">
+    <sch:rule context="//vcard:Organization">
       <sch:let name="validMax" value="count(foaf:page) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor contactpagina (foaf:page)</sch:report>
@@ -239,7 +238,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="e-mail" id="https://data.vlaanderen.be/shacl/metadata_dcat#ContactinfoShape/2cf221c2b6f9a619b0515c507ddd2bbb40fbb285">
     <sch:title>413. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Contactinfo%3Ae-mail)</sch:title>
-    <sch:rule context="//vcard:Organization/vcard:hasEmail[$profile]">
+    <sch:rule context="//vcard:Organization/vcard:hasEmail">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van e-mail moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (vcard:hasEmail)</sch:assert>
@@ -248,7 +247,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="e-mail" id="https://data.vlaanderen.be/shacl/metadata_dcat#ContactinfoShape/42ad698554950cda0098f1f04803fac8470af8ad">
     <sch:title>1004. E-mail - Het e-mailadres waarmee een gebruiker contact kan opnemen voor informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Contactinfo%3Ae-mail)</sch:title>
-    <sch:rule context="//vcard:Organization[$profile]">
+    <sch:rule context="//vcard:Organization">
       <sch:let name="validMax" value="count(vcard:hasEmail) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor e-mail (vcard:hasEmail)</sch:report>
@@ -256,7 +255,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="gestructureerde identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#IdentificatorShape/0e92d523a1837590188fbfddd2ab0d9f901bdcab">
     <sch:title>Gestructureerde identificator - Identificator vh object opgesplitst in zijn onderdelen. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Identificator%3Agestructureerde%20identificator)</sch:title>
-    <sch:rule context="//adms:Identifier/generiek:gestructureerdeIdentificator[$profile]">
+    <sch:rule context="//adms:Identifier/generiek:gestructureerdeIdentificator">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(generiek:GestructureerdeIdentificator) = 1 or count(//generiek:GestructureerdeIdentificator[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van gestructureerde identificator moet van het type &lt;https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator&gt; zijn. (generiek:gestructureerdeIdentificator)</sch:assert>
@@ -265,7 +264,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="gestructureerde identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#IdentificatorShape/6789412851c92fe5eb8479182507dd72e28ab811">
     <sch:title>Gestructureerde identificator - Identificator vh object opgesplitst in zijn onderdelen. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Identificator%3Agestructureerde%20identificator)</sch:title>
-    <sch:rule context="//adms:Identifier[$profile]">
+    <sch:rule context="//adms:Identifier">
       <sch:let name="validMax" value="count(generiek:gestructureerdeIdentificator) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor gestructureerde identificator (generiek:gestructureerdeIdentificator)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor gestructureerde identificator (generiek:gestructureerdeIdentificator)</sch:report>
@@ -273,7 +272,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="notatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#IdentificatorShape/71a444ee0ec5b354586504464e5c6bffb69d78c8">
     <sch:title>Notatie - String gebruikt om het object uniek te identificeren.  (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Identificator%3Anotatie)</sch:title>
-    <sch:rule context="//adms:Identifier/skos:notation[$profile]">
+    <sch:rule context="//adms:Identifier/skos:notation">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van notatie moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (skos:notation)</sch:assert>
       <sch:report test="$isLiteral">De range van notatie moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (skos:notation)</sch:report>
@@ -281,7 +280,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="notatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#IdentificatorShape/ccb2d543d17baa8b6b0ca2a42156eed6f23e3f6e">
     <sch:title>Notatie - String gebruikt om het object uniek te identificeren.  (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Identificator%3Anotatie)</sch:title>
-    <sch:rule context="//adms:Identifier[$profile]">
+    <sch:rule context="//adms:Identifier">
       <sch:let name="validMax" value="count(skos:notation) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor notatie (skos:notation)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor notatie (skos:notation)</sch:report>
@@ -289,7 +288,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="toegekend door" id="https://data.vlaanderen.be/shacl/metadata_dcat#IdentificatorShape/ed560feb860205e0339910c9b2942564c01b5e11">
     <sch:title>Toegekend door - Link naar de agent die de identificator heeft uitgegeven. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Identificator%3Atoegekend%20door)</sch:title>
-    <sch:rule context="//adms:Identifier/dct:creator[$profile]">
+    <sch:rule context="//adms:Identifier/dct:creator">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(foaf:Agent) = 1 or count(//foaf:Agent[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van toegekend door moet van het type &lt;http://xmlns.com/foaf/0.1/Agent&gt; zijn. (dct:creator)</sch:assert>
@@ -298,7 +297,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="toegekend door" id="https://data.vlaanderen.be/shacl/metadata_dcat#IdentificatorShape/f0a3fc099a35481d2891e1eac3a099feb6f942d8">
     <sch:title>Toegekend door - Link naar de agent die de identificator heeft uitgegeven. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Identificator%3Atoegekend%20door)</sch:title>
-    <sch:rule context="//adms:Identifier[$profile]">
+    <sch:rule context="//adms:Identifier">
       <sch:let name="validMax" value="count(dct:creator) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor toegekend door (dct:creator)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor toegekend door (dct:creator)</sch:report>
@@ -306,7 +305,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="toegekend door (String)" id="https://data.vlaanderen.be/shacl/metadata_dcat#IdentificatorShape/5f023c37e7d18ecf8aecd2bb45eae0a05687cd6f">
     <sch:title>Toegekend door (string) - Naam vd agent die de identificator heeft toegekend. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Identificator%3Atoegekend%20door%20(String))</sch:title>
-    <sch:rule context="//adms:Identifier/adms:schemaAgency[$profile]">
+    <sch:rule context="//adms:Identifier/adms:schemaAgency">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van toegekend door (String) moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (adms:schemaAgency)</sch:assert>
       <sch:report test="$isLiteral">De range van toegekend door (String) moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (adms:schemaAgency)</sch:report>
@@ -314,7 +313,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="toegekend door (String)" id="https://data.vlaanderen.be/shacl/metadata_dcat#IdentificatorShape/9f8532791e13c302ae6dcc70ef353c796f948c85">
     <sch:title>Toegekend door (string) - Naam vd agent die de identificator heeft toegekend. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Identificator%3Atoegekend%20door%20(String))</sch:title>
-    <sch:rule context="//adms:Identifier[$profile]">
+    <sch:rule context="//adms:Identifier">
       <sch:let name="validMax" value="count(adms:schemaAgency) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor toegekend door (String) (adms:schemaAgency)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor toegekend door (String) (adms:schemaAgency)</sch:report>
@@ -322,7 +321,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="toegekend op" id="https://data.vlaanderen.be/shacl/metadata_dcat#IdentificatorShape/0f275ebdc16f2be1bf67063a80faf4ccea40332b">
     <sch:title>Toegekend op - Tijdstip waarop de identificator werd uitgegeven. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Identificator%3Atoegekend%20op)</sch:title>
-    <sch:rule context="//adms:Identifier/dct:issued[$profile]">
+    <sch:rule context="//adms:Identifier/dct:issued">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
       <sch:assert test="$isNotEmpty and $isDate">De range van toegekend op moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</sch:assert>
@@ -331,7 +330,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="toegekend op" id="https://data.vlaanderen.be/shacl/metadata_dcat#IdentificatorShape/3b5973d35f612c133f22e9f710f65db63d861b6b">
     <sch:title>Toegekend op - Tijdstip waarop de identificator werd uitgegeven. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Identificator%3Atoegekend%20op)</sch:title>
-    <sch:rule context="//adms:Identifier[$profile]">
+    <sch:rule context="//adms:Identifier">
       <sch:let name="validMax" value="count(dct:issued) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor toegekend op (dct:issued)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor toegekend op (dct:issued)</sch:report>
@@ -339,7 +338,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="aanmaakdatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/73a4bdd8cd7b0472b3b38dc9f56b0f32b8239284">
     <sch:title>1201. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Aaanmaakdatum)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord/dct:issued[$profile]">
+    <sch:rule context="//dcat:CatalogRecord/dct:issued">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
       <sch:assert test="$isNotEmpty and $isDate">De range van aanmaakdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</sch:assert>
@@ -348,7 +347,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="aanmaakdatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/8172f8df2a73384c65fdb3332d8ee0c9ef574804">
     <sch:title>1202. Aanmaakdatum - De datum van (formele) opname van de bijbehorende dataset of dataservice in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Aaanmaakdatum)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord[$profile]">
+    <sch:rule context="//dcat:CatalogRecord">
       <sch:let name="validMax" value="count(dct:issued) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor aanmaakdatum (dct:issued)</sch:report>
@@ -356,7 +355,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="alternatieve identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/39607ae8317e4f99846f57f713d51b19528e5764">
     <sch:title>1204. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een record in de catalogus kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Aalternatieve%20identificator)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord/adms:identifier[$profile]">
+    <sch:rule context="//dcat:CatalogRecord/adms:identifier">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(adms:Identifier) = 1 or count(//adms:Identifier[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:assert>
@@ -365,7 +364,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="bron metadata record landingspagina" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/e7e0fa856a7a9fd5e0507143109ff56bbed15bc5">
     <sch:title>Bron metadata record landingspagina - Een webpagina in een menselijk leesbare vorm van de bron metadata record. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Abron%20metadata%20record%20landingspagina)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord/mdcat:landingpageVoorBronMetadata[$profile]">
+    <sch:rule context="//dcat:CatalogRecord/mdcat:landingpageVoorBronMetadata">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van bron metadata record landingspagina moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (mdcat:landingpageVoorBronMetadata)</sch:assert>
@@ -374,7 +373,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="bron metadatarecord" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/ac72a26a136d49612ab47e1ead54cb3ac0f9dcb3">
     <sch:title>Bron metadatarecord - De record in een andere catalogus waarvan deze record en de beschrijvingen van het bijhorende hoofdonderwerp van afgeleid zijn. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Abron%20metadatarecord)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord/dct:source[$profile]">
+    <sch:rule context="//dcat:CatalogRecord/dct:source">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van bron metadatarecord moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (dct:source)</sch:assert>
@@ -383,7 +382,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
   </sch:pattern>
   <sch:pattern name="bron metadatarecord" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/c779d25f1f0ba872826b725cf9254a3bec5a82ce">
     <sch:title>Bron metadatarecord - De record in een andere catalogus waarvan deze record en de beschrijvingen van het bijhorende hoofdonderwerp van afgeleid zijn. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Abron%20metadatarecord)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord[$profile]">
+    <sch:rule context="//dcat:CatalogRecord">
       <sch:let name="validMax" value="count(dct:source) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor bron metadatarecord (dct:source)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor bron metadatarecord (dct:source)</sch:report>
@@ -394,7 +393,7 @@ standaard bekend is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-
 regels het hoofdonderwerp waarnaar de
 Catalogus Record verwijst, beschreven
 wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Aconform)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord/dct:conformsTo[$profile]">
+    <sch:rule context="//dcat:CatalogRecord/dct:conformsTo">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:Standard) = 1 or count(//dct:Standard[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</sch:assert>
@@ -403,7 +402,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="hoofdonderwerp" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/2a7abc3b7d6df32e4a340775a9e1522a0ac1c669">
     <sch:title>1206. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Ahoofdonderwerp)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord[$profile]">
+    <sch:rule context="//dcat:CatalogRecord">
       <sch:let name="validMax" value="count(foaf:primaryTopic) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor hoofdonderwerp (foaf:primaryTopic)</sch:report>
@@ -411,7 +410,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="hoofdonderwerp" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/e7d5497a1597fc6c5856517ab46c01bae413001b">
     <sch:title>1208. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Ahoofdonderwerp)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord/foaf:primaryTopic[$profile]">
+    <sch:rule context="//dcat:CatalogRecord/foaf:primaryTopic">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dcat:Dataset|dcat:DataService) = 1 or count((//dcat:Dataset|//dcat:DataService)[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van hoofdonderwerp moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (foaf:primaryTopic)</sch:assert>
@@ -420,7 +419,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="hoofdonderwerp" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/f806d2d1fd264df77aee55564a0a70eecd47ee2e">
     <sch:title>1209. Hoofdonderwerp - De resource (dataset of dataservice) beschreven in het record. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Ahoofdonderwerp)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord[$profile]">
+    <sch:rule context="//dcat:CatalogRecord">
       <sch:let name="validMin" value="count(foaf:primaryTopic) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor hoofdonderwerp (foaf:primaryTopic)</sch:report>
@@ -428,7 +427,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/05134c4e7c34157d6f7ac1128713a08418e0fe7d">
     <sch:title>1210. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord/dct:identifier[$profile]">
+    <sch:rule context="//dcat:CatalogRecord/dct:identifier">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:assert>
       <sch:report test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:report>
@@ -436,7 +435,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/972d73e7a13100b66c0c2f44466edac47aa1ab28">
     <sch:title>1211. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord[$profile]">
+    <sch:rule context="//dcat:CatalogRecord">
       <sch:let name="validMin" value="count(dct:identifier) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:report>
@@ -444,7 +443,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/bb43a48c77e7d98609af3d3bb1b1648370465308">
     <sch:title>1212. Identificator - De unieke identificator van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord[$profile]">
+    <sch:rule context="//dcat:CatalogRecord">
       <sch:let name="validMax" value="count(dct:identifier) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:report>
@@ -452,7 +451,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/8041fe094c27b123422bd03a4e13ff0641087607">
     <sch:title>1216. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Atitel)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord/dct:title[$profile]">
+    <sch:rule context="//dcat:CatalogRecord/dct:title">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:title[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:assert>
@@ -461,7 +460,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/f28ce523c4b4fcb15d8c7d4f279da195ba7403ab">
     <sch:title>1217. Titel - De naam van het record in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Atitel)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord/dct:title[$profile]">
+    <sch:rule context="//dcat:CatalogRecord/dct:title">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:assert>
@@ -470,7 +469,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="wijzigingsdatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/29906bf16cadf6d568c4da3e161ef38ba2f726fd">
     <sch:title>1218. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Awijzigingsdatum)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord[$profile]">
+    <sch:rule context="//dcat:CatalogRecord">
       <sch:let name="validMax" value="count(dct:modified) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</sch:report>
@@ -478,7 +477,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="wijzigingsdatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/6a51b2354ea38a815d6131b4e05f8587791de4e0">
     <sch:title>1219. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Awijzigingsdatum)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord[$profile]">
+    <sch:rule context="//dcat:CatalogRecord">
       <sch:let name="validMin" value="count(dct:modified) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor wijzigingsdatum (dct:modified)</sch:report>
@@ -486,7 +485,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="wijzigingsdatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusRecordShape/9e7585433d0896bc44cb41cdd8189793bd115cd0">
     <sch:title>1220. Wijzigingsdatum - De meest recente datum waarop de record in de catalogus is gewijzigd, bijgewerkt of aangepast. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusRecord%3Awijzigingsdatum)</sch:title>
-    <sch:rule context="//dcat:CatalogRecord/dct:modified[$profile]">
+    <sch:rule context="//dcat:CatalogRecord/dct:modified">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
       <sch:assert test="$isNotEmpty and $isDate">De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</sch:assert>
@@ -495,7 +494,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="alternatieve identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/39607ae8317e4f99846f57f713d51b19528e5764">
     <sch:title>1301. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een dataservice kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aalternatieve%20identificator)</sch:title>
-    <sch:rule context="//dcat:DataService/adms:identifier[$profile]">
+    <sch:rule context="//dcat:DataService/adms:identifier">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(adms:Identifier) = 1 or count(//adms:Identifier[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:assert>
@@ -504,7 +503,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/0e9a7d4dbf6ec19568d474169ad717f71e882319">
     <sch:title>1303. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Abeschrijving)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:description[$profile]">
+    <sch:rule context="//dcat:DataService/dct:description">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</sch:assert>
@@ -513,7 +512,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/da05d674f29a225a7115411e9f7ca442a25f2c88">
     <sch:title>1306. Beschrijving - Een bondige tekstuele omschrijving van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Abeschrijving)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:description[$profile]">
+    <sch:rule context="//dcat:DataService/dct:description">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:description[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</sch:assert>
@@ -522,7 +521,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="biedt informatie aan over" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/5ed2c890f2c7588313cc9f93b35524bdb2d6328d">
     <sch:title>1308. Biedt informatie aan over - De data die via deze dataservice worden aangeboden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Abiedt%20informatie%20aan%20over)</sch:title>
-    <sch:rule context="//dcat:DataService/dcat:servesdataset[$profile]">
+    <sch:rule context="//dcat:DataService/dcat:servesdataset">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van biedt informatie aan over moet van het type &lt;http://www.w3.org/ns/dcat#Dataset&gt; zijn. (dcat:servesdataset)</sch:assert>
@@ -531,7 +530,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="conform aan protocol" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/80a839685f13d2584ebe2f9b5d9a93ae2c1b21a0">
     <sch:title>1309. Conform aan protocol - Een protocol waaraan de dataservice voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aconform%20aan%20protocol)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:conformsTo[$profile]">
+    <sch:rule context="//dcat:DataService/dct:conformsTo">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:Standard) = 1 or count(//dct:Standard[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van conform aan protocol moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</sch:assert>
@@ -540,7 +539,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/19ee039173472235e539aea2aa961ff7d3b89f5a">
     <sch:title>1312. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Acontactinformatie)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(dcat:contactPoint) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</sch:report>
@@ -548,7 +547,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/458062b0ae03c559426b85df3dd28e1c785acb0b">
     <sch:title>1313. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Acontactinformatie)</sch:title>
-    <sch:rule context="//dcat:DataService/dcat:contactPoint[$profile]">
+    <sch:rule context="//dcat:DataService/dcat:contactPoint">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(vcard:Organization) = 1 or count(//vcard:Organization[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</sch:assert>
@@ -557,7 +556,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/e332dbce5947de4314c3ed3fe5862f26d70a15c4">
     <sch:title>1314. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Acontactinformatie)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMin" value="count(dcat:contactPoint) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</sch:report>
@@ -565,7 +564,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="creatiedatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/6b0d5813153da700505d795c17d681878225c6d1">
     <sch:title>Creatiedatum - Het tijdsmoment waarop de dataservice voor het eerst werd geactiveerd. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Acreatiedatum)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(dct:created) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor creatiedatum (dct:created)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor creatiedatum (dct:created)</sch:report>
@@ -573,7 +572,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="creatiedatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/a0b7156be408a447d937582d4d0c3cafea754f8b">
     <sch:title>Creatiedatum - Het tijdsmoment waarop de dataservice voor het eerst werd geactiveerd. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Acreatiedatum)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:created[$profile]">
+    <sch:rule context="//dcat:DataService/dct:created">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
       <sch:assert test="$isNotEmpty and $isDate">De range van creatiedatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:created)</sch:assert>
@@ -582,7 +581,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="endpointURL" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/67c89165b0f38567bf099862ffdef88f25e68714">
     <sch:title>1315. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3AendpointURL)</sch:title>
-    <sch:rule context="//dcat:DataService/dcat:endpointURL[$profile]">
+    <sch:rule context="//dcat:DataService/dcat:endpointURL">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van endpointURL moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (dcat:endpointURL)</sch:assert>
@@ -591,7 +590,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="endpointURL" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/9978564bd5823785ddace8934e848c68e6e813e3">
     <sch:title>1317. Endpointurl - De rootlocatie of het primaire endpoint van de dienst (een web-resolvable URI). (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3AendpointURL)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(dcat:endpointURL) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor endpointURL (dcat:endpointURL)</sch:report>
@@ -599,7 +598,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="endpointbeschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/66883b2795f003760d4bb617bd1f472da1e1524f">
     <sch:title>1319. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aendpointbeschrijving)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(dcat:endpointDescription) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor endpointbeschrijving (dcat:endpointDescription)</sch:report>
@@ -607,7 +606,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="endpointbeschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/bd44e3e6c4317f226cd1124fbaf1d72e94e8f15e">
     <sch:title>1320. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aendpointbeschrijving)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMin" value="count(dcat:endpointDescription) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor endpointbeschrijving (dcat:endpointDescription)</sch:report>
@@ -615,7 +614,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="endpointbeschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/dbc2548616486a154002cfba6a3bc2cbc554a682">
     <sch:title>1321. Endpointbeschrijving - Een beschrijving van de diensten die beschikbaar zijn via de end-points, met inbegrip van hun operaties, parameters, enz. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aendpointbeschrijving)</sch:title>
-    <sch:rule context="//dcat:DataService/dcat:endpointDescription[$profile]">
+    <sch:rule context="//dcat:DataService/dcat:endpointDescription">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van endpointbeschrijving moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:endpointDescription)</sch:assert>
@@ -624,7 +623,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/05134c4e7c34157d6f7ac1128713a08418e0fe7d">
     <sch:title>1322. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:identifier[$profile]">
+    <sch:rule context="//dcat:DataService/dct:identifier">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:assert>
       <sch:report test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:report>
@@ -632,7 +631,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/972d73e7a13100b66c0c2f44466edac47aa1ab28">
     <sch:title>1323. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMin" value="count(dct:identifier) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:report>
@@ -640,7 +639,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/bb43a48c77e7d98609af3d3bb1b1648370465308">
     <sch:title>1324. Identificator - De unieke identificator van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(dct:identifier) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:report>
@@ -648,7 +647,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="landingspagina" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/fe1a78c9169da2469a23fd783cf9a69060bfe198">
     <sch:title>1327. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene aanvullende informatie over de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alandingspagina)</sch:title>
-    <sch:rule context="//dcat:DataService/dcat:landingPage[$profile]">
+    <sch:rule context="//dcat:DataService/dcat:landingPage">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van landingspagina moet van het type &lt;http://www.w3.org/2001/XMLSchema#anyURI&gt; zijn. (dcat:landingPage)</sch:assert>
@@ -657,7 +656,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="landingspagina voor authenticatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/2be8f764879c3f2218306704a430503d286c30e9">
     <sch:title>1328. Landingspagina voor authenticatie - Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alandingspagina%20voor%20authenticatie)</sch:title>
-    <sch:rule context="//dcat:DataService/mdcat:landingspaginaVoorAuthenticatie[$profile]">
+    <sch:rule context="//dcat:DataService/mdcat:landingspaginaVoorAuthenticatie">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van landingspagina voor authenticatie moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (mdcat:landingspaginaVoorAuthenticatie)</sch:assert>
@@ -666,7 +665,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="landingspagina voor authenticatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/e9bf439f5272396af4486645c4dd4ae47c27c030">
     <sch:title>1330. Landingspagina voor authenticatie - Een verwijzing naar de landingspagina met de specifieke informatie over de authenticatie voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alandingspagina%20voor%20authenticatie)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(mdcat:landingspaginaVoorAuthenticatie) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor authenticatie (mdcat:landingspaginaVoorAuthenticatie)</sch:report>
@@ -674,7 +673,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="landingspagina voor gebruiksinformatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/b643cb8952d752ef63a2b25c7fcebd89d08fb015">
     <sch:title>1332. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(mdcat:landingspaginaVoorGebruiksinformatie) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor gebruiksinformatie (mdcat:landingspaginaVoorGebruiksinformatie)</sch:report>
@@ -682,7 +681,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="landingspagina voor gebruiksinformatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/c4eb7e771a95c6c3e5c04255458173a2b0b40f43">
     <sch:title>1333. Landingspagina voor gebruiksinformatie - Een verwijzing naar de landingspagina met de specifieke informatie over het gebruik van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alandingspagina%20voor%20gebruiksinformatie)</sch:title>
-    <sch:rule context="//dcat:DataService/mdcat:landingspaginaVoorGebruiksinformatie[$profile]">
+    <sch:rule context="//dcat:DataService/mdcat:landingspaginaVoorGebruiksinformatie">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van landingspagina voor gebruiksinformatie moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (mdcat:landingspaginaVoorGebruiksinformatie)</sch:assert>
@@ -691,7 +690,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="landingspagina voor statusinformatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/0cdcfe2387440711ebbe94a2fcc93a29377956c5">
     <sch:title>1334. Landingspagina voor statusinformatie - Een verwijzing naar de statuspagina van de dataservice (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alandingspagina%20voor%20statusinformatie)</sch:title>
-    <sch:rule context="//dcat:DataService/mdcat:landingspaginaVoorStatusinformatie[$profile]">
+    <sch:rule context="//dcat:DataService/mdcat:landingspaginaVoorStatusinformatie">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van landingspagina voor statusinformatie moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (mdcat:landingspaginaVoorStatusinformatie)</sch:assert>
@@ -700,7 +699,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="landingspagina voor statusinformatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/82e4f4e38a285ebeffb0f14c036b491b71a26200">
     <sch:title>1336. Landingspagina voor statusinformatie - Een verwijzing naar de statuspagina van de dataservice (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alandingspagina%20voor%20statusinformatie)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(mdcat:landingspaginaVoorStatusinformatie) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor landingspagina voor statusinformatie (mdcat:landingspaginaVoorStatusinformatie)</sch:report>
@@ -708,7 +707,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="levensfase" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/13afabc6c35a0042403bd3a9f50222200152231a">
     <sch:title>1338. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alevensfase)</sch:title>
-    <sch:rule context="//dcat:DataService/mdcat:levensfase[$profile]">
+    <sch:rule context="//dcat:DataService/mdcat:levensfase">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van levensfase moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:levensfase)</sch:assert>
@@ -717,7 +716,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="levensfase" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/8a32a3e6b5ca4b68f8846b184e7faa4f48a0ee1d">
     <sch:title>1340. Levensfase - De levensfase waarin de dataservice zich bevindt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alevensfase)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(mdcat:levensfase) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor levensfase (mdcat:levensfase)</sch:report>
@@ -725,7 +724,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="licentie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/509740cc7b3c86ebee90dc6303c11c40e2b08212">
     <sch:title>1341. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alicentie)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:license[$profile]">
+    <sch:rule context="//dcat:DataService/dct:license">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:LicenseDocument) = 1 or count(//dct:LicenseDocument[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</sch:assert>
@@ -734,7 +733,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="licentie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/cafd2e3e66044d8ba2c435a9353e6880952086c5">
     <sch:title>1343. Licentie - De licentie van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Alicentie)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(dct:license) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor licentie (dct:license)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor licentie (dct:license)</sch:report>
@@ -742,7 +741,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="ontwikkelingstoestand" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/4523d6e75f8993d15c9332b0aae5dbbe64a85b5a">
     <sch:title>1345. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aontwikkelingstoestand)</sch:title>
-    <sch:rule context="//dcat:DataService/mdcat:ontwikkelingstoestand[$profile]">
+    <sch:rule context="//dcat:DataService/mdcat:ontwikkelingstoestand">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van ontwikkelingstoestand moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:ontwikkelingstoestand)</sch:assert>
@@ -751,7 +750,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="ontwikkelingstoestand" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/76f6cfca9a1964a539a879c911777c741a37cff0">
     <sch:title>1346. Ontwikkelingstoestand - De ontwikkelingstoestand waarin de dataservice is gedeployed. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aontwikkelingstoestand)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(mdcat:ontwikkelingstoestand) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor ontwikkelingstoestand (mdcat:ontwikkelingstoestand)</sch:report>
@@ -759,7 +758,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="publicatiedatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/0e54e6660eb6bc0ea08ebfce3dbbf188c3e400d8">
     <sch:title>Publicatiedatum - Het tijdsmoment waarop de service werd gepubliceerd door de uitgever. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Apublicatiedatum)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:issued[$profile]">
+    <sch:rule context="//dcat:DataService/dct:issued">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
       <sch:assert test="$isNotEmpty and $isDate">De range van publicatiedatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</sch:assert>
@@ -768,7 +767,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="publicatiedatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/fe9c62143da275c7458e0e71dedeb277670a016b">
     <sch:title>Publicatiedatum - Het tijdsmoment waarop de service werd gepubliceerd door de uitgever. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Apublicatiedatum)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(dct:issued) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor publicatiedatum (dct:issued)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor publicatiedatum (dct:issued)</sch:report>
@@ -776,7 +775,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="rechten" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/62bb7a143add01ac0956709b58850f4f5e5a0e47">
     <sch:title>1349. Rechten - Bepalingen van juridische aard die gelden op de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Arechten)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:rights[$profile]">
+    <sch:rule context="//dcat:DataService/dct:rights">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:RightsStatement) = 1 or count(//dct:RightsStatement[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</sch:assert>
@@ -785,7 +784,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="statuut" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/f96c5f798f9e9c00220a293bd11f37e83616d33b">
     <sch:title>Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Astatuut)</sch:title>
-    <sch:rule context="//dcat:DataService/mdcat:statuut[$profile]">
+    <sch:rule context="//dcat:DataService/mdcat:statuut">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</sch:assert>
@@ -794,7 +793,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="thema" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/1712ef1b325d7d2807bc601d6409b70a42eaff10">
     <sch:title>1351. Thema - De hoofdcategorie waartoe de dataservice behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Athema)</sch:title>
-    <sch:rule context="//dcat:DataService/dcat:theme[$profile]">
+    <sch:rule context="//dcat:DataService/dcat:theme">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</sch:assert>
@@ -803,7 +802,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/25d18a6e2598024ea186cc7be4391bdfd1bca21f">
     <sch:title>1354. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Atitel)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMin" value="count(dct:title) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor titel (dct:title)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor titel (dct:title)</sch:report>
@@ -811,7 +810,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/8041fe094c27b123422bd03a4e13ff0641087607">
     <sch:title>1357. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Atitel)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:title[$profile]">
+    <sch:rule context="//dcat:DataService/dct:title">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:title[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:assert>
@@ -820,7 +819,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/f28ce523c4b4fcb15d8c7d4f279da195ba7403ab">
     <sch:title>1358. Titel - De naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Atitel)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:title[$profile]">
+    <sch:rule context="//dcat:DataService/dct:title">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:assert>
@@ -829,7 +828,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/7463895a2bb9e7e4c96cd9a2e7f83ce2cf787098">
     <sch:title>1360. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Atoegankelijkheid)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMin" value="count(dct:accessRights) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</sch:report>
@@ -837,7 +836,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/a81035a5dbbdae24651c34e5602a1fe6fe5427a3">
     <sch:title>1361. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Atoegankelijkheid)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:accessRights[$profile]">
+    <sch:rule context="//dcat:DataService/dct:accessRights">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</sch:assert>
@@ -846,7 +845,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/f9524ba86e28981345a2b84aea788460ad4e805e">
     <sch:title>1363. Toegankelijkheid - De toegankelijkheid voor de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Atoegankelijkheid)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(dct:accessRights) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</sch:report>
@@ -854,7 +853,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="trefwoord" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/1b8b3557ea1ccbabc0962c345782ae53740e72e1">
     <sch:title>1364. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Atrefwoord)</sch:title>
-    <sch:rule context="//dcat:DataService/dcat:keyword[$profile]">
+    <sch:rule context="//dcat:DataService/dcat:keyword">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dcat:keyword[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor trefwoord (dcat:keyword)</sch:assert>
@@ -863,7 +862,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="trefwoord" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/44f6426e2306c5bc0421823eb4a1a034b615f715">
     <sch:title>1365. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Atrefwoord)</sch:title>
-    <sch:rule context="//dcat:DataService/dcat:keyword[$profile]">
+    <sch:rule context="//dcat:DataService/dcat:keyword">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</sch:assert>
@@ -872,7 +871,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="versie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/302090a90a5755780bc8fe09be4bcd29193cfd6d">
     <sch:title>1667. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aversie)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(owl:versionInfo) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</sch:report>
@@ -880,7 +879,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="versie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/587f313308111b587d1bd2440a56622e64624864">
     <sch:title>1668. Versie - Een unieke aanduiding van een variant van de dataservice door middel van een versienummer of -naam van de dataservice. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Aversie)</sch:title>
-    <sch:rule context="//dcat:DataService/owl:versionInfo[$profile]">
+    <sch:rule context="//dcat:DataService/owl:versionInfo">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</sch:assert>
       <sch:report test="$isLiteral">De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</sch:report>
@@ -888,7 +887,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="wijzigingsdatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/29906bf16cadf6d568c4da3e161ef38ba2f726fd">
     <sch:title>Wijzigingsdatum - Het tijdsmoment waarop de dataservice werd gewijzigd (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Awijzigingsdatum)</sch:title>
-    <sch:rule context="//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:DataService">
       <sch:let name="validMax" value="count(dct:modified) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</sch:report>
@@ -896,7 +895,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="wijzigingsdatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DataServiceShape/9e7585433d0896bc44cb41cdd8189793bd115cd0">
     <sch:title>Wijzigingsdatum - Het tijdsmoment waarop de dataservice werd gewijzigd (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#DataService%3Awijzigingsdatum)</sch:title>
-    <sch:rule context="//dcat:DataService/dct:modified[$profile]">
+    <sch:rule context="//dcat:DataService/dct:modified">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
       <sch:assert test="$isNotEmpty and $isDate">De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</sch:assert>
@@ -905,7 +904,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="alternatieve identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/39607ae8317e4f99846f57f713d51b19528e5764">
     <sch:title>v067. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een dataset kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Aalternatieve%20identificator)</sch:title>
-    <sch:rule context="//dcat:Dataset/adms:identifier[$profile]">
+    <sch:rule context="//dcat:Dataset/adms:identifier">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(adms:Identifier) = 1 or count(//adms:Identifier[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:assert>
@@ -914,7 +913,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/0e9a7d4dbf6ec19568d474169ad717f71e882319">
     <sch:title>v207. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Abeschrijving)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:description[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:description">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</sch:assert>
@@ -923,7 +922,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/7521953addc62cf367ab3c8ec0dc63cb5981ea23">
     <sch:title>v037. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Abeschrijving)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMin" value="count(dct:description) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor beschrijving (dct:description)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor beschrijving (dct:description)</sch:report>
@@ -931,7 +930,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/da05d674f29a225a7115411e9f7ca442a25f2c88">
     <sch:title>v215. Beschrijving - Een bondige tekstuele omschrijving van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Abeschrijving)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:description[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:description">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:description[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</sch:assert>
@@ -940,7 +939,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="conform" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/dd5cf5b162b3f92600a391f44660bf2b255693ac">
     <sch:title>v056. Conform - Een standaard, schema, applicatieprofiel, vocabularium, CRS, ... waaraan de dataset voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Aconform)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:conformsTo[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:conformsTo">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:Standard) = 1 or count(//dct:Standard[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</sch:assert>
@@ -949,7 +948,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/19ee039173472235e539aea2aa961ff7d3b89f5a">
     <sch:title>1705. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Acontactinformatie)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMax" value="count(dcat:contactPoint) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor contactinformatie (dcat:contactPoint)</sch:report>
@@ -957,7 +956,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/458062b0ae03c559426b85df3dd28e1c785acb0b">
     <sch:title>1406. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Acontactinformatie)</sch:title>
-    <sch:rule context="//dcat:Dataset/dcat:contactPoint[$profile]">
+    <sch:rule context="//dcat:Dataset/dcat:contactPoint">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(vcard:Organization) = 1 or count(//vcard:Organization[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van contactinformatie moet van het type &lt;http://www.w3.org/2006/vcard/ns#Kind&gt; zijn. (dcat:contactPoint)</sch:assert>
@@ -966,7 +965,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="contactinformatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/e332dbce5947de4314c3ed3fe5862f26d70a15c4">
     <sch:title>v041. Contactinformatie - De relevante contactinformatie waarmee een eindgebruiker in contact kan treden met de verantwoordelijken van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Acontactinformatie)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMin" value="count(dcat:contactPoint) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor contactinformatie (dcat:contactPoint)</sch:report>
@@ -974,7 +973,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="creatiedatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/6b0d5813153da700505d795c17d681878225c6d1">
     <sch:title>Creatiedatum - Het tijdsmoment waarop de dataset ontstaan is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Acreatiedatum)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMax" value="count(dct:created) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor creatiedatum (dct:created)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor creatiedatum (dct:created)</sch:report>
@@ -982,7 +981,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="creatiedatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/a0b7156be408a447d937582d4d0c3cafea754f8b">
     <sch:title>Creatiedatum - Het tijdsmoment waarop de dataset ontstaan is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Acreatiedatum)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:created[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:created">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
       <sch:assert test="$isNotEmpty and $isDate">De range van creatiedatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:created)</sch:assert>
@@ -991,7 +990,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="distributie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/cfbe0a11423fe15e990c3cbd5209404c26dbef0f">
     <sch:title>v046. Distributie - Een beschikbare distributie van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Adistributie)</sch:title>
-    <sch:rule context="//dcat:Dataset/dcat:distribution[$profile]">
+    <sch:rule context="//dcat:Dataset/dcat:distribution">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dcat:Distribution) = 1 or count(//dcat:Distribution[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van distributie moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (dcat:distribution)</sch:assert>
@@ -1000,7 +999,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="eigenaar" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/0addb769185db828aa4c44888f0aa906471c3d06">
     <sch:title>Eigenaar - de agent die de eigendomsrechten heeft (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Aeigenaar)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:rightsHolder[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:rightsHolder">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(foaf:Agent) = 1 or count(//foaf:Agent[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van eigenaar moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:rightsHolder)</sch:assert>
@@ -1009,7 +1008,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="geografische dekking" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/883b5dc28b6bef2ce82b138ead1eb3c7f2073b92">
     <sch:title>Geografische dekking - Het geografische gebied waarover de dataset informatie heeft. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Ageografische%20dekking)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:spatial[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:spatial">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:Location) = 1 or count(//dct:Location[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van geografische dekking moet van het type &lt;http://purl.org/dc/terms/Location&gt; zijn. (dct:spatial)</sch:assert>
@@ -1018,7 +1017,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="herkomst" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/7f7729e4df614394423f92badbe4304148f90b07">
     <sch:title>Herkomst - De ontstaansgeschiedenis van een dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Aherkomst)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:provenance[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:provenance">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:ProvenanceStatement) = 1 or count(//dct:ProvenanceStatement[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van herkomst moet van het type &lt;http://purl.org/dc/terms/ProvenanceStatement&gt; zijn. (dct:provenance)</sch:assert>
@@ -1027,7 +1026,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/05134c4e7c34157d6f7ac1128713a08418e0fe7d">
     <sch:title>v060. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:identifier[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:identifier">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:assert>
       <sch:report test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:report>
@@ -1035,7 +1034,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/972d73e7a13100b66c0c2f44466edac47aa1ab28">
     <sch:title>1708. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMin" value="count(dct:identifier) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:report>
@@ -1043,7 +1042,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/bb43a48c77e7d98609af3d3bb1b1648370465308">
     <sch:title>1409. Identificator - De unieke identificator van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMax" value="count(dct:identifier) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:report>
@@ -1051,7 +1050,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="landingspagina" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/fe1a78c9169da2469a23fd783cf9a69060bfe198">
     <sch:title>1712. Landingspagina - Een algemene webpagina waarnaar kan worden genavigeerd in een webbrowser, met algemene informatie over de dataset, zijn distributies en/of aanvullende informatie. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Alandingspagina)</sch:title>
-    <sch:rule context="//dcat:Dataset/dcat:landingPage[$profile]">
+    <sch:rule context="//dcat:Dataset/dcat:landingPage">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van landingspagina moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (dcat:landingPage)</sch:assert>
@@ -1060,7 +1059,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="publicatiedatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/0e54e6660eb6bc0ea08ebfce3dbbf188c3e400d8">
     <sch:title>Publicatiedatum - Het tijdsmoment waarop de dataset werd gepubliceerd door de uitgever. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Apublicatiedatum)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:issued[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:issued">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
       <sch:assert test="$isNotEmpty and $isDate">De range van publicatiedatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:issued)</sch:assert>
@@ -1069,7 +1068,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="publicatiedatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/fe9c62143da275c7458e0e71dedeb277670a016b">
     <sch:title>Publicatiedatum - Het tijdsmoment waarop de dataset werd gepubliceerd door de uitgever. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Apublicatiedatum)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMax" value="count(dct:issued) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor publicatiedatum (dct:issued)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor publicatiedatum (dct:issued)</sch:report>
@@ -1077,7 +1076,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="statuut" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/f96c5f798f9e9c00220a293bd11f37e83616d33b">
     <sch:title>Statuut - Een aanduiding van op welke basis de catalogusresource beschikbaar is. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Astatuut)</sch:title>
-    <sch:rule context="//dcat:Dataset/mdcat:statuut[$profile]">
+    <sch:rule context="//dcat:Dataset/mdcat:statuut">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van statuut moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (mdcat:statuut)</sch:assert>
@@ -1086,7 +1085,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="thema" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/1712ef1b325d7d2807bc601d6409b70a42eaff10">
     <sch:title>v115. Thema - De hoofdcategorie waartoe de dataset behoort. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Athema)</sch:title>
-    <sch:rule context="//dcat:Dataset/dcat:theme[$profile]">
+    <sch:rule context="//dcat:Dataset/dcat:theme">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van thema moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:theme)</sch:assert>
@@ -1095,7 +1094,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/25d18a6e2598024ea186cc7be4391bdfd1bca21f">
     <sch:title>v039. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Atitel)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMin" value="count(dct:title) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor titel (dct:title)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor titel (dct:title)</sch:report>
@@ -1103,7 +1102,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/8041fe094c27b123422bd03a4e13ff0641087607">
     <sch:title>v214. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Atitel)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:title[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:title">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:title[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:assert>
@@ -1112,7 +1111,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/f28ce523c4b4fcb15d8c7d4f279da195ba7403ab">
     <sch:title>v206. Titel - De naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Atitel)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:title[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:title">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:assert>
@@ -1121,7 +1120,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/7463895a2bb9e7e4c96cd9a2e7f83ce2cf787098">
     <sch:title>1716. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Atoegankelijkheid)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMin" value="count(dct:accessRights) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor toegankelijkheid (dct:accessRights)</sch:report>
@@ -1129,7 +1128,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/a81035a5dbbdae24651c34e5602a1fe6fe5427a3">
     <sch:title>1717. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Atoegankelijkheid)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:accessRights[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:accessRights">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van toegankelijkheid moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:accessRights)</sch:assert>
@@ -1138,7 +1137,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="toegankelijkheid" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/f9524ba86e28981345a2b84aea788460ad4e805e">
     <sch:title>v100. Toegankelijkheid - De toegankelijkheid voor de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Atoegankelijkheid)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMax" value="count(dct:accessRights) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor toegankelijkheid (dct:accessRights)</sch:report>
@@ -1146,7 +1145,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="trefwoord" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/1b8b3557ea1ccbabc0962c345782ae53740e72e1">
     <sch:title>1719. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Atrefwoord)</sch:title>
-    <sch:rule context="//dcat:Dataset/dcat:keyword[$profile]">
+    <sch:rule context="//dcat:Dataset/dcat:keyword">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dcat:keyword[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor trefwoord (dcat:keyword)</sch:assert>
@@ -1155,7 +1154,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="trefwoord" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/44f6426e2306c5bc0421823eb4a1a034b615f715">
     <sch:title>1720. Trefwoord - Een trefwoord of tag die de resource beschrijft. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Atrefwoord)</sch:title>
-    <sch:rule context="//dcat:Dataset/dcat:keyword[$profile]">
+    <sch:rule context="//dcat:Dataset/dcat:keyword">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van trefwoord moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dcat:keyword)</sch:assert>
@@ -1164,7 +1163,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="versie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/302090a90a5755780bc8fe09be4bcd29193cfd6d">
     <sch:title>v076. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Aversie)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMax" value="count(owl:versionInfo) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor versie (owl:versionInfo)</sch:report>
@@ -1172,7 +1171,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="versie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/587f313308111b587d1bd2440a56622e64624864">
     <sch:title>v075. Versie - Een unieke aanduiding van een variant van de dataset door middel van een versienummer of -naam van de dataset. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Aversie)</sch:title>
-    <sch:rule context="//dcat:Dataset/owl:versionInfo[$profile]">
+    <sch:rule context="//dcat:Dataset/owl:versionInfo">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</sch:assert>
       <sch:report test="$isLiteral">De range van versie moet van het type &lt;http://www.w3.org/2001/XMLSchema#string&gt; zijn. (owl:versionInfo)</sch:report>
@@ -1180,7 +1179,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="voorbeeldweergave" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/b797fd4af5bc2767e8e3a3799a5aae84ec998d04">
     <sch:title>Voorbeeldweergave - Een verkleinde weergave van een afbeelding die de dataset illustreert.? (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Avoorbeeldweergave)</sch:title>
-    <sch:rule context="//dcat:Dataset/adms:sample[$profile]">
+    <sch:rule context="//dcat:Dataset/adms:sample">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dcat:Distribution) = 1 or count(//dcat:Distribution[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van voorbeeldweergave moet van het type &lt;http://www.w3.org/ns/dcat#Distribution&gt; zijn. (adms:sample)</sch:assert>
@@ -1189,7 +1188,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="wijzigingsdatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/29906bf16cadf6d568c4da3e161ef38ba2f726fd">
     <sch:title>Wijzigingsdatum - Het tijdsmoment waarop de dataset werd geactualiseerd (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Awijzigingsdatum)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="validMax" value="count(dct:modified) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor wijzigingsdatum (dct:modified)</sch:report>
@@ -1197,7 +1196,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="wijzigingsdatum" id="https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/9e7585433d0896bc44cb41cdd8189793bd115cd0">
     <sch:title>Wijzigingsdatum - Het tijdsmoment waarop de dataset werd geactualiseerd (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Awijzigingsdatum)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:modified[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:modified">
       <sch:let name="isNotEmpty" value="normalize-space(.) != ''"/>
       <sch:let name="isDate" value="matches(., '^\d{4}-\d{2}-\d{2}(Z|(-|\+)\d{2}:\d{2}|T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|(-|\+)\d{2}:\d{2})?)?$')"/>
       <sch:assert test="$isNotEmpty and $isDate">De range van wijzigingsdatum moet van het type &lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; zijn. (dct:modified)</sch:assert>
@@ -1206,7 +1205,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
   </sch:pattern>
   <sch:pattern name="alternatieve identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/39607ae8317e4f99846f57f713d51b19528e5764">
     <sch:title>1801. Alternatieve identificator - Een alternatieve identificator (dan de unieke identificator) voor een distributie kan hier beschreven worden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Aalternatieve%20identificator)</sch:title>
-    <sch:rule context="//dcat:Distribution/adms:identifier[$profile]">
+    <sch:rule context="//dcat:Distribution/adms:identifier">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(adms:Identifier) = 1 or count(//adms:Identifier[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van alternatieve identificator moet van het type &lt;http://www.w3.org/ns/adms#Identifier&gt; zijn. (adms:identifier)</sch:assert>
@@ -1217,7 +1216,7 @@ wordt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendest
     <sch:title>Conform - Een standaard, schema, implementatie-
 model, applicatieprofiel, vocabularium
 waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Aconform)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:conformsTo[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:conformsTo">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:Standard) = 1 or count(//dct:Standard[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van conform moet van het type &lt;http://purl.org/dc/terms/Standard&gt; zijn. (dct:conformsTo)</sch:assert>
@@ -1226,7 +1225,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="downloadURL" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/0e61107f343f202ee672ef465cfcdbbcd746e21d">
     <sch:title>1803. Downloadurl - De URL waar de data gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3AdownloadURL)</sch:title>
-    <sch:rule context="//dcat:Distribution/dcat:downloadURL[$profile]">
+    <sch:rule context="//dcat:Distribution/dcat:downloadURL">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van downloadURL moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (dcat:downloadURL)</sch:assert>
@@ -1235,7 +1234,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="downloadURL" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/1ff94e5c0d35c7d1a7f2c4bd160a8c8e4eee6f97">
     <sch:title>v090. Downloadurl - De URL waar de data gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3AdownloadURL)</sch:title>
-    <sch:rule context="//dcat:Distribution[$profile]">
+    <sch:rule context="//dcat:Distribution">
       <sch:let name="validMax" value="count(dcat:downloadURL) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</sch:report>
@@ -1243,7 +1242,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="formaat" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/866f7e6bf04104e9aa0f82fa4b8b0ff05ef17dc7">
     <sch:title>Formaat - Het bestandsformaat waarin de data wordt gedeeld. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Aformaat)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:format[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:format">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van formaat moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dct:format)</sch:assert>
@@ -1252,7 +1251,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="formaat" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/c202c852e84ae0c736f1f6a8f8030db817602116">
     <sch:title>1901. Formaat - Het bestandsformaat waarin de data wordt gedeeld. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Aformaat)</sch:title>
-    <sch:rule context="//dcat:Distribution[$profile]">
+    <sch:rule context="//dcat:Distribution">
       <sch:let name="validMax" value="count(dct:format) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor formaat (dct:format)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor formaat (dct:format)</sch:report>
@@ -1260,7 +1259,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/05134c4e7c34157d6f7ac1128713a08418e0fe7d">
     <sch:title>1902. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:identifier[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:identifier">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:assert test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:assert>
       <sch:report test="$isLiteral">De range van identificator moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Literal&gt; zijn. (dct:identifier)</sch:report>
@@ -1268,7 +1267,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/972d73e7a13100b66c0c2f44466edac47aa1ab28">
     <sch:title>1903. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:Distribution[$profile]">
+    <sch:rule context="//dcat:Distribution">
       <sch:let name="validMin" value="count(dct:identifier) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor identificator (dct:identifier)</sch:report>
@@ -1276,7 +1275,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="identificator" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/bb43a48c77e7d98609af3d3bb1b1648370465308">
     <sch:title>1904. Identificator - De unieke identificator van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Aidentificator)</sch:title>
-    <sch:rule context="//dcat:Distribution[$profile]">
+    <sch:rule context="//dcat:Distribution">
       <sch:let name="validMax" value="count(dct:identifier) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor identificator (dct:identifier)</sch:report>
@@ -1284,7 +1283,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="licentie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/509740cc7b3c86ebee90dc6303c11c40e2b08212">
     <sch:title>v087. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Alicentie)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:license[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:license">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:LicenseDocument) = 1 or count(//dct:LicenseDocument[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van licentie moet van het type &lt;http://purl.org/dc/terms/LicenseDocument&gt; zijn. (dct:license)</sch:assert>
@@ -1293,7 +1292,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="licentie" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/cafd2e3e66044d8ba2c435a9353e6880952086c5">
     <sch:title>v088. Licentie - De licentie van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Alicentie)</sch:title>
-    <sch:rule context="//dcat:Distribution[$profile]">
+    <sch:rule context="//dcat:Distribution">
       <sch:let name="validMax" value="count(dct:license) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor licentie (dct:license)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor licentie (dct:license)</sch:report>
@@ -1301,7 +1300,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="rechten" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/62bb7a143add01ac0956709b58850f4f5e5a0e47">
     <sch:title>1907. Rechten - Bepalingen van juridische aard die gelden op de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Arechten)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:rights[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:rights">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dct:RightsStatement) = 1 or count(//dct:RightsStatement[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van rechten moet van het type &lt;http://purl.org/dc/terms/RightsStatement&gt; zijn. (dct:rights)</sch:assert>
@@ -1310,7 +1309,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/8041fe094c27b123422bd03a4e13ff0641087607">
     <sch:title>v216. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Atitel)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:title[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:title">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:title[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:assert>
@@ -1319,7 +1318,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/f28ce523c4b4fcb15d8c7d4f279da195ba7403ab">
     <sch:title>v205. Titel - De naam van de distributie. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Atitel)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:title[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:title">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:assert>
@@ -1328,7 +1327,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="toegangsURL" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/28a9b5a610271b2ad2cd6917763075560213ca20">
     <sch:title>v220. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3AtoegangsURL)</sch:title>
-    <sch:rule context="//dcat:Distribution[$profile]">
+    <sch:rule context="//dcat:Distribution">
       <sch:let name="validMax" value="count(dcat:accessURL) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor toegangsURL (dcat:accessURL)</sch:report>
@@ -1336,7 +1335,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="toegangsURL" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/3d0e850677d211050dd9e93ec6496e6af9908da6">
     <sch:title>1910. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3AtoegangsURL)</sch:title>
-    <sch:rule context="//dcat:Distribution/dcat:accessURL[$profile]">
+    <sch:rule context="//dcat:Distribution/dcat:accessURL">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van toegangsURL moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (dcat:accessURL)</sch:assert>
@@ -1345,7 +1344,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="toegangsURL" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/bf4475984ce7d0eb4bade6e749e672a8efa7dd2d">
     <sch:title>v079. Toegangsurl - Een URL waar de data kan gevonden worden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3AtoegangsURL)</sch:title>
-    <sch:rule context="//dcat:Distribution[$profile]">
+    <sch:rule context="//dcat:Distribution">
       <sch:let name="validMin" value="count(dcat:accessURL) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor toegangsURL (dcat:accessURL)</sch:report>
@@ -1353,7 +1352,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="verdeler" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/97ed7a72fee66a4fd972d36d70822272beaf40ce">
     <sch:title>Verdeler - de agent die instaat voor de verdeling (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Averdeler)</sch:title>
-    <sch:rule context="//dcat:Distribution[$profile]">
+    <sch:rule context="//dcat:Distribution">
       <sch:let name="validMax" value="count(geodcat:distributor) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor verdeler (geodcat:distributor)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor verdeler (geodcat:distributor)</sch:report>
@@ -1361,7 +1360,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="verdeler" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/e142be9d61d29a86c3e36db738d8a9600b4a6ba7">
     <sch:title>Verdeler - de agent die instaat voor de verdeling (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Averdeler)</sch:title>
-    <sch:rule context="//dcat:Distribution/geodcat:distributor[$profile]">
+    <sch:rule context="//dcat:Distribution/geodcat:distributor">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(foaf:Agent) = 1 or count(//foaf:Agent[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van verdeler moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (geodcat:distributor)</sch:assert>
@@ -1370,7 +1369,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="wordt aangeboden door" id="https://data.vlaanderen.be/shacl/metadata_dcat#DistributieShape/c612c1f62d45c84405f45260ab0737a10f5b0a18">
     <sch:title>1912. Wordt aangeboden door - Een dataservice die deze distributie aanbiedt. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Distributie%3Awordt%20aangeboden%20door)</sch:title>
-    <sch:rule context="//dcat:Distribution/dcat:accessService[$profile]">
+    <sch:rule context="//dcat:Distribution/dcat:accessService">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van wordt aangeboden door moet van het type &lt;http://www.w3.org/ns/dcat#DataService&gt; zijn. (dcat:accessService)</sch:assert>
@@ -1379,7 +1378,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#VoorbeeldWeergaveShape/0e9a7d4dbf6ec19568d474169ad717f71e882319">
     <sch:title>Beschrijving - Een bondige tekstuele omschrijving van de afbeelding (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#VoorbeeldWeergave%3Abeschrijving)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:description[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:description">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van beschrijving moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:description)</sch:assert>
@@ -1388,7 +1387,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="beschrijving" id="https://data.vlaanderen.be/shacl/metadata_dcat#VoorbeeldWeergaveShape/da05d674f29a225a7115411e9f7ca442a25f2c88">
     <sch:title>Beschrijving - Een bondige tekstuele omschrijving van de afbeelding (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#VoorbeeldWeergave%3Abeschrijving)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:description[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:description">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:description[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor beschrijving (dct:description)</sch:assert>
@@ -1397,7 +1396,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="downloadURL" id="https://data.vlaanderen.be/shacl/metadata_dcat#VoorbeeldWeergaveShape/0e61107f343f202ee672ef465cfcdbbcd746e21d">
     <sch:title>Downloadurl - De URL waar de afbeelding gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#VoorbeeldWeergave%3AdownloadURL)</sch:title>
-    <sch:rule context="//dcat:Distribution/dcat:downloadURL[$profile]">
+    <sch:rule context="//dcat:Distribution/dcat:downloadURL">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
       <sch:assert test="$validClass">De range van downloadURL moet van het type &lt;http://www.w3.org/2000/01/rdf-schema#Resource&gt; zijn. (dcat:downloadURL)</sch:assert>
@@ -1406,7 +1405,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="downloadURL" id="https://data.vlaanderen.be/shacl/metadata_dcat#VoorbeeldWeergaveShape/1ff94e5c0d35c7d1a7f2c4bd160a8c8e4eee6f97">
     <sch:title>Downloadurl - De URL waar de afbeelding gedownload kan worden. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#VoorbeeldWeergave%3AdownloadURL)</sch:title>
-    <sch:rule context="//dcat:Distribution[$profile]">
+    <sch:rule context="//dcat:Distribution">
       <sch:let name="validMax" value="count(dcat:downloadURL) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor downloadURL (dcat:downloadURL)</sch:report>
@@ -1414,7 +1413,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="mediatype" id="https://data.vlaanderen.be/shacl/metadata_dcat#VoorbeeldWeergaveShape/06b127df99a6de2b3aef269b0d4b8746a5b78dcc">
     <sch:title>Mediatype - Het voorstellingsvorm van de afbeelding (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#VoorbeeldWeergave%3Amediatype)</sch:title>
-    <sch:rule context="//dcat:Distribution[$profile]">
+    <sch:rule context="//dcat:Distribution">
       <sch:let name="validMax" value="count(dcat:mediatype) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor mediatype (dcat:mediatype)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor mediatype (dcat:mediatype)</sch:report>
@@ -1422,7 +1421,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="mediatype" id="https://data.vlaanderen.be/shacl/metadata_dcat#VoorbeeldWeergaveShape/f15bdaee3382af94fe22b0dade89fc2e9fefbbdc">
     <sch:title>Mediatype - Het voorstellingsvorm van de afbeelding (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#VoorbeeldWeergave%3Amediatype)</sch:title>
-    <sch:rule context="//dcat:Distribution/dcat:mediatype[$profile]">
+    <sch:rule context="//dcat:Distribution/dcat:mediatype">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van mediatype moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:mediatype)</sch:assert>
@@ -1431,7 +1430,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#VoorbeeldWeergaveShape/8041fe094c27b123422bd03a4e13ff0641087607">
     <sch:title>Titel - naam van de afbeelding (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#VoorbeeldWeergave%3Atitel)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:title[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:title">
       <sch:let name="current" value="."/>
       <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:title[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
       <sch:assert test="$isUniqueLang">Slechts 1 waarde voor elke taal toegelaten voor titel (dct:title)</sch:assert>
@@ -1440,7 +1439,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="titel" id="https://data.vlaanderen.be/shacl/metadata_dcat#VoorbeeldWeergaveShape/f28ce523c4b4fcb15d8c7d4f279da195ba7403ab">
     <sch:title>Titel - naam van de afbeelding (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#VoorbeeldWeergave%3Atitel)</sch:title>
-    <sch:rule context="//dcat:Distribution/dct:title[$profile]">
+    <sch:rule context="//dcat:Distribution/dct:title">
       <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
       <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
       <sch:assert test="$isLiteral and $hasLang">De range van titel moet van het type &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#langString&gt; zijn. (dct:title)</sch:assert>
@@ -1449,7 +1448,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="Catalogus Resource (source)" id="https://data.vlaanderen.be/shacl/metadata_dcat#RelatieQualificatieShape/230fa664054f86199f30c98c6d4140bfb1437470">
     <sch:title>Catalogus resource (source) - Referentie naar verbonden klasse. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#RelatieQualificatie%3ACatalogus%20Resource%20(source))</sch:title>
-    <sch:rule context="//dcat:Relationship[$profile]">
+    <sch:rule context="//dcat:Relationship">
       <sch:let name="validMin" value="count(mdcat:RelatieQualificatie.catalogusResource.source) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor Catalogus Resource (source) (mdcat:RelatieQualificatie.catalogusResource.source)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor Catalogus Resource (source) (mdcat:RelatieQualificatie.catalogusResource.source)</sch:report>
@@ -1457,7 +1456,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="Catalogus Resource (source)" id="https://data.vlaanderen.be/shacl/metadata_dcat#RelatieQualificatieShape/aa69087cd9f59b7d23c9ca16a88c4298d77dcd0c">
     <sch:title>Catalogus resource (source) - Referentie naar verbonden klasse. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#RelatieQualificatie%3ACatalogus%20Resource%20(source))</sch:title>
-    <sch:rule context="//dcat:Relationship/mdcat:RelatieQualificatie.catalogusResource.source[$profile]">
+    <sch:rule context="//dcat:Relationship/mdcat:RelatieQualificatie.catalogusResource.source">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dcat:Dataset|dcat:DataService) = 1 or count((//dcat:Dataset|//dcat:DataService)[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van Catalogus Resource (source) moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (mdcat:RelatieQualificatie.catalogusResource.source)</sch:assert>
@@ -1466,7 +1465,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="Catalogus Resource (source)" id="https://data.vlaanderen.be/shacl/metadata_dcat#RelatieQualificatieShape/f5a6aff37ed40db28a354dd68f524952b0433d4a">
     <sch:title>Catalogus resource (source) - Referentie naar verbonden klasse. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#RelatieQualificatie%3ACatalogus%20Resource%20(source))</sch:title>
-    <sch:rule context="//dcat:Relationship[$profile]">
+    <sch:rule context="//dcat:Relationship">
       <sch:let name="validMax" value="count(mdcat:RelatieQualificatie.catalogusResource.source) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor Catalogus Resource (source) (mdcat:RelatieQualificatie.catalogusResource.source)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor Catalogus Resource (source) (mdcat:RelatieQualificatie.catalogusResource.source)</sch:report>
@@ -1474,7 +1473,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="Catalogus Resource (target)" id="https://data.vlaanderen.be/shacl/metadata_dcat#RelatieQualificatieShape/78ce02089c3f0ee33902d0bc3cc0e00e7d26e097">
     <sch:title>Catalogus resource (target) - Referentie naar verbonden klasse. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#RelatieQualificatie%3ACatalogus%20Resource%20(target))</sch:title>
-    <sch:rule context="//dcat:Relationship[$profile]">
+    <sch:rule context="//dcat:Relationship">
       <sch:let name="validMin" value="count(mdcat:RelatieQualificatie.catalogusResource.target) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor Catalogus Resource (target) (mdcat:RelatieQualificatie.catalogusResource.target)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor Catalogus Resource (target) (mdcat:RelatieQualificatie.catalogusResource.target)</sch:report>
@@ -1482,7 +1481,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="Catalogus Resource (target)" id="https://data.vlaanderen.be/shacl/metadata_dcat#RelatieQualificatieShape/80179238c15e4eb0f284c28f3a87c523281be2cd">
     <sch:title>Catalogus resource (target) - Referentie naar verbonden klasse. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#RelatieQualificatie%3ACatalogus%20Resource%20(target))</sch:title>
-    <sch:rule context="//dcat:Relationship/mdcat:RelatieQualificatie.catalogusResource.target[$profile]">
+    <sch:rule context="//dcat:Relationship/mdcat:RelatieQualificatie.catalogusResource.target">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dcat:Dataset|dcat:DataService) = 1 or count((//dcat:Dataset|//dcat:DataService)[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van Catalogus Resource (target) moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (mdcat:RelatieQualificatie.catalogusResource.target)</sch:assert>
@@ -1491,7 +1490,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="Catalogus Resource (target)" id="https://data.vlaanderen.be/shacl/metadata_dcat#RelatieQualificatieShape/c883e705823614530bb3fd7b4046023772ea8807">
     <sch:title>Catalogus resource (target) - Referentie naar verbonden klasse. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#RelatieQualificatie%3ACatalogus%20Resource%20(target))</sch:title>
-    <sch:rule context="//dcat:Relationship[$profile]">
+    <sch:rule context="//dcat:Relationship">
       <sch:let name="validMax" value="count(mdcat:RelatieQualificatie.catalogusResource.target) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor Catalogus Resource (target) (mdcat:RelatieQualificatie.catalogusResource.target)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor Catalogus Resource (target) (mdcat:RelatieQualificatie.catalogusResource.target)</sch:report>
@@ -1499,7 +1498,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="rol" id="https://data.vlaanderen.be/shacl/metadata_dcat#RelatieQualificatieShape/68837b0eda962a941b0162e1ae4c5f0e471e0c51">
     <sch:title>Rol - De functie hoe de entiteiten zich tot elkaar verhouden.  (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#RelatieQualificatie%3Arol)</sch:title>
-    <sch:rule context="//dcat:Relationship[$profile]">
+    <sch:rule context="//dcat:Relationship">
       <sch:let name="validMin" value="count(dcat:hadRole) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor rol (dcat:hadRole)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor rol (dcat:hadRole)</sch:report>
@@ -1507,7 +1506,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="rol" id="https://data.vlaanderen.be/shacl/metadata_dcat#RelatieQualificatieShape/acb59b00c5c67fec8d3f0b2543d5259a09b17d18">
     <sch:title>Rol - De functie hoe de entiteiten zich tot elkaar verhouden.  (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#RelatieQualificatie%3Arol)</sch:title>
-    <sch:rule context="//dcat:Relationship[$profile]">
+    <sch:rule context="//dcat:Relationship">
       <sch:let name="validMax" value="count(dcat:hadRole) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor rol (dcat:hadRole)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor rol (dcat:hadRole)</sch:report>
@@ -1515,7 +1514,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="rol" id="https://data.vlaanderen.be/shacl/metadata_dcat#RelatieQualificatieShape/e5ccf692ee38c28199531eb5e0c59554153a57c3">
     <sch:title>Rol - De functie hoe de entiteiten zich tot elkaar verhouden.  (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#RelatieQualificatie%3Arol)</sch:title>
-    <sch:rule context="//dcat:Relationship/dcat:hadRole[$profile]">
+    <sch:rule context="//dcat:Relationship/dcat:hadRole">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(skos:Concept) = 1 or count(//skos:Concept[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van rol moet van het type &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; zijn. (dcat:hadRole)</sch:assert>
@@ -1524,7 +1523,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="relatie" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusResourceShape/0f8fcba8defd790e04421c1042f74286d52c564b">
     <sch:title>Relatie - een verband tussen twee resources. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusResource%3Arelatie)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:relation[$profile]|//dcat:DataService/dct:relation[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:relation|//dcat:DataService/dct:relation">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(dcat:Dataset|dcat:DataService) = 1 or count((//dcat:Dataset|//dcat:DataService)[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van relatie moet van het type &lt;http://www.w3.org/ns/dcat#Resource&gt; zijn. (dct:relation)</sch:assert>
@@ -1533,7 +1532,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="uitgever" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusResourceShape/5334cf8edf5cc07e349524728fe4c9b076e4c45e">
     <sch:title>2002. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusResource%3Auitgever)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]|//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:Dataset|//dcat:DataService">
       <sch:let name="validMax" value="count(dct:publisher) &lt;= 1"/>
       <sch:assert test="$validMax">Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</sch:assert>
       <sch:report test="$validMax">Maximaal 1 waarden toegelaten voor uitgever (dct:publisher)</sch:report>
@@ -1541,7 +1540,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="uitgever" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusResourceShape/aabe67e6a56c5e2fc5695716e8f7b66edd525085">
     <sch:title>v052. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusResource%3Auitgever)</sch:title>
-    <sch:rule context="//dcat:Dataset/dct:publisher[$profile]|//dcat:DataService/dct:publisher[$profile]">
+    <sch:rule context="//dcat:Dataset/dct:publisher|//dcat:DataService/dct:publisher">
       <sch:let name="resource" value="@rdf:resource"/>
       <sch:let name="validClass" value="count(foaf:Agent) = 1 or count(//foaf:Agent[@rdf:about = $resource]) = 1"/>
       <sch:assert test="$validClass">De range van uitgever moet van het type &lt;http://purl.org/dc/terms/Agent&gt; zijn. (dct:publisher)</sch:assert>
@@ -1550,7 +1549,7 @@ waaraan de distributie voldoet. (https://data.vlaanderen.be/doc/applicatieprofie
   </sch:pattern>
   <sch:pattern name="uitgever" id="https://data.vlaanderen.be/shacl/metadata_dcat#CatalogusResourceShape/e2d4034a0a398701f4257641ebcbc85e8683b29d">
     <sch:title>v049. Uitgever - De uitgever, de entiteit die verantwoordelijk is voor het beschikbaar stellen, van de resource in de catalogus. (https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#CatalogusResource%3Auitgever)</sch:title>
-    <sch:rule context="//dcat:Dataset[$profile]|//dcat:DataService[$profile]">
+    <sch:rule context="//dcat:Dataset|//dcat:DataService">
       <sch:let name="validMin" value="count(dct:publisher) &gt;= 1"/>
       <sch:assert test="$validMin">Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</sch:assert>
       <sch:report test="$validMin">Minimaal 1 waarden verwacht voor uitgever (dct:publisher)</sch:report>


### PR DESCRIPTION
Fixes for schematron rules:
- labels that contained errors
- removed profile check in the schematron, so it can be applied through schematroncriteria following the other schematrons