### PR TITLE
Virtual catalog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ When saving a record, this uuid is appended to the dataset URI, provided that th
 </dcat:CatalogRecord>
 ```
 
+## Transifex for translations
+
+A script is included to manage translation work. The files currently managed by this process can be found in:
+- `/src/main/plugin/dcat-ap/loc/xxx/labels.xml`
+- `/src/main/plugin/dcat-ap/loc/xxx/strings.xml`
+
+For the above files, a counterpart was created in `/transifex/translations/xxx/en_US.xml`. This counterpart file is structured to be parseable by Transifex. When modifying any of the contained strings, apply the following process:
+1. Modify the *counterpart*, following the same structure.
+2. Execute `transifex.sh -u` to upload the `en_US` changes to Transifex.
+3. Use Transifex to do translation work: https://app.transifex.com/geonetwork/metadata101.
+4. Execute `transifex.sh -d` to download the latest changes to the `/transifex/translations` folder.
+5. Execute `transifex.sh -a` to apply the changes to the various plugin loc files.
+6. Check git status for changes, commit when happy.
+
+
 ## How to create a profile? 
 
 Various implementations / profiles exist of DCAT-AP, each corresponding to, e.g., a specific use case or national implementation. This section illustrates the necessary steps in order to add such a profile to the plugin.

--- a/src/main/java/org/fao/geonet/schema/dcatap/DCATAPSchemaPlugin.java
+++ b/src/main/java/org/fao/geonet/schema/dcatap/DCATAPSchemaPlugin.java
@@ -32,6 +32,7 @@ import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.index.es.EsRestClient;
@@ -108,9 +109,11 @@ public class DCATAPSchemaPlugin extends SchemaPlugin implements AssociatedResour
                 if (o instanceof Element) {
                     Element sib = (Element) o;
                     String url = sib.getAttributeValue("resource", DCATAPNamespaces.RDF);
-                    AssociatedResource resource =
-                        new AssociatedResource(url.substring(url.lastIndexOf('/') + 1), "", "isComposedOf", url, "");
-                    listOfResources.add(resource);
+                    if (StringUtils.isNotEmpty(url)) {
+                        AssociatedResource resource =
+                            new AssociatedResource(url.substring(url.lastIndexOf('/') + 1), "", "isComposedOf", url, "");
+                        listOfResources.add(resource);
+                    }
                 }
             }
         } catch (JDOMException e) {

--- a/src/main/plugin/dcat-ap/config/associated-panel/dcatapcatalog.json
+++ b/src/main/plugin/dcat-ap/config/associated-panel/dcatapcatalog.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "display": "radio",
+    "multilingualFields": [],
+    "associatedResourcesTypes": [
+      {
+        "type": "siblings",
+        "label": "linkToSibling",
+        "config": {
+          "fields": {"associationType": "isComposedOf", "initiativeType": "" },
+          "sources": {
+            "metadataStore": {
+              "params": {
+                "isTemplate": "n"
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -134,7 +134,7 @@
           </xsl:otherwise>
         </xsl:choose>
       </xsl:when>
-      <xsl:otherwise>
+      <xsl:when test="count(//dcat:DataService) > 0">
         <xsl:choose>
           <xsl:when test="//dcat:DataService/dct:title[@xml:lang = $langId-2char]">
             <xsl:value-of select="//dcat:DataService/dct:title[@xml:lang = $langId-2char][1]"/>
@@ -149,17 +149,33 @@
             </xsl:if>
           </xsl:otherwise>
         </xsl:choose>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:choose>
+          <xsl:when test="//dcat:Catalog/dct:title[@xml:lang = $langId-2char]">
+            <xsl:value-of select="//dcat:Catalog/dct:title[@xml:lang = $langId-2char][1]"/>
+          </xsl:when>
+          <xsl:when test="//dcat:Catalog/dct:title[@xml:lang = $defaultLang-2char]">
+            <xsl:value-of select="concat(//dcat:Catalog/dct:title[@xml:lang = $defaultLang-2char][1], ' (', normalize-space(//dcat:Catalog/dct:title[@xml:lang = $defaultLang-2char][1]/@xml:lang), ')')"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="//dcat:Catalog/dct:title[1]"/>
+            <xsl:if test="//dcat:Catalog/dct:title[1]/@xml:lang and normalize-space(//dcat:Catalog/dct:title[1]/@xml:lang) != '' ">
+              <xsl:value-of select="concat(' (',//dcat:Catalog/dct:title[1]/@xml:lang,')')" />
+            </xsl:if>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 
   <xsl:template mode="getMetadataAbstract" match="rdf:RDF">
-    <xsl:value-of select="//dcat:Dataset/dct:description|//dcat:DataService/dct:description" />
+    <xsl:value-of select="//dcat:Dataset/dct:description|//dcat:DataService/dct:description|//dcat:Catalog/dct:description" />
   </xsl:template>
 
   <xsl:template mode="getMetadataHeader" match="rdf:RDF">
     <div class="gn-abstract">
-      <xsl:value-of select="(//dcat:Dataset/dct:description|//dcat:DataService/dct:description)[1]"/>
+      <xsl:value-of select="(//dcat:Dataset/dct:description|//dcat:DataService/dct:description|//dcat:Catalog/dct:description)[1]"/>
     </div>
     <xsl:if test="$root = 'div'">
       <div class="one-line-ellipsis" ng-if="user.isEditorOrMore()">
@@ -175,8 +191,11 @@
       <xsl:when test="count(//dcat:Dataset) > 0">
         <xsl:value-of select="'dataset'"/>
       </xsl:when>
-      <xsl:otherwise>
+      <xsl:when test="count(//dcat:DataService) > 0">
         <xsl:value-of select="'service'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'catalog'"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -70,7 +70,7 @@
     <xsl:variable name="associatedRecords" as="node()*" select="rdf:RDF/dcat:Catalog/dcat:record/@rdf:resource"/>
 
     <!-- When record is not a catalog, it should have only one CatalogRecord (cf. update-fixed-info). -->
-    <xsl:variable name="catalogRecord" as="node()" select=".//dcat:CatalogRecord[not(@rdf:about = $associatedRecords)]"/>
+    <xsl:variable name="catalogRecord" as="node()?" select="(.//dcat:CatalogRecord[not(@rdf:about = $associatedRecords)])[1]"/>
 
     <xsl:variable name="identifier" as="xs:string*" select="$catalogRecord/dct:identifier"/>
     <xsl:variable name="dateStamp" select="$catalogRecord/dct:modified"/>

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -59,7 +59,7 @@
   <xsl:template match="/">
 
     <xsl:variable name="virtualCatalog"
-                  select="rdf:RDF[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog"
+                  select="rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog"
                   as="node()*"/>
 
     <xsl:variable name="isVirtualCatalog"
@@ -268,7 +268,7 @@
         <xsl:apply-templates mode="index-reference-date" select="."/>
 
         <xsl:if test="$isVirtualCatalog">
-          <xsl:for-each select="../dcat:CatalogRecord/dct:identifier">
+          <xsl:for-each select="../dcat:CatalogRecord[@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource]/dct:identifier">
             <agg_associated><xsl:value-of select="."/></agg_associated>
           </xsl:for-each>
         </xsl:if>

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -58,15 +58,22 @@
 
   <xsl:template match="/">
 
-    <xsl:variable name="dateStamp" select=".//dcat:CatalogRecord/dct:modified"/>
-    <xsl:variable name="identifier" as="xs:string" select=".//dcat:CatalogRecord/dct:identifier"/>
-
     <xsl:variable name="virtualCatalog"
                   select="rdf:RDF[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog"
                   as="node()*"/>
+
     <xsl:variable name="isVirtualCatalog"
                   select="exists($virtualCatalog)"
                   as="xs:boolean"/>
+
+    <!-- Record associated in virtual catalog -->
+    <xsl:variable name="associatedRecords" as="node()*" select="rdf:RDF/dcat:Catalog/dcat:record/@rdf:resource"/>
+
+    <!-- When record is not a catalog, it should have only one CatalogRecord (cf. update-fixed-info). -->
+    <xsl:variable name="catalogRecord" as="node()" select=".//dcat:CatalogRecord[not(@rdf:about = $associatedRecords)]"/>
+
+    <xsl:variable name="identifier" as="xs:string*" select="$catalogRecord/dct:identifier"/>
+    <xsl:variable name="dateStamp" select="$catalogRecord/dct:modified"/>
 
     <xsl:for-each select="(.//(dcat:Dataset|dcat:DataService)|$virtualCatalog)">
       <doc>

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -267,6 +267,11 @@
 
         <xsl:apply-templates mode="index-reference-date" select="."/>
 
+        <xsl:if test="$isVirtualCatalog">
+          <xsl:for-each select="../dcat:CatalogRecord/dct:identifier">
+            <agg_associated><xsl:value-of select="."/></agg_associated>
+          </xsl:for-each>
+        </xsl:if>
         <!-- Index more fields in this element -->
         <xsl:apply-templates mode="index-extra-fields" select="."/>
       </doc>

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -62,7 +62,7 @@
     <xsl:variable name="identifier" as="xs:string" select=".//dcat:CatalogRecord/dct:identifier"/>
 
     <xsl:variable name="virtualCatalog"
-                  select="rdf:RDF[not(dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog"
+                  select="rdf:RDF[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog"
                   as="node()*"/>
     <xsl:variable name="isVirtualCatalog"
                   select="exists($virtualCatalog)"

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -22,6 +22,7 @@
     <for name="dct:description" use="textarea"/>
     <for name="adms:versionNotes" use="textarea"/>
     <for name="dcat:byteSize" use="number"/>
+    <for name="mdcat:stars" use="number"/>
     <for name="dcat:spatialResolutionInMeters" use="number"/>
 
     <for name="dct:type" xpath="foaf:Agent" use="thesaurus-list-picker">
@@ -1363,7 +1364,7 @@
                         name="associatedRecord"
                         del=".">
             <field xpath="dct:identifier"/>
-<!-- TODO mdcat:stars, ...            <field xpath="dct:description" or="description" in="."/>-->
+            <field xpath="mdcat:stars" or="stars" in="."/>
           </section>
         </section>
       </tab>
@@ -1428,6 +1429,7 @@
         <for name="dct:LicenseDocument"/>
         <for name="dct:LicenseDocument/dct:type"/>
         <for name="dct:rights"/>
+        <for name="mdcat:stars"/>
       </flatModeExceptions>
     </view>
 

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -524,7 +524,13 @@
                    data-file-types=".png,.gif,.jpeg,.jpg"
                    displayIfRecord="count(//dcat:dataset) > 0"/>
 
-        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata"/>
+        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata"
+                         displayIfRecord="count(rdf:RDF[not(dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog) = 0"/>
+
+        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata"
+                   editor-config="dcatapcatalog"
+                   displayIfRecord="count(rdf:RDF[not(dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0"/>
+
         <directive data-gn-validation-report=""/>
       </sidePanel>
 
@@ -1336,6 +1342,21 @@
                  or="keyword"
                  in="/rdf:RDF/dcat:Catalog"/>
 
+        </section>
+      </tab>
+
+      <tab id="tabCatalogAssociatedRecords" mode="flat" displayIfRecord="count(rdf:RDF[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0" hideIfNotDisplayed="true">
+        <section name="associatedRecords">
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:record"/>
+
+          <action type="associatedResource"
+                  name="linkToSibling"
+                  btnClass="fa fa-plus"
+                  process="siblings">
+            <directiveAttributes>{"fields": {"associationType": "isComposedOf", "initiativeType": "" },
+              "sources": {"metadataStore": {"params": {"isTemplate": "n"}}
+              }}</directiveAttributes>
+          </action>
         </section>
       </tab>
 

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -525,11 +525,11 @@
                    displayIfRecord="count(//dcat:dataset) > 0"/>
 
         <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata"
-                         displayIfRecord="count(rdf:RDF[not(dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog) = 0"/>
+                         displayIfRecord="count(rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog) = 0"/>
 
         <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata"
                    editor-config="dcatapcatalog"
-                   displayIfRecord="count(rdf:RDF[not(dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0"/>
+                   displayIfRecord="count(rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0"/>
 
         <directive data-gn-validation-report=""/>
       </sidePanel>
@@ -1330,7 +1330,7 @@
         </section>
       </tab>
 
-      <tab id="tabCatalog" default="true" mode="flat" displayIfRecord="count(rdf:RDF[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0" hideIfNotDisplayed="true">
+      <tab id="tabCatalog" default="true" mode="flat" displayIfRecord="count(rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0" hideIfNotDisplayed="true">
         <section name="catalogInformation">
           <field xpath="/rdf:RDF/dcat:Catalog/dct:title"/>
           <field xpath="/rdf:RDF/dcat:Catalog/dct:description"/>
@@ -1345,7 +1345,7 @@
         </section>
       </tab>
 
-      <tab id="tabCatalogAssociatedRecords" mode="flat" displayIfRecord="count(rdf:RDF[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0" hideIfNotDisplayed="true">
+      <tab id="tabCatalogAssociatedRecords" mode="flat" displayIfRecord="count(rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0" hideIfNotDisplayed="true">
         <section>
           <!--          <field xpath="/rdf:RDF/dcat:Catalog/dcat:record"/>-->
 
@@ -1356,7 +1356,7 @@
                         name="associatedRecord"
                         del=".">
             <field xpath="dct:identifier"/>
-            <field xpath="dct:description" or="subject" in="."/>
+<!-- TODO mdcat:stars, ...            <field xpath="dct:description" or="description" in="."/>-->
           </section>
 
           <action type="associatedResource"

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -52,6 +52,13 @@
         max="1"
         labelKey="dcat.addAccessRight"/>
     </for>
+    <for name="dct:language" xpath="dcat:Catalog" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.language"
+        xpath="/dct:language"
+        max=""
+        labelKey="dcat.addLanguage"/>
+    </for>
     <for name="dct:language" xpath="dcat:CatalogRecord" use="thesaurus-list-picker">
       <directiveAttributes
         thesaurus="external.theme.language"
@@ -1314,6 +1321,21 @@
               <snippets name="protocols-vl"/>
             </template>
           </action>
+        </section>
+      </tab>
+
+      <tab id="tabCatalog" default="true" mode="flat" displayIfRecord="count(rdf:RDF[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0" hideIfNotDisplayed="true">
+        <section name="catalogInformation">
+          <field xpath="/rdf:RDF/dcat:Catalog/dct:title"/>
+          <field xpath="/rdf:RDF/dcat:Catalog/dct:description"/>
+          <field xpath="/rdf:RDF/dcat:Catalog/dct:language"
+                 or="language"
+                 in="/rdf:RDF/dcat:Catalog"/>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:keyword"
+                 or="keyword"
+                 in="/rdf:RDF/dcat:Catalog"/>
+
         </section>
       </tab>
 

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -509,6 +509,7 @@
       <name>vcard:fn</name>
       <name>skos:inScheme</name>
       <name>skos:notation</name>
+      <name>mdcat:stars</name>
     </exclude>
   </multilingualFields>
 

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -1346,8 +1346,18 @@
       </tab>
 
       <tab id="tabCatalogAssociatedRecords" mode="flat" displayIfRecord="count(rdf:RDF[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0" hideIfNotDisplayed="true">
-        <section name="associatedRecords">
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:record"/>
+        <section>
+          <!--          <field xpath="/rdf:RDF/dcat:Catalog/dcat:record"/>-->
+
+          <!-- List all related records to add additional properties.
+          When this element is removed, update-fixed-info also remove corresponding dcat:record in Catalog.
+          -->
+          <section forEach="/rdf:RDF/dcat:CatalogRecord[@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource]"
+                        name="associatedRecord"
+                        del=".">
+            <field xpath="dct:identifier"/>
+            <field xpath="dct:description" or="subject" in="."/>
+          </section>
 
           <action type="associatedResource"
                   name="linkToSibling"

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -1347,7 +1347,14 @@
 
       <tab id="tabCatalogAssociatedRecords" mode="flat" displayIfRecord="count(rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0" hideIfNotDisplayed="true">
         <section>
-          <!--          <field xpath="/rdf:RDF/dcat:Catalog/dcat:record"/>-->
+          <action type="associatedResource"
+                  name="linkToSibling"
+                  btnClass="fa fa-plus"
+                  process="siblings">
+            <directiveAttributes>{"fields": {"associationType": "isComposedOf", "initiativeType": "" },
+              "sources": {"metadataStore": {"params": {"isTemplate": "n"}}
+              }}</directiveAttributes>
+          </action>
 
           <!-- List all related records to add additional properties.
           When this element is removed, update-fixed-info also remove corresponding dcat:record in Catalog.
@@ -1358,15 +1365,6 @@
             <field xpath="dct:identifier"/>
 <!-- TODO mdcat:stars, ...            <field xpath="dct:description" or="description" in="."/>-->
           </section>
-
-          <action type="associatedResource"
-                  name="linkToSibling"
-                  btnClass="fa fa-plus"
-                  process="siblings">
-            <directiveAttributes>{"fields": {"associationType": "isComposedOf", "initiativeType": "" },
-              "sources": {"metadataStore": {"params": {"isTemplate": "n"}}
-              }}</directiveAttributes>
-          </action>
         </section>
       </tab>
 

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -1537,7 +1537,19 @@
     </view>-->
 
     <view name="xml">
+
       <sidePanel>
+        <directive data-gn-overview-manager=""
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   displayIfRecord="count(//dcat:dataset) > 0"/>
+
+        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata"
+                   displayIfRecord="count(rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog) = 0"/>
+
+        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata"
+                   editor-config="dcatapcatalog"
+                   displayIfRecord="count(rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0"/>
+
         <directive data-gn-validation-report=""/>
       </sidePanel>
       <tab id="xml" default="true"/>

--- a/src/main/plugin/dcat-ap/layout/layout-custom-fields-concepts.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout-custom-fields-concepts.xsl
@@ -177,7 +177,8 @@
     <xsl:param name="config" as="node()"/>
     <xsl:variable name="resourcePath"
                   select="concat('./dcat:Catalog',
-                                  if (ancestor::*[1]/name() = 'dcat:CatalogRecord') then '/dcat:record/dcat:CatalogRecord'
+                                  if (ancestor::*[1]/name() = 'dcat:Catalog') then ''
+                                  else if (ancestor::*[1]/name() = 'dcat:CatalogRecord') then '/dcat:record/dcat:CatalogRecord'
                                   else if ($isDcatService) then '/dcat:service/dcat:DataService'
                                   else '/dcat:dataset/dcat:Dataset')"/>
 

--- a/src/main/plugin/dcat-ap/layout/layout.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout.xsl
@@ -444,10 +444,21 @@
                                 'resourceTitleObject',
                                 '')"/>
 
-        <xsl:if test="$recordTitle != ''">
-          <div class="col-sm-9 col-xs-11">
-            <input type="text" readonly="readonly" value="{$recordTitle}" class="form-control"/></div>
-        </xsl:if>
+        <xsl:choose>
+          <xsl:when test="$recordTitle != ''">
+            <div class="col-sm-9 col-xs-11">
+              <input type="text" readonly="readonly" value="{$recordTitle}" class="form-control"/>
+            </div>
+          </xsl:when>
+          <xsl:otherwise>
+            <div class="col-sm-9 col-xs-11">
+              <div class="alert alert-danger">
+                <strong><xsl:value-of select="$strings/virtualCatalogAssociatedRecordNotFound"/></strong><br/>
+                <xsl:value-of select="$strings/virtualCatalogAssociatedRecordNotFound-help"/>
+              </div>
+            </div>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:if>
     </xsl:if>
   </xsl:template>

--- a/src/main/plugin/dcat-ap/layout/layout.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout.xsl
@@ -445,7 +445,8 @@
                                 '')"/>
 
         <xsl:if test="$recordTitle != ''">
-          <div class="col-md-12"><xsl:value-of select="$recordTitle"/></div>
+          <div class="col-sm-9 col-xs-11">
+            <input type="text" readonly="readonly" value="{$recordTitle}" class="form-control"/></div>
         </xsl:if>
       </xsl:if>
     </xsl:if>

--- a/src/main/plugin/dcat-ap/layout/layout.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout.xsl
@@ -322,6 +322,7 @@
       <xsl:variable name="isDisabled" select="
             (name(.) = 'dct:identifier' and count(preceding-sibling::*[name(.) = 'dct:identifier']) = 0 and name(..) = ('dcat:Dataset', 'dcat:DataService')) or
             (name(..) = 'dcat:Distribution' and name(.) = ('dct:identifier')) or
+            (name(.) = 'dct:identifier' and $isVirtualCatalogAssociatedRecord) or
             (name(..) = 'dcat:CatalogRecord' and not($isVirtualCatalogAssociatedRecord)) or
             (name(../../..) = 'dcat:CatalogRecord' and name(..) = 'dct:Standard')"/>
 
@@ -434,6 +435,19 @@
           </xsl:for-each>
         </xsl:otherwise>
       </xsl:choose>
+
+      <xsl:if test="name(.) = 'dct:identifier' and $isVirtualCatalogAssociatedRecord">
+        <xsl:variable name="recordTitle"
+                      select="java:getIndexField(
+                                '',
+                                normalize-space(text()),
+                                'resourceTitleObject',
+                                '')"/>
+
+        <xsl:if test="$recordTitle != ''">
+          <div class="col-md-12"><xsl:value-of select="$recordTitle"/></div>
+        </xsl:if>
+      </xsl:if>
     </xsl:if>
   </xsl:template>
 

--- a/src/main/plugin/dcat-ap/layout/layout.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout.xsl
@@ -314,10 +314,15 @@
       <xsl:variable name="contextXpath" select="gn-fn-metadata:getXPath(.)"/>
       <xsl:variable name="fieldNode" select="$editorConfig/editor/fields/for[@name = $name and @templateModeOnly and (not(@xpath) or @xpath = $contextXpath)]"/>
 
+      <xsl:variable name="catalogRecordUri"
+                    select="ancestor::dcat:CatalogRecord/@rdf:about"/>
+      <xsl:variable name="isVirtualCatalogAssociatedRecord"
+                    select="$catalogRecordUri = ancestor::rdf:RDF/dcat:Catalog/dcat:record/@rdf:resource"/>
+
       <xsl:variable name="isDisabled" select="
             (name(.) = 'dct:identifier' and count(preceding-sibling::*[name(.) = 'dct:identifier']) = 0 and name(..) = ('dcat:Dataset', 'dcat:DataService')) or
             (name(..) = 'dcat:Distribution' and name(.) = ('dct:identifier')) or
-            (name(..) = 'dcat:CatalogRecord') or
+            (name(..) = 'dcat:CatalogRecord' and not($isVirtualCatalogAssociatedRecord)) or
             (name(../../..) = 'dcat:CatalogRecord' and name(..) = 'dct:Standard')"/>
 
       <xsl:choose>

--- a/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
@@ -38,7 +38,7 @@
                required="no"/>
 
     <xsl:variable name="isVirtualCatalog"
-                  select="exists($metadata[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
+                  select="exists($metadata[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
                   as="xs:boolean"/>
 
     <xsl:variable name="languageIri"
@@ -74,7 +74,7 @@
   <xsl:template name="get-dcat-ap-other-languages-as-json">
 
     <xsl:variable name="isVirtualCatalog"
-                  select="exists($metadata[not(dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
+                  select="exists($metadata[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
                   as="xs:boolean"/>
 
     <xsl:variable name="languageContainerElement"

--- a/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
@@ -35,8 +35,18 @@
   <!-- Get the main metadata languages -->
   <xsl:template name="get-dcat-ap-language">
     <xsl:param name="languageIri"
-               select="$metadata//dcat:CatalogRecord/dct:language[1]/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)"
                required="no"/>
+
+    <xsl:variable name="isVirtualCatalog"
+                  select="exists($metadata[not(dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
+                  as="xs:boolean"/>
+
+    <xsl:variable name="languageIri"
+               select="if ($languageIri)
+                            then $languageIri
+                            else if ($isVirtualCatalog)
+                            then $metadata/dcat:Catalog/dct:language[1]/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)
+                            else $metadata//dcat:CatalogRecord/dct:language[1]/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)"/>
 
     <xsl:variable name="languageCode"
                   select="lower-case(replace(
@@ -63,8 +73,17 @@
   <!-- Get the list of other languages in JSON -->
   <xsl:template name="get-dcat-ap-other-languages-as-json">
 
+    <xsl:variable name="isVirtualCatalog"
+                  select="exists($metadata[not(dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
+                  as="xs:boolean"/>
+
+    <xsl:variable name="languageContainerElement"
+                  select="if ($isVirtualCatalog)
+                              then $metadata/dcat:Catalog/dct:language
+                              else $metadata//dcat:CatalogRecord/dct:language"/>
+
     <xsl:variable name="langURIs">
-      <xsl:for-each select="$metadata//dcat:CatalogRecord/dct:language/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)">
+      <xsl:for-each select="$languageContainerElement/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)">
         <langURI>
           <xsl:value-of select="string()"/>
         </langURI>
@@ -74,6 +93,7 @@
       <langURI>http://publications.europa.eu/resource/authority/language/DEU</langURI>
       <langURI>http://publications.europa.eu/resource/authority/language/FRA</langURI>
     </xsl:variable>
+
     <xsl:variable name="langs">
       <xsl:for-each select="distinct-values($langURIs/langURI)">
         <xsl:variable name="languageCode">

--- a/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
@@ -38,7 +38,7 @@
                required="no"/>
 
     <xsl:variable name="isVirtualCatalog"
-                  select="exists($metadata[not(dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
+                  select="exists($metadata[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
                   as="xs:boolean"/>
 
     <xsl:variable name="languageIri"

--- a/src/main/plugin/dcat-ap/layout/utility-tpl.xsl
+++ b/src/main/plugin/dcat-ap/layout/utility-tpl.xsl
@@ -36,7 +36,10 @@
   </xsl:template>
 
   <xsl:template name="get-dcat-ap-title">
-    <xsl:value-of select="$metadata/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:title[1]|$metadata/dcat:Catalog/dcat:service/dcat:DataService/dct:title[1]"/>
+    <xsl:value-of select="$metadata/dcat:Catalog/(
+                                        dcat:dataset/dcat:Dataset/dct:title[1]
+                                        |dcat:service/dcat:DataService/dct:title[1]
+                                        |dct:title[1])[1]"/>
   </xsl:template>
 
   <xsl:template name="get-dcat-ap-extents-as-json">[]</xsl:template>

--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -152,7 +152,7 @@
   </element>
   <element name="dct:LicenseDocument">
     <label>Licentie Document</label>
-    <description>Een legaal document dat officiële toestemming geeft om iets te doen met een resource.</description>
+    <description>Een legaal document dat offici&#xEB;le toestemming geeft om iets te doen met een resource.</description>
     <btnLabel>Licentie Document</btnLabel>
   </element>
   <element name="dct:Location">
@@ -222,7 +222,7 @@
   </element>
   <element name="dct:identifier">
     <label>Identificator</label>
-    <description>Vul aan met een identificator waarmee een gebruiker naar deze resource kan verwijzen (bv. een URI of een andere unieke identificator in de context van de catalogus). De vooraf ingevulde en niet te wijzigen waarde is de UUID voor deze resource in GeoNetwork. Je kan één of meerdere eigen identificatoren toevoegen. </description>
+    <description>Vul aan met een identificator waarmee een gebruiker naar deze resource kan verwijzen (bv. een URI of een andere unieke identificator in de context van de catalogus). De vooraf ingevulde en niet te wijzigen waarde is de UUID voor deze resource in GeoNetwork. Je kan &#xE9;&#xE9;n of meerdere eigen identificatoren toevoegen. </description>
     <btnLabel>Identificator</btnLabel>
   </element>
   <element name="dct:isReferencedBy">
@@ -932,7 +932,7 @@
   </element>
   <element name="mobilitydcatap:mobilityTheme">
     <label>Mobiliteitsthema</label>
-    <description>Deze eigenschap refereert naar het mobiliteits-gerelateerde thema (i.e., een specifiek onderwerp, categorie of type) van de geleverde inhoud.\n\nEen dataset mag geassocieerd worden met meerdere themas. Een thema is belangrijk voor geïnteresseerden in een bepaald type data.</description>
+    <description>Deze eigenschap refereert naar het mobiliteits-gerelateerde thema (i.e., een specifiek onderwerp, categorie of type) van de geleverde inhoud.\n\nEen dataset mag geassocieerd worden met meerdere themas. Een thema is belangrijk voor ge&#xEF;nteresseerden in een bepaald type data.</description>
     <btnLabel>Mobiliteitsthema</btnLabel>
   </element>
   <element name="mobilitydcatap:transportMode">
@@ -944,7 +944,7 @@
     <label>Network coverage</label>
     <description>This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed.
       For other transport modes, the property is meant to refer to the physical infrastructure which is used by the services covered by the data.
-      For all modes, the property SHOULD also indicate if the data content relates to the EU’s trans-European transport network [EU-TEN-T].</description>
+      For all modes, the property SHOULD also indicate if the data content relates to the EU&#x2019;s trans-European transport network [EU-TEN-T].</description>
     <btnLabel>Network coverage</btnLabel>
   </element>
   <element name="mobilitydcatap:georeferencingMethod">
@@ -956,7 +956,7 @@
     <label>Bedoelde informatie service</label>
     <description>This property MAY describe predefined information services, which the data content is intended to support.
       Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR].
-      Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
+      Examples of such services include &#x201C;location search&#x201D;, which is based on a datasets with address identifiers, or &#x201C;trip plan computation&#x201D;, which is based on datasets about a road network.</description>
     <btnLabel>Bedoelde informatie service</btnLabel>
   </element>
   <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
@@ -993,11 +993,6 @@
     <label>Statuut</label>
     <description>Statuut</description>
     <btnLabel>Statuut</btnLabel>
-  </element>
-  <element name="mdcat:stars">
-    <label>Stars</label>
-    <description></description>
-    <btnLabel></btnLabel>
   </element>
   <element name="mdcat:MAGDA-categorie">
     <label>MAGDA-categorie</label>
@@ -1041,7 +1036,12 @@
   </element>
   <element name="mdcat:ontwikkelingstoestand">
     <label>Ontwikkelingstoestand</label>
-    <description>De ontwikkelingstoestand voor de geïmplementeerde dataservice.</description>
+    <description>De ontwikkelingstoestand voor de ge&#xEF;mplementeerde dataservice.</description>
     <btnLabel>Ontwikkelingstoestand</btnLabel>
+  </element>
+  <element name="mdcat:stars">
+    <label>Sterren</label>
+    <description>Rating van 1-5 sterren</description>
+    <btnLabel>Sterren</btnLabel>
   </element>
 </labels>

--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -994,6 +994,11 @@
     <description>Statuut</description>
     <btnLabel>Statuut</btnLabel>
   </element>
+  <element name="mdcat:stars">
+    <label>Stars</label>
+    <description></description>
+    <btnLabel></btnLabel>
+  </element>
   <element name="mdcat:MAGDA-categorie">
     <label>MAGDA-categorie</label>
     <description>MAGDA-categorie</description>

--- a/src/main/plugin/dcat-ap/loc/dut/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/strings.xml
@@ -9,19 +9,19 @@
   <tabDistribution>Distributies</tabDistribution>
   <tabService>Service</tabService>
   <tabRecord>Record</tabRecord>
+  <tabCatalog>Catalogus</tabCatalog>
+  <tabCatalogAssociatedRecords>Geassocieerde records</tabCatalogAssociatedRecords>
+  <associatedRecords>Geassocieerde records</associatedRecords>
+  <associatedRecord>Geassocieerd record</associatedRecord>
+  <virtualCatalogAssociatedRecordNotFound>Geassocieerd records niet in catalogus gevonden</virtualCatalogAssociatedRecordNotFound>
+  <virtualCatalogAssociatedRecordNotFound-help>Record kan verwijderd geweest zijn. Check de relatie.</virtualCatalogAssociatedRecordNotFound-help>
   <basicInformation>Basisinformatie</basicInformation>
   <versionInformation>Versie informatie</versionInformation>
   <usageInformation>Gebruiksinformatie</usageInformation>
   <geographicalInformation>Ruimtelijke en temporele begrenzing</geographicalInformation>
   <relationInformation>Relatie</relationInformation>
   <serviceInformation>Service informatie</serviceInformation>
-  <catalogInformation>Catalogus informatie</catalogInformation>
-  <tabCatalog>Catalogus</tabCatalog>
-  <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
-  <associatedRecords>Records</associatedRecords>
-  <associatedRecord>Associated record</associatedRecord>
-  <virtualCatalogAssociatedRecordNotFound>Associated record not found in catalog.</virtualCatalogAssociatedRecordNotFound>
-  <virtualCatalogAssociatedRecordNotFound-help>Record may have been deleted. Check the relationship.</virtualCatalogAssociatedRecordNotFound-help>
+  <catalogInformation>Catalogusinformatie</catalogInformation>
   <extraInformation>Extra informatie</extraInformation>
   <catalogRecordInformation>Cataloog record</catalogRecordInformation>
   <conformToInformation>Conformiteit met standaard</conformToInformation>
@@ -101,9 +101,9 @@
   <hvd-section>Hoogwaardige Dataset (HVD)</hvd-section>
   <hvd-tab>Hoogwaardige Dataset (HVD)</hvd-tab>
   <hvd-view>Hoogwaardige Dataset (HVD)</hvd-view>
-  <mobility-section>Mobility</mobility-section>
-  <mobility-tab>Mobility</mobility-tab>
-  <mobility-view>Mobility</mobility-view>
+  <mobility-section>Mobiliteit</mobility-section>
+  <mobility-tab>Mobiliteit</mobility-tab>
+  <mobility-view>Mobiliteit</mobility-view>
   <vl-view>Vlaanderen</vl-view>
   <vl-tab-service>Service</vl-tab-service>
   <vl-tab-dataset>Dataset</vl-tab-dataset>

--- a/src/main/plugin/dcat-ap/loc/dut/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/strings.xml
@@ -20,6 +20,8 @@
   <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
   <associatedRecords>Records</associatedRecords>
   <associatedRecord>Associated record</associatedRecord>
+  <virtualCatalogAssociatedRecordNotFound>Associated record not found in catalog.</virtualCatalogAssociatedRecordNotFound>
+  <virtualCatalogAssociatedRecordNotFound-help>Record may have been deleted. Check the relationship.</virtualCatalogAssociatedRecordNotFound-help>
   <extraInformation>Extra informatie</extraInformation>
   <catalogRecordInformation>Cataloog record</catalogRecordInformation>
   <conformToInformation>Conformiteit met standaard</conformToInformation>

--- a/src/main/plugin/dcat-ap/loc/dut/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/strings.xml
@@ -15,6 +15,11 @@
   <geographicalInformation>Ruimtelijke en temporele begrenzing</geographicalInformation>
   <relationInformation>Relatie</relationInformation>
   <serviceInformation>Service informatie</serviceInformation>
+  <catalogInformation>Catalogus informatie</catalogInformation>
+  <tabCatalog>Catalogus</tabCatalog>
+  <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
+  <associatedRecords>Records</associatedRecords>
+  <associatedRecord>Associated record</associatedRecord>
   <extraInformation>Extra informatie</extraInformation>
   <catalogRecordInformation>Cataloog record</catalogRecordInformation>
   <conformToInformation>Conformiteit met standaard</conformToInformation>

--- a/src/main/plugin/dcat-ap/loc/eng/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/labels.xml
@@ -995,6 +995,11 @@
     <description>Tooltip: Statute</description>
     <btnLabel>Statute</btnLabel>
   </element>
+  <element name="mdcat:stars">
+    <label>Stars</label>
+    <description></description>
+    <btnLabel></btnLabel>
+  </element>
   <element name="mdcat:MAGDA-categorie">
     <label>MAGDA-category</label>
     <description>Tooltip: MAGDA-category</description>

--- a/src/main/plugin/dcat-ap/loc/eng/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/labels.xml
@@ -945,7 +945,7 @@
     <label>Network coverage</label>
     <description>This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed.
       For other transport modes, the property is meant to refer to the physical infrastructure which is used by the services covered by the data.
-      For all modes, the property SHOULD also indicate if the data content relates to the EU’s trans-European transport network [EU-TEN-T].</description>
+      For all modes, the property SHOULD also indicate if the data content relates to the EU&#x2019;s trans-European transport network [EU-TEN-T].</description>
     <btnLabel>Network coverage</btnLabel>
   </element>
   <element name="mobilitydcatap:georeferencingMethod">
@@ -957,7 +957,7 @@
     <label>Intended information service</label>
     <description>This property MAY describe predefined information services, which the data content is intended to support.
       Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR].
-      Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
+      Examples of such services include &#x201C;location search&#x201D;, which is based on a datasets with address identifiers, or &#x201C;trip plan computation&#x201D;, which is based on datasets about a road network.</description>
     <btnLabel>Intended information service</btnLabel>
   </element>
   <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
@@ -994,11 +994,6 @@
     <label>Statute</label>
     <description>Tooltip: Statute</description>
     <btnLabel>Statute</btnLabel>
-  </element>
-  <element name="mdcat:stars">
-    <label>Stars</label>
-    <description></description>
-    <btnLabel></btnLabel>
   </element>
   <element name="mdcat:MAGDA-categorie">
     <label>MAGDA-category</label>
@@ -1044,5 +1039,10 @@
     <label>Development status</label>
     <description>The development status of the deployed dataservice.</description>
     <btnLabel>Development status</btnLabel>
+  </element>
+  <element name="mdcat:stars">
+    <label>Stars</label>
+    <description>Rating of 1-5 stars</description>
+    <btnLabel>Stars</btnLabel>
   </element>
 </labels>

--- a/src/main/plugin/dcat-ap/loc/eng/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/strings.xml
@@ -9,6 +9,12 @@
   <tabDistribution>Distributions</tabDistribution>
   <tabService>Service</tabService>
   <tabRecord>Record</tabRecord>
+  <tabCatalog>Catalog</tabCatalog>
+  <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
+  <associatedRecords>Associated records</associatedRecords>
+  <associatedRecord>Associated record</associatedRecord>
+  <virtualCatalogAssociatedRecordNotFound>Associated record not found in catalog.</virtualCatalogAssociatedRecordNotFound>
+  <virtualCatalogAssociatedRecordNotFound-help>Record may have been deleted. Check the relationship.</virtualCatalogAssociatedRecordNotFound-help>
   <basicInformation>Basic information</basicInformation>
   <versionInformation>Version information</versionInformation>
   <usageInformation>Usage information</usageInformation>
@@ -16,12 +22,6 @@
   <relationInformation>Relation</relationInformation>
   <serviceInformation>Service information</serviceInformation>
   <catalogInformation>Catalog information</catalogInformation>
-  <tabCatalog>Catalog</tabCatalog>
-  <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
-  <associatedRecords>Records</associatedRecords>
-  <associatedRecord>Associated record</associatedRecord>
-  <virtualCatalogAssociatedRecordNotFound>Associated record not found in catalog.</virtualCatalogAssociatedRecordNotFound>
-  <virtualCatalogAssociatedRecordNotFound-help>Record may have been deleted. Check the relationship.</virtualCatalogAssociatedRecordNotFound-help>
   <extraInformation>Extra information</extraInformation>
   <catalogRecordInformation>Catalog record</catalogRecordInformation>
   <conformToInformation>Conformiteit met standaard</conformToInformation>

--- a/src/main/plugin/dcat-ap/loc/eng/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/strings.xml
@@ -15,6 +15,11 @@
   <geographicalInformation>Spatial and temporal extent</geographicalInformation>
   <relationInformation>Relation</relationInformation>
   <serviceInformation>Service information</serviceInformation>
+  <catalogInformation>Catalog information</catalogInformation>
+  <tabCatalog>Catalog</tabCatalog>
+  <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
+  <associatedRecords>Records</associatedRecords>
+  <associatedRecord>Associated record</associatedRecord>
   <extraInformation>Extra information</extraInformation>
   <catalogRecordInformation>Catalog record</catalogRecordInformation>
   <conformToInformation>Conformiteit met standaard</conformToInformation>

--- a/src/main/plugin/dcat-ap/loc/eng/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/strings.xml
@@ -20,6 +20,8 @@
   <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
   <associatedRecords>Records</associatedRecords>
   <associatedRecord>Associated record</associatedRecord>
+  <virtualCatalogAssociatedRecordNotFound>Associated record not found in catalog.</virtualCatalogAssociatedRecordNotFound>
+  <virtualCatalogAssociatedRecordNotFound-help>Record may have been deleted. Check the relationship.</virtualCatalogAssociatedRecordNotFound-help>
   <extraInformation>Extra information</extraInformation>
   <catalogRecordInformation>Catalog record</catalogRecordInformation>
   <conformToInformation>Conformiteit met standaard</conformToInformation>

--- a/src/main/plugin/dcat-ap/loc/fre/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/labels.xml
@@ -995,6 +995,11 @@
     <description>Tooltip: Statute</description>
     <btnLabel>Statute</btnLabel>
   </element>
+  <element name="mdcat:stars">
+    <label>Stars</label>
+    <description></description>
+    <btnLabel></btnLabel>
+  </element>
   <element name="mdcat:MAGDA-categorie">
     <label>MAGDA-category</label>
     <description>Tooltip: MAGDA-category</description>

--- a/src/main/plugin/dcat-ap/loc/fre/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/labels.xml
@@ -945,7 +945,7 @@
     <label>Network coverage</label>
     <description>This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed.
       For other transport modes, the property is meant to refer to the physical infrastructure which is used by the services covered by the data.
-      For all modes, the property SHOULD also indicate if the data content relates to the EU’s trans-European transport network [EU-TEN-T].</description>
+      For all modes, the property SHOULD also indicate if the data content relates to the EU&#x2019;s trans-European transport network [EU-TEN-T].</description>
     <btnLabel>Network coverage</btnLabel>
   </element>
   <element name="mobilitydcatap:georeferencingMethod">
@@ -957,7 +957,7 @@
     <label>Intended information service</label>
     <description>This property MAY describe predefined information services, which the data content is intended to support.
       Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR].
-      Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network.</description>
+      Examples of such services include &#x201C;location search&#x201D;, which is based on a datasets with address identifiers, or &#x201C;trip plan computation&#x201D;, which is based on datasets about a road network.</description>
     <btnLabel>Intended information service</btnLabel>
   </element>
   <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
@@ -994,11 +994,6 @@
     <label>Statute</label>
     <description>Tooltip: Statute</description>
     <btnLabel>Statute</btnLabel>
-  </element>
-  <element name="mdcat:stars">
-    <label>Stars</label>
-    <description></description>
-    <btnLabel></btnLabel>
   </element>
   <element name="mdcat:MAGDA-categorie">
     <label>MAGDA-category</label>
@@ -1044,5 +1039,10 @@
     <label>Development status</label>
     <description>The development status of the deployed dataservice.</description>
     <btnLabel>Development status</btnLabel>
+  </element>
+  <element name="mdcat:stars">
+    <label>Stars</label>
+    <description>Rating of 1-5 stars</description>
+    <btnLabel>Stars</btnLabel>
   </element>
 </labels>

--- a/src/main/plugin/dcat-ap/loc/fre/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/strings.xml
@@ -9,6 +9,12 @@
   <tabDistribution>Distributions</tabDistribution>
   <tabService>Service</tabService>
   <tabRecord>Record</tabRecord>
+  <tabCatalog>Catalog</tabCatalog>
+  <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
+  <associatedRecords>Associated records</associatedRecords>
+  <associatedRecord>Associated record</associatedRecord>
+  <virtualCatalogAssociatedRecordNotFound>Associated record not found in catalog.</virtualCatalogAssociatedRecordNotFound>
+  <virtualCatalogAssociatedRecordNotFound-help>Record may have been deleted. Check the relationship.</virtualCatalogAssociatedRecordNotFound-help>
   <basicInformation>Basic information</basicInformation>
   <versionInformation>Version information</versionInformation>
   <usageInformation>Usage information</usageInformation>
@@ -16,26 +22,20 @@
   <relationInformation>Relation</relationInformation>
   <serviceInformation>Service information</serviceInformation>
   <catalogInformation>Catalog information</catalogInformation>
-  <tabCatalog>Catalog</tabCatalog>
-  <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
-  <associatedRecords>Records</associatedRecords>
-  <associatedRecord>Associated record</associatedRecord>
-  <virtualCatalogAssociatedRecordNotFound>Associated record not found in catalog.</virtualCatalogAssociatedRecordNotFound>
-  <virtualCatalogAssociatedRecordNotFound-help>Record may have been deleted. Check the relationship.</virtualCatalogAssociatedRecordNotFound-help>
   <extraInformation>Extra information</extraInformation>
   <catalogRecordInformation>Catalog record</catalogRecordInformation>
   <conformToInformation>Conformiteit met standaard</conformToInformation>
-  <overviews>Aperçus</overviews>
+  <overviews>Aper&#xE7;us</overviews>
   <distribution>Distribution</distribution>
-  <dcat.addThemes>Thèmes</dcat.addThemes>
+  <dcat.addThemes>Th&#xE8;mes</dcat.addThemes>
   <dcat.addTags>Mots clef/balises</dcat.addTags>
   <dcat.addType>Type</dcat.addType>
-  <dcat.addAccessRight>Droit d\'accès</dcat.addAccessRight>
+  <dcat.addAccessRight>Droit d\'acc&#xE8;s</dcat.addAccessRight>
   <dcat.addFormat>Format</dcat.addFormat>
   <dcat.addPackageFormat>Format du packet</dcat.addPackageFormat>
   <dcat.addCompressFormat>Format de compression</dcat.addCompressFormat>
-  <dcat.addMediaType>Type de média</dcat.addMediaType>
-  <dcat.addAccrualPeriodicity>Fréquence de mise à jour</dcat.addAccrualPeriodicity>
+  <dcat.addMediaType>Type de m&#xE9;dia</dcat.addMediaType>
+  <dcat.addAccrualPeriodicity>Fr&#xE9;quence de mise &#xE0; jour</dcat.addAccrualPeriodicity>
   <dcat.addLanguage>Langue</dcat.addLanguage>
   <add-license>License</add-license>
   <license-modellicentie-gratis>Model license for free reuse</license-modellicentie-gratis>

--- a/src/main/plugin/dcat-ap/loc/fre/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/strings.xml
@@ -15,6 +15,11 @@
   <geographicalInformation>Spatial and temporal extent</geographicalInformation>
   <relationInformation>Relation</relationInformation>
   <serviceInformation>Service information</serviceInformation>
+  <catalogInformation>Catalog information</catalogInformation>
+  <tabCatalog>Catalog</tabCatalog>
+  <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
+  <associatedRecords>Records</associatedRecords>
+  <associatedRecord>Associated record</associatedRecord>
   <extraInformation>Extra information</extraInformation>
   <catalogRecordInformation>Catalog record</catalogRecordInformation>
   <conformToInformation>Conformiteit met standaard</conformToInformation>

--- a/src/main/plugin/dcat-ap/loc/fre/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/strings.xml
@@ -20,6 +20,8 @@
   <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
   <associatedRecords>Records</associatedRecords>
   <associatedRecord>Associated record</associatedRecord>
+  <virtualCatalogAssociatedRecordNotFound>Associated record not found in catalog.</virtualCatalogAssociatedRecordNotFound>
+  <virtualCatalogAssociatedRecordNotFound-help>Record may have been deleted. Check the relationship.</virtualCatalogAssociatedRecordNotFound-help>
   <extraInformation>Extra information</extraInformation>
   <catalogRecordInformation>Catalog record</catalogRecordInformation>
   <conformToInformation>Conformiteit met standaard</conformToInformation>

--- a/src/main/plugin/dcat-ap/loc/ger/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/labels.xml
@@ -1890,6 +1890,11 @@
     <description>Tooltip: version</description>
     <btnLabel>version</btnLabel>
   </element>
+  <element name="mdcat:stars">
+    <label>Stars</label>
+    <description></description>
+    <btnLabel></btnLabel>
+  </element>
   <element name="mdcat:landingspaginaVoorAuthenticatie" context="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/mdcat:landingspaginaVoorAuthenticatie">
     <label>Authentication</label>
     <description>Landing page with information about authentication.</description>

--- a/src/main/plugin/dcat-ap/loc/ger/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/strings.xml
@@ -19,6 +19,11 @@
   <geographicalInformation>Spatial and temporal extent</geographicalInformation>
   <relationInformation>Relation</relationInformation>
   <serviceInformation>Service information</serviceInformation>
+  <catalogInformation>Catalog information</catalogInformation>
+  <tabCatalog>Catalog</tabCatalog>
+  <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
+  <associatedRecords>Records</associatedRecords>
+  <associatedRecord>Associated record</associatedRecord>
   <extraInformation>Extra information</extraInformation>
   <catalogRecordInformation>Catalog record</catalogRecordInformation>
   <conformToInformation>Conformiteit met standaard</conformToInformation>

--- a/src/main/plugin/dcat-ap/loc/ger/strings.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/strings.xml
@@ -24,6 +24,8 @@
   <tabCatalogAssociatedRecords>Associated records</tabCatalogAssociatedRecords>
   <associatedRecords>Records</associatedRecords>
   <associatedRecord>Associated record</associatedRecord>
+  <virtualCatalogAssociatedRecordNotFound>Associated record not found in catalog.</virtualCatalogAssociatedRecordNotFound>
+  <virtualCatalogAssociatedRecordNotFound-help>Record may have been deleted. Check the relationship.</virtualCatalogAssociatedRecordNotFound-help>
   <extraInformation>Extra information</extraInformation>
   <catalogRecordInformation>Catalog record</catalogRecordInformation>
   <conformToInformation>Conformiteit met standaard</conformToInformation>

--- a/src/main/plugin/dcat-ap/process/sibling-add.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-add.xsl
@@ -46,16 +46,33 @@
       </xsl:if>
     </xsl:copy>
 
-    <!--
-     <dcat:CatalogRecord rdf:about="https://metadata.vlaanderen.be/srv/resources/records/record1">
-        <foaf:primaryTopic rdf:resource="https://metadata.vlaanderen.be/srv/resources/datasets/uri1"/>
-        <mdcat:stars>5</mdcat:stars>
-        <mdcat:customkeyword>
-        </mdcat:customkeyword>
-        <dct:subject>
-        </dct:subject>
-    </dcat:CatalogRecord>
-    -->
+    <xsl:if test="$uuids != ''">
+      <xsl:for-each select="tokenize($uuids, ',')">
+        <xsl:choose>
+          <xsl:when test="contains(., '#')">
+            <xsl:variable name="tokens" select="tokenize(., '#')"/>
+            <dcat:CatalogRecord rdf:about="{concat($nodeUrl, 'api/records/', $tokens[1])}">
+              <dct:identifier><xsl:value-of select="$tokens[1]"/></dct:identifier>
+              <!--
+              <foaf:primaryTopic rdf:resource="https://metadata.vlaanderen.be/srv/resources/datasets/3986f189-9c4a-4ebb-973c-75036a05cba9"/>
+              -->
+              <mdcat:stars></mdcat:stars>
+              <dct:subject></dct:subject>
+            </dcat:CatalogRecord>
+          </xsl:when>
+          <xsl:otherwise>
+            <dcat:CatalogRecord rdf:about="{concat($nodeUrl, 'api/records/', .)}">
+              <dct:identifier><xsl:value-of select="."/></dct:identifier>
+              <!--
+              <foaf:primaryTopic rdf:resource="https://metadata.vlaanderen.be/srv/resources/datasets/3986f189-9c4a-4ebb-973c-75036a05cba9"/>
+              -->
+              <mdcat:stars></mdcat:stars>
+              <dct:subject></dct:subject>
+            </dcat:CatalogRecord>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:if>
   </xsl:template>
 
 

--- a/src/main/plugin/dcat-ap/process/sibling-add.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-add.xsl
@@ -23,9 +23,10 @@
 
   <xsl:variable name="nodeUrl" select="util:getSettingValue('nodeUrl')"/>
 
-  <xsl:variable name="catalogUuid" select=".//rdf:RDF/dcat:CatalogRecord[not(@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource)]/dct:identifier"/>
+  <xsl:variable name="catalogUuid" select="/rdf:RDF/geonet:info/uuid"/>
 
   <xsl:template match="dcat:Catalog">
+
     <xsl:copy>
       <xsl:copy-of select="*"/>
 

--- a/src/main/plugin/dcat-ap/process/sibling-add.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-add.xsl
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:mdcat="https://data.vlaanderen.be/ns/metadata-dcat#"
+                xmlns:spdx="http://spdx.org/rdf/terms#"
+                xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:owl="http://www.w3.org/2002/07/owl#"
+                xmlns:adms="http://www.w3.org/ns/adms#"
+                exclude-result-prefixes="#all"
+                version="2.0">
+
+
+  <!-- A list of uuids of the target records
+  Each record is described by
+  'uuid#associationType#initiativeType#title#remoteUrl,uuid#...'
+  and are comma separated.
+  title and remoteUrl may be empty for local record.
+  -->
+  <xsl:param name="uuids"/>
+  <xsl:param name="associationType"/>
+  <xsl:param name="initiativeType"/>
+
+  <xsl:variable name="nodeUrl" select="util:getSettingValue('nodeUrl')"/>
+
+  <xsl:template match="dcat:Catalog">
+    <xsl:copy>
+      <xsl:copy-of select="*"/>
+
+      <xsl:if test="$uuids != ''">
+        <xsl:for-each select="tokenize($uuids, ',')">
+          <xsl:choose>
+            <xsl:when test="contains(., '#')">
+              <xsl:variable name="tokens" select="tokenize(., '#')"/>
+              <dcat:record rdf:resource="{concat($nodeUrl, 'api/records/', $tokens[1])}"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <dcat:record rdf:resource="{concat($nodeUrl, 'api/records/', .)}"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+      </xsl:if>
+    </xsl:copy>
+
+    <!--
+     <dcat:CatalogRecord rdf:about="https://metadata.vlaanderen.be/srv/resources/records/record1">
+        <foaf:primaryTopic rdf:resource="https://metadata.vlaanderen.be/srv/resources/datasets/uri1"/>
+        <mdcat:stars>5</mdcat:stars>
+        <mdcat:customkeyword>
+        </mdcat:customkeyword>
+        <dct:subject>
+        </dct:subject>
+    </dcat:CatalogRecord>
+    -->
+  </xsl:template>
+
+
+  <xsl:template match="@*|*|text()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|*|text()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Always remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+</xsl:stylesheet>

--- a/src/main/plugin/dcat-ap/process/sibling-add.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-add.xsl
@@ -6,11 +6,7 @@
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
-                xmlns:mdcat="https://data.vlaanderen.be/ns/metadata-dcat#"
-                xmlns:spdx="http://spdx.org/rdf/terms#"
                 xmlns:foaf="http://xmlns.com/foaf/0.1/"
-                xmlns:owl="http://www.w3.org/2002/07/owl#"
-                xmlns:adms="http://www.w3.org/ns/adms#"
                 exclude-result-prefixes="#all"
                 version="2.0">
 
@@ -27,50 +23,27 @@
 
   <xsl:variable name="nodeUrl" select="util:getSettingValue('nodeUrl')"/>
 
+  <xsl:variable name="catalogUuid" select=".//rdf:RDF/dcat:CatalogRecord[not(@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource)]/dct:identifier"/>
+
   <xsl:template match="dcat:Catalog">
     <xsl:copy>
       <xsl:copy-of select="*"/>
 
       <xsl:if test="$uuids != ''">
         <xsl:for-each select="tokenize($uuids, ',')">
-          <xsl:choose>
-            <xsl:when test="contains(., '#')">
-              <xsl:variable name="tokens" select="tokenize(., '#')"/>
-              <dcat:record rdf:resource="{concat($nodeUrl, 'api/records/', $tokens[1])}"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <dcat:record rdf:resource="{concat($nodeUrl, 'api/records/', .)}"/>
-            </xsl:otherwise>
-          </xsl:choose>
+          <xsl:variable name="tokens" select="tokenize(., '#')"/>
+          <dcat:record rdf:resource="{concat($nodeUrl, 'api/records/', $catalogUuid, '/', $tokens[1])}"/>
         </xsl:for-each>
       </xsl:if>
     </xsl:copy>
 
     <xsl:if test="$uuids != ''">
       <xsl:for-each select="tokenize($uuids, ',')">
-        <xsl:choose>
-          <xsl:when test="contains(., '#')">
-            <xsl:variable name="tokens" select="tokenize(., '#')"/>
-            <dcat:CatalogRecord rdf:about="{concat($nodeUrl, 'api/records/', $tokens[1])}">
-              <dct:identifier><xsl:value-of select="$tokens[1]"/></dct:identifier>
-              <!--
-              <foaf:primaryTopic rdf:resource="https://metadata.vlaanderen.be/srv/resources/datasets/3986f189-9c4a-4ebb-973c-75036a05cba9"/>
-              -->
-              <mdcat:stars></mdcat:stars>
-              <dct:subject></dct:subject>
-            </dcat:CatalogRecord>
-          </xsl:when>
-          <xsl:otherwise>
-            <dcat:CatalogRecord rdf:about="{concat($nodeUrl, 'api/records/', .)}">
-              <dct:identifier><xsl:value-of select="."/></dct:identifier>
-              <!--
-              <foaf:primaryTopic rdf:resource="https://metadata.vlaanderen.be/srv/resources/datasets/3986f189-9c4a-4ebb-973c-75036a05cba9"/>
-              -->
-              <mdcat:stars></mdcat:stars>
-              <dct:subject></dct:subject>
-            </dcat:CatalogRecord>
-          </xsl:otherwise>
-        </xsl:choose>
+        <xsl:variable name="tokens" select="tokenize(., '#')"/>
+        <dcat:CatalogRecord rdf:about="{concat($nodeUrl, 'api/records/', $catalogUuid, '/', $tokens[1])}">
+          <dct:identifier><xsl:value-of select="$tokens[1]"/></dct:identifier>
+          <foaf:primaryTopic rdf:resource="{concat($nodeUrl, 'api/records/', $tokens[1])}"/>
+        </dcat:CatalogRecord>
       </xsl:for-each>
     </xsl:if>
   </xsl:template>
@@ -82,6 +55,5 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Always remove geonet:* elements. -->
   <xsl:template match="geonet:*" priority="2"/>
 </xsl:stylesheet>

--- a/src/main/plugin/dcat-ap/process/sibling-remove.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-remove.xsl
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:geonet="http://www.fao.org/geonetwork"
                 xmlns:util="java:org.fao.geonet.util.XslUtil"
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
-                xmlns:mdcat="https://data.vlaanderen.be/ns/metadata-dcat#"
-                xmlns:spdx="http://spdx.org/rdf/terms#"
-                xmlns:foaf="http://xmlns.com/foaf/0.1/"
-                xmlns:owl="http://www.w3.org/2002/07/owl#"
-                xmlns:adms="http://www.w3.org/ns/adms#"
                 exclude-result-prefixes="#all"
                 version="2.0">
 
@@ -18,8 +12,10 @@
 
   <xsl:variable name="nodeUrl" select="util:getSettingValue('nodeUrl')"/>
 
-  <xsl:template match="dcat:Catalog/dcat:record[@rdf:resource = concat($nodeUrl, 'api/records/', $uuidref)]|
-                                     dcat:CatalogRecord[@rdf:about = concat($nodeUrl, 'api/records/', $uuidref)]"/>
+  <xsl:variable name="catalogUuid" select=".//rdf:RDF/dcat:CatalogRecord[not(@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource)]/dct:identifier"/>
+
+  <xsl:template match="dcat:Catalog/dcat:record[@rdf:resource = concat($nodeUrl, 'api/records/', $catalogUuid, '/', $uuidref)]|
+                                     dcat:CatalogRecord[@rdf:about = concat($nodeUrl, 'api/records/', $catalogUuid, '/', $uuidref)]"/>
 
   <xsl:template match="@*|*|text()">
     <xsl:copy>
@@ -27,6 +23,5 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Always remove geonet:* elements. -->
   <xsl:template match="geonet:*" priority="2"/>
 </xsl:stylesheet>

--- a/src/main/plugin/dcat-ap/process/sibling-remove.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-remove.xsl
@@ -9,10 +9,9 @@
                 version="2.0">
 
   <xsl:param name="uuidref"/>
+  <xsl:variable name="catalogUuid" select="/rdf:RDF/geonet:info/uuid"/>
 
   <xsl:variable name="nodeUrl" select="util:getSettingValue('nodeUrl')"/>
-
-  <xsl:variable name="catalogUuid" select=".//rdf:RDF/dcat:CatalogRecord[not(@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource)]/dct:identifier"/>
 
   <xsl:template match="dcat:Catalog/dcat:record[@rdf:resource = concat($nodeUrl, 'api/records/', $catalogUuid, '/', $uuidref)]|
                                      dcat:CatalogRecord[@rdf:about = concat($nodeUrl, 'api/records/', $catalogUuid, '/', $uuidref)]"/>

--- a/src/main/plugin/dcat-ap/process/sibling-remove.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-remove.xsl
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:mdcat="https://data.vlaanderen.be/ns/metadata-dcat#"
+                xmlns:spdx="http://spdx.org/rdf/terms#"
+                xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:owl="http://www.w3.org/2002/07/owl#"
+                xmlns:adms="http://www.w3.org/ns/adms#"
+                exclude-result-prefixes="#all"
+                version="2.0">
+
+  <xsl:param name="uuidref"/>
+
+  <xsl:variable name="nodeUrl" select="util:getSettingValue('nodeUrl')"/>
+
+  <xsl:template match="dcat:Catalog/dcat:record[@rdf:resource = concat($nodeUrl, 'api/records/', $uuidref)]|
+                                     dcat:CatalogRecord[@rdf:about = concat($nodeUrl, 'api/records/', $uuidref)]"/>
+
+  <xsl:template match="@*|*|text()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|*|text()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Always remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+</xsl:stylesheet>

--- a/src/main/plugin/dcat-ap/schema/dcat.xsd
+++ b/src/main/plugin/dcat-ap/schema/dcat.xsd
@@ -119,6 +119,7 @@
 
                 <!-- Profile / dcat-ap-vl & metadata-dcat -->
                 <xs:element ref="adms:identifier" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="mdcat:stars" minOccurs="0"/>
 
                 <!-- Profile / mobilityDCAT-AP -->
                 <!-- Mandatory -->

--- a/src/main/plugin/dcat-ap/schema/dcat.xsd
+++ b/src/main/plugin/dcat-ap/schema/dcat.xsd
@@ -44,7 +44,6 @@
   <xs:import namespace="http://data.europa.eu/r5r/" schemaLocation="profiles/eu-dcat-ap-hvd.xsd"/>
   <xs:import namespace="https://w3id.org/mobilitydcat-ap" schemaLocation="profiles/eu-dcat-ap-mobility.xsd"/>
 
-
   <xs:element name="Catalog" type="dcat:Catalog_type"/>
 
   <!-- dcat:Catalog-->
@@ -61,7 +60,7 @@
           <xs:element name="dataset" type="dcat:Dataset_type" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="keyword" type="rdf:PlainLiteral" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="landingPage" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element name="record" type="dcat:CatalogRecord_type" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="record" type="dcat:Catalog_CatalogRecord_type" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="service" type="dcat:DataService_type" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="theme" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="themeTaxonomy" type="skos:ConceptScheme" minOccurs="0" maxOccurs="unbounded"/>
@@ -95,43 +94,47 @@
     </xs:complexContent>
   </xs:complexType>
 
+  <xs:complexType name="Catalog_CatalogRecord_type">
+    <xs:sequence>
+      <xs:element ref="dcat:CatalogRecord" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute ref="rdf:resource"/>
+  </xs:complexType>
+
+  <xs:element name="CatalogRecord" type="dcat:CatalogRecord_type"/>
+
   <!-- dcat:CatalogRecord-->
   <xs:complexType name="CatalogRecord_type">
-    <xs:sequence>
-      <xs:element name="CatalogRecord">
-        <xs:complexType>
-          <xs:complexContent>
-            <xs:extension base="rdf:Resource">
-              <xs:sequence>
-                <!-- dcat -->
-                <xs:element ref="foaf:primaryTopic" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:modified" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:conformsTo" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="adms:status" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:issued" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:title" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:description" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:source" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:language" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:rights" minOccurs="0" maxOccurs="unbounded"/>
-                <!-- additionally, required by GeoNetwork for identification -->
-                <xs:element ref="dct:identifier" minOccurs="0" maxOccurs="unbounded"/> <!-- Required by GeoNetwork for MD identifications -->
+    <xs:complexContent>
+      <xs:extension base="rdf:Resource">
+        <xs:sequence>
+          <!-- dcat -->
+          <xs:element ref="foaf:primaryTopic" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:modified" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:conformsTo" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="adms:status" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:issued" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:title" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:description" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:source" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:language" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:rights" minOccurs="0" maxOccurs="unbounded"/>
+          <!-- additionally, required by GeoNetwork for identification -->
+          <xs:element ref="dct:identifier" minOccurs="0"
+                      maxOccurs="unbounded"/> <!-- Required by GeoNetwork for MD identifications -->
 
-                <!-- Profile / dcat-ap-vl & metadata-dcat -->
-                <xs:element ref="adms:identifier" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="mdcat:stars" minOccurs="0"/>
+          <!-- Profile / dcat-ap-vl & metadata-dcat -->
+          <xs:element ref="adms:identifier" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="mdcat:stars" minOccurs="0" maxOccurs="unbounded"/>
 
-                <!-- Profile / mobilityDCAT-AP -->
-                <!-- Mandatory -->
-                <xs:element ref="dct:created" minOccurs="0" maxOccurs="unbounded"/>
-                <!-- Optional -->
-                <xs:element ref="dct:publisher" minOccurs="0" maxOccurs="unbounded"/>
-              </xs:sequence>
-            </xs:extension>
-          </xs:complexContent>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
+          <!-- Profile / mobilityDCAT-AP -->
+          <!-- Mandatory -->
+          <xs:element ref="dct:created" minOccurs="0" maxOccurs="unbounded"/>
+          <!-- Optional -->
+          <xs:element ref="dct:publisher" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 
   <!-- dcat:Dataset-->

--- a/src/main/plugin/dcat-ap/schema/profiles/mdcat.xsd
+++ b/src/main/plugin/dcat-ap/schema/profiles/mdcat.xsd
@@ -30,4 +30,14 @@
   <xs:element name="ontwikkelingstoestand" type="skos:Concept"/>
   <xs:element name="MAGDA-categorie" type="dct:subject"/>
   <xs:element name="statuut" type="dct:subject"/>
+
+  <!-- 5 stars evaluation between 1 and 5 -->
+  <xs:element name="stars" type="xs:integer">
+    <xs:simpleType>
+      <xs:restriction base="xs:integer">
+        <xs:minInclusive value="1"/>
+        <xs:maxInclusive value="5"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
 </xs:schema>

--- a/src/main/plugin/dcat-ap/schema/profiles/mdcat.xsd
+++ b/src/main/plugin/dcat-ap/schema/profiles/mdcat.xsd
@@ -32,7 +32,7 @@
   <xs:element name="statuut" type="dct:subject"/>
 
   <!-- 5 stars evaluation between 1 and 5 -->
-  <xs:element name="stars" type="xs:integer">
+  <xs:element name="stars">
     <xs:simpleType>
       <xs:restriction base="xs:integer">
         <xs:minInclusive value="1"/>

--- a/src/main/plugin/dcat-ap/schema/rdf.xsd
+++ b/src/main/plugin/dcat-ap/schema/rdf.xsd
@@ -104,9 +104,10 @@ The Resource Description Framework [RDF] is defined to have an extensible system
   </xs:complexType>
   <!-- CatalogRoot -->
   <xs:complexType name="CatalogRoot">
-    <xs:choice>
+    <xs:sequence>
       <xs:element ref="dcat:Catalog"/>
-    </xs:choice>
+      <xs:element ref="dcat:CatalogRecord" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
   </xs:complexType>
   <!-- individual elements -->
   <xs:element name="type" type="rdf:ResourceRef"/>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-cardinalities.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-cardinalities.sch
@@ -68,13 +68,13 @@
     <sch:param name="max" value="1"/>
   </sch:pattern>
   <sch:pattern is-a="CardinalityCheck" id="Catalog_publisher">
-    <sch:param name="context" value="//dcat:Catalog"/>
+    <sch:param name="context" value="//dcat:Catalog[dcat:dataset or dcat:dataservice]"/>
     <sch:param name="element" value="dct:publisher"/>
     <sch:param name="min" value="1"/>
     <sch:param name="max" value="1"/>
   </sch:pattern>
   <sch:pattern is-a="CardinalityCheck" id="Catalog_record">
-    <sch:param name="context" value="//dcat:Catalog"/>
+    <sch:param name="context" value="//dcat:Catalog[dcat:dataset or dcat:dataservice]"/>
     <sch:param name="element" value="dcat:record"/>
     <sch:param name="min" value="1"/>
     <sch:param name="max" value="1"/>
@@ -98,7 +98,7 @@
     <sch:param name="max" value="n"/>
   </sch:pattern>
   <sch:pattern is-a="CardinalityCheck" id="Catalog_modified">
-    <sch:param name="context" value="//dcat:Catalog"/>
+    <sch:param name="context" value="//dcat:Catalog[dcat:dataset or dcat:dataservice]"/>
     <sch:param name="element" value="dct:modified"/>
     <sch:param name="min" value="0"/>
     <sch:param name="max" value="n"/>
@@ -141,7 +141,7 @@
     <sch:param name="max" value="1"/>
   </sch:pattern>
   <sch:pattern is-a="CardinalityCheck" id="CatalogRecord_modified">
-    <sch:param name="context" value="dcat:CatalogRecord"/>
+    <sch:param name="context" value="dcat:CatalogRecord[ancestor::dcat:Catalog[dcat:dataset or dcat:dataservice]]"/>
     <sch:param name="element" value="dct:modified"/>
     <sch:param name="min" value="1"/>
     <sch:param name="max" value="1"/>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
@@ -1,0 +1,20 @@
+<rdf:RDF xmlns:dcat="http://www.w3.org/ns/dcat#"
+         xmlns:dct="http://purl.org/dc/terms/"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/"
+         xmlns:mdcat="https://data.vlaanderen.be/ns/metadata-dcat#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+>
+  <dcat:Catalog rdf:about="https://metadata.vlaanderen.be/virtualcatalogtemplate">
+    <dct:title xml:lang="nl">Virtual catalog template</dct:title>
+    <dct:description xml:lang="nl">Metadata Vlaanderen (agentschap Digitaal Vlaanderen)</dct:description>
+    <dcat:record rdf:resource="https://metadata.vlaanderen.be/srv/resources/records/record1"/>
+  </dcat:Catalog>
+  <dcat:CatalogRecord rdf:about="https://metadata.vlaanderen.be/srv/resources/records/record1">
+    <foaf:primaryTopic rdf:resource="https://metadata.vlaanderen.be/srv/resources/datasets/uri1"/>
+    <mdcat:stars></mdcat:stars>
+    <mdcat:customkeyword>
+    </mdcat:customkeyword>
+    <dct:subject>
+    </dct:subject>
+  </dcat:CatalogRecord>
+</rdf:RDF>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
@@ -1,11 +1,20 @@
-<rdf:RDF xmlns:dcat="http://www.w3.org/ns/dcat#"
-         xmlns:dct="http://purl.org/dc/terms/"
-         xmlns:foaf="http://xmlns.com/foaf/0.1/"
-         xmlns:mdcat="https://data.vlaanderen.be/ns/metadata-dcat#"
+<rdf:RDF xmlns:schema="http://schema.org/"
          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
->
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:dct="http://purl.org/dc/terms/"
+         xmlns:dcat="http://www.w3.org/ns/dcat#">
   <dcat:Catalog rdf:about="https://metadata.vlaanderen.be/virtualcatalogtemplate">
+    <dct:description xml:lang="nl">Metadata Vlaanderen (agentschap Digitaal Vlaanderen)</dct:description>
+    <dct:language>
+      <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
+        <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
+        <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">Dutch</skos:prefLabel>
+        <skos:prefLabel xml:lang="de">Niederländisch</skos:prefLabel>
+        <skos:prefLabel xml:lang="fr">néerlandais</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
+      </skos:Concept>
+    </dct:language>
     <dct:title xml:lang="nl">Virtual catalog template</dct:title>
-    <dct:description xml:lang="nl"></dct:description>
   </dcat:Catalog>
 </rdf:RDF>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
@@ -6,15 +6,6 @@
 >
   <dcat:Catalog rdf:about="https://metadata.vlaanderen.be/virtualcatalogtemplate">
     <dct:title xml:lang="nl">Virtual catalog template</dct:title>
-    <dct:description xml:lang="nl">Metadata Vlaanderen (agentschap Digitaal Vlaanderen)</dct:description>
-    <dcat:record rdf:resource="https://metadata.vlaanderen.be/srv/resources/records/record1"/>
+    <dct:description xml:lang="nl"></dct:description>
   </dcat:Catalog>
-  <dcat:CatalogRecord rdf:about="https://metadata.vlaanderen.be/srv/resources/records/record1">
-    <foaf:primaryTopic rdf:resource="https://metadata.vlaanderen.be/srv/resources/datasets/uri1"/>
-    <mdcat:stars></mdcat:stars>
-    <mdcat:customkeyword>
-    </mdcat:customkeyword>
-    <dct:subject>
-    </dct:subject>
-  </dcat:CatalogRecord>
 </rdf:RDF>

--- a/src/main/plugin/dcat-ap/update-fixed-info-variables.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info-variables.xsl
@@ -92,6 +92,9 @@
 
   <xsl:variable name="resourceUUID">
     <xsl:choose>
+      <xsl:when test="$isVirtualCatalog">
+        <xsl:value-of select="$recordUUID"/>
+      </xsl:when>
       <xsl:when test="count($resource/dct:identifier[matches(., concat('^', $uuidRegex, '$'))]) > 0">
         <xsl:value-of select="$resource/dct:identifier[matches(., concat('^', $uuidRegex, '$'))][1]"/>
       </xsl:when>

--- a/src/main/plugin/dcat-ap/update-fixed-info-variables.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info-variables.xsl
@@ -61,7 +61,7 @@
                 select="document('layout/config-editor.xml')"/>
 
   <xsl:variable name="isVirtualCatalog"
-                      select="exists(/root/rdf:RDF[not(dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
+                      select="exists(/root/rdf:RDF[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
                       as="xs:boolean"/>
 
   <xsl:variable name="resourceType">

--- a/src/main/plugin/dcat-ap/update-fixed-info-variables.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info-variables.xsl
@@ -22,6 +22,7 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
@@ -59,13 +60,23 @@
   <xsl:variable name="editorConfig"
                 select="document('layout/config-editor.xml')"/>
 
+  <xsl:variable name="isVirtualCatalog"
+                      select="exists(/root/rdf:RDF[not(dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
+                      as="xs:boolean"/>
+
   <xsl:variable name="resourceType">
     <xsl:choose>
       <xsl:when test="/root/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
         <xsl:value-of select="'datasets'"/>
       </xsl:when>
-      <xsl:otherwise>
+      <xsl:when test="/root/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:DataService">
         <xsl:value-of select="'services'"/>
+      </xsl:when>
+      <xsl:when test="$isVirtualCatalog">
+        <xsl:value-of select="'catalog'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'datasets'"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>

--- a/src/main/plugin/dcat-ap/update-fixed-info-variables.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info-variables.xsl
@@ -61,7 +61,7 @@
                 select="document('layout/config-editor.xml')"/>
 
   <xsl:variable name="isVirtualCatalog"
-                      select="exists(/root/rdf:RDF[not(//dcat:dataset/(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
+                      select="exists(/root/rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
                       as="xs:boolean"/>
 
   <xsl:variable name="resourceType">

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -191,6 +191,15 @@
     </xsl:copy>
   </xsl:template>
 
+  <xsl:template match="dcat:Catalog[$isVirtualCatalog and not(dct:identifier)]" priority="10">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|*"/>
+      <dct:identifier>
+        <xsl:value-of select="$recordUUID"/>
+      </dct:identifier>
+    </xsl:copy>
+  </xsl:template>
+
   <xsl:template match="dcat:Catalog[not($isVirtualCatalog)]" priority="10">
     <dcat:Catalog>
       <xsl:attribute name="rdf:about">

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -55,7 +55,6 @@
   <xsl:include href="update-fixed-info-variables.xsl"/>
   <xsl:include href="update-fixed-info-dcat-ap-vl.xsl"/>
 
-
   <!-- Ignore element not in main language (they are handled in dcat2-translations-builder. -->
   <xsl:template match="*[
                           count(*) = 0
@@ -192,7 +191,7 @@
     </xsl:copy>
   </xsl:template>
 
-  <xsl:template match="dcat:Catalog" priority="10">
+  <xsl:template match="dcat:Catalog[not($isVirtualCatalog)]" priority="10">
     <dcat:Catalog>
       <xsl:attribute name="rdf:about">
         <xsl:value-of select="concat($resourcePrefix, '/catalogs/', $env/system/site/siteId)"/>

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -306,7 +306,7 @@
   </xsl:template>
 
 
-  <xsl:template match="dcat:CatalogRecord" priority="2">
+  <xsl:template match="dcat:CatalogRecord[not($isVirtualCatalog)]" priority="2">
     <xsl:copy copy-namespaces="no">
       <xsl:call-template name="handle-record-id"/>
       <dct:modified>

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -306,7 +306,9 @@
   </xsl:template>
 
 
-  <xsl:template match="dcat:CatalogRecord[not($isVirtualCatalog)]" priority="2">
+  <!-- Virtual catalog contains additional CatalogRecord for all associated resources.
+  Only alter the one matching the Catalog instance. -->
+  <xsl:template match="dcat:CatalogRecord[not(@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource)]" priority="2">
     <xsl:copy copy-namespaces="no">
       <xsl:call-template name="handle-record-id"/>
       <dct:modified>

--- a/transifex/translations/dcat-ap_loc_labels/en_US.xml
+++ b/transifex/translations/dcat-ap_loc_labels/en_US.xml
@@ -1059,4 +1059,9 @@
     <item>The development status of the deployed dataservice.</item>
     <item>Development status</item>
   </string-array>
+  <string-array name="mdcat:stars">
+    <item>Stars</item>
+    <item>Rating of 1-5 stars</item>
+    <item>Stars</item>
+  </string-array>
 </resources>

--- a/transifex/translations/dcat-ap_loc_strings/en_US.xml
+++ b/transifex/translations/dcat-ap_loc_strings/en_US.xml
@@ -9,6 +9,12 @@
     <string name="tabDistribution">Distributions</string>
     <string name="tabService">Service</string>
     <string name="tabRecord">Record</string>
+    <string name="tabCatalog">Catalog</string>
+    <string name="tabCatalogAssociatedRecords">Associated records</string>
+    <string name="associatedRecords">Associated records</string>
+    <string name="associatedRecord">Associated record</string>
+    <string name="virtualCatalogAssociatedRecordNotFound">Associated record not found in catalog.</string>
+    <string name="virtualCatalogAssociatedRecordNotFound-help">Record may have been deleted. Check the relationship.</string>
 
     <!-- Section labels -->
     <string name="basicInformation">Basic information</string>
@@ -17,6 +23,7 @@
     <string name="geographicalInformation">Spatial and temporal extent</string>
     <string name="relationInformation">Relation</string>
     <string name="serviceInformation">Service information</string>
+    <string name="catalogInformation">Catalog information</string>
     <string name="extraInformation">Extra information</string>
     <string name="catalogRecordInformation">Catalog record</string>
     <string name="conformToInformation">Conformiteit met standaard</string>


### PR DESCRIPTION
A virtual catalog is a record describing a group of records. eg. a data space. For each attached records, some properties can be added eg. stars, keywords

A virtual catalog is a DCAT record not containing `dcat:Dataset|dcat:DataService`.

```xpath
exists(rdf:RDF[not(*/(dcat:Dataset|dcat:DataService))]/dcat:Catalog)
```


## Example

```xml
<rdf:RDF xmlns:schema="http://schema.org/"
         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
         xmlns:spdx="http://spdx.org/rdf/terms#"
         xmlns:owl="http://www.w3.org/2002/07/owl#"
         xmlns:dc="http://purl.org/dc/elements/1.1/"
         xmlns:mobilitydcatap="https://w3id.org/mobilitydcat-ap"
         xmlns:adms="http://www.w3.org/ns/adms#"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:locn="http://www.w3.org/ns/locn#"
         xmlns:mdcat="https://data.vlaanderen.be/ns/metadata-dcat#"
         xmlns:foaf="http://xmlns.com/foaf/0.1/"
         xmlns:dct="http://purl.org/dc/terms/"
         xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
         xmlns:dcat="http://www.w3.org/ns/dcat#"
         xmlns:dcatap="http://data.europa.eu/r5r/">
  <dcat:Catalog>
      <dcat:keyword>dataspace</dcat:keyword>
      <dcat:record rdf:resource="http://localhost:8080/geonetwork/srv/api/records/44ad3004-fd1b-490e-87fa-fcb6b5b6e43c/e161c72c-3a25-4b53-885e-ef1f8c84583d"/>
      <dct:description xml:lang="nl">Metadata Vlaanderen (agentschap Digitaal Vlaanderen)</dct:description>
      <dct:language>
         <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
            <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
            <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
            <skos:prefLabel xml:lang="en">Dutch</skos:prefLabel>
            <skos:prefLabel xml:lang="de">Niederländisch</skos:prefLabel>
            <skos:prefLabel xml:lang="fr">néerlandais</skos:prefLabel>
            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
         </skos:Concept>
      </dct:language>
      <dct:title xml:lang="nl">Inland water data space</dct:title>
   </dcat:Catalog>
  <dcat:CatalogRecord rdf:about="http://localhost:8080/geonetwork/srv/api/records/44ad3004-fd1b-490e-87fa-fcb6b5b6e43c/e161c72c-3a25-4b53-885e-ef1f8c84583d">
      <foaf:primaryTopic rdf:resource="http://localhost:8080/geonetwork/srv/api/records/e161c72c-3a25-4b53-885e-ef1f8c84583d"/>
      <dct:identifier>e161c72c-3a25-4b53-885e-ef1f8c84583d</dct:identifier>
      <mdcat:stars>2</mdcat:stars>
   </dcat:CatalogRecord>
  <dcat:CatalogRecord rdf:about="http://localhost:8080/geonetwork/srv/api/records/44ad3004-fd1b-490e-87fa-fcb6b5b6e43c">
      <foaf:primaryTopic rdf:resource="resources/services/78dd54ab-21a0-44b6-a74b-020445175528"/>
      <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-19</dct:modified>
      <dct:identifier>44ad3004-fd1b-490e-87fa-fcb6b5b6e43c</dct:identifier>
   </dcat:CatalogRecord>
