### PR TITLE
Index (HVD) ELI

### DIFF
--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -26,6 +26,7 @@
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:dcatap="http://data.europa.eu/r5r/"
                 xmlns:schema="http://schema.org/"
                 xmlns:foaf="http://xmlns.com/foaf/0.1/"
                 xmlns:skos="http://www.w3.org/2004/02/skos/core#"
@@ -209,6 +210,12 @@
           </xsl:for-each-group>
           <xsl:if test="position() != last()">,</xsl:if>
         </resourceLanguage>
+
+        <xsl:for-each select="dcatap:applicableLegislation">
+            <applicableLegislation type="object">
+                "<xsl:value-of select="@rdf:resource"/>"
+            </applicableLegislation>
+        </xsl:for-each>
 
         <xsl:apply-templates mode="index-keyword" select="."/>
 


### PR DESCRIPTION
Now indexing `dcatap:applicableLegislation` to more reliably filter on HVD records in the facets.

![image](https://github.com/user-attachments/assets/3294afb0-fcd7-43bf-8fa1-a81f07ed1104)

This correctly functions with multiple definitions of `dcatap:applicableLegislation` and requires adding `applicableLegislation` to the list of `arrayFields` in GeoNetwork (https://agiv.visualstudio.com/Metadata/_git/MetadataGeonetwork/pullrequest/43423). Could you advise on whether this is the right approach @fxprunayre ? 

Previously, our facets depended on 1) ISO keyword ELI 2) DCAT HVD category. This would lead to inconsistent behaviour as you could have DCAT records with an HVD category defined, without defining the ELI, and still popping up in the facet.