### PR TITLE
Fixing template titles

### DIFF
--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
@@ -28,7 +28,7 @@
     </dcat:record>
     <dcat:dataset>
       <dcat:Dataset>
-        <dct:title xml:lang="nl">&lt;span id="template3">&lt;strong&gt;Andere gegevens&lt;/strong&gt; (niet-open en niet-geo): Sjabloon voor Metadata van Generieke Gesloten data, conform metadata-DCAT v2.0&lt;/span></dct:title>
+        <dct:title xml:lang="nl">Andere gegevens (niet-open en niet-geo): Sjabloon voor Metadata van Generieke Gesloten data, conform metadata-DCAT v2.0</dct:title>
         <dct:description xml:lang="nl"/>
         <dcat:contactPoint>
           <vcard:Organization>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
@@ -28,7 +28,7 @@
     </dcat:record>
     <dcat:service>
       <dcat:DataService>
-        <dct:title xml:lang="nl">&lt;span id="template3">&lt;strong&gt;Andere gegevens&lt;/strong&gt; (niet-open en niet-geo): Sjabloon voor Metadata van Generieke Gesloten services, conform metadata-DCAT v2.0&lt;/span></dct:title>
+        <dct:title xml:lang="nl">Andere gegevens (niet-open en niet-geo): Sjabloon voor Metadata van Generieke Gesloten services, conform metadata-DCAT v2.0</dct:title>
         <dct:description/>
         <dct:publisher>
           <foaf:Agent>


### PR DESCRIPTION
Some templates contain titles with HTML tags, that does not render well in basic GeoNetwork UI:

![image](https://github.com/user-attachments/assets/0e04cb1e-3053-479b-8633-b4f812886791)


