### PR TITLE
Updated for core 4.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>gn-schemas</artifactId>
     <groupId>org.geonetwork-opensource.schemas</groupId>
-    <version>4.4.7-SNAPSHOT</version>
+    <version>4.4.7-0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/src/main/java/org/fao/geonet/schema/dcatap/DCATAPSchemaPlugin.java
+++ b/src/main/java/org/fao/geonet/schema/dcatap/DCATAPSchemaPlugin.java
@@ -215,4 +215,21 @@ public class DCATAPSchemaPlugin extends SchemaPlugin implements AssociatedResour
         }
         return null;
     }
+
+    @Override
+    public List<String> getMetadataLanguages(Element metadata) {
+        return List.of();
+    }
+
+    @Override
+    public boolean isMultilingualElementType(String elementType) {
+        List<String> multilingualElementTypes = List.of("rdf:plainLiteral");
+        return multilingualElementTypes.contains(elementType);
+    }
+
+    @Override
+    public boolean duplicateElementsForMultilingual() {
+        return true;
+    }
+
 }


### PR DESCRIPTION
Goal: align with GN 4.4.7-0, make sure the dcat-ap plugin works. This would additionally eliminate the difference between `main` and `profile/vl/main`.