</rdf:RDF>
```

## Editor 

### Main properties

* title
* description
* keywords

![image](https://github.com/user-attachments/assets/6acd4de0-fa1d-4e2f-ae75-17e6fff4f9be)


### Associated records

Associated records member of the catalog can be added using the side panel

![image](https://github.com/user-attachments/assets/cfcea903-5339-411b-8da1-6cd10d0480ec)


or from the main form

![image](https://github.com/user-attachments/assets/91485dbb-28c7-450e-bf4a-bacb61c9ae95)

When associated, the reference is composed of 2 sections:

* a `dcat:record` reference in the catalog

```xml
<dcat:record rdf:resource="https://metadata.vlaanderen.be/srv/resources/records/catalogueUuid/recordUuid"/>
```

* a `dcat:CatalogRecord` element with optionnally additional properties

```xml
   <dcat:CatalogRecord rdf:about="https://metadata.vlaanderen.be/srv/resources/records/catalogueUuid/recordUuid">
        <foaf:primaryTopic rdf:resource="https://metadata.vlaanderen.be/srv/api/records/recordUuid"/>
        <mdcat:stars>2</mdcat:stars>
    </dcat:CatalogRecord>
```

Related record may be removed at some point and no constraint checks are in place but in editor mode, not found related record will be highlighted:

![image](https://github.com/user-attachments/assets/dafd511f-5e99-4168-8500-0c906d856c3a)



## View mode

Catalog records provide quick access to associated records:

![image](https://github.com/user-attachments/assets/80a112ae-2194-4e3e-a462-b45662a8f7b2)

Associated records contain link to the catalog:

![image](https://github.com/user-attachments/assets/132acdbf-ab89-4aa0-942d-3057f1b05588)



## Home page quick access

To give more visibility to virtual catalog, the home page tabs can be configured to highlight them:


![image](https://github.com/user-attachments/assets/0822d580-841a-4605-98ea-8a9827bb7e0b)


Add this to the UI configuration:

```js
   info: [
              {
                type: "search",
                title: "Data spaces",
                active: true,
                params: {
                  resourceType: "catalog",
                  sortBy: "createDate",
                  sortOrder: "desc",
                  from: 1,
                  to: 12
                }
              }, {
                type: "search",
                title: "lastRecords",
```
