### PR TITLE
fixed csw-brief for dcat-ap

### DIFF
--- a/src/main/plugin/dcat-ap/present/csw/csw-brief.xsl
+++ b/src/main/plugin/dcat-ap/present/csw/csw-brief.xsl
@@ -23,15 +23,16 @@
   -->
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
-    xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:dct="http://purl.org/dc/terms/"
-    xmlns:dcat="http://www.w3.org/ns/dcat#"
-    xmlns:geonet="http://www.fao.org/geonetwork">
+                xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:geonet="http://www.fao.org/geonetwork">
 
   <xsl:param name="displayInfo"/>
 
-  <xsl:template match="//dcat:Catalog/dcat:record/dcat:CatalogRecord">
+  <xsl:template match="//dcat:CatalogRecord[not(@rdf:about =  ../dcat:Catalog/dcat:record/@rdf:resource)]">
     <xsl:variable name="info" select="geonet:info"/>
     <csw:BriefRecord>
       <xsl:for-each select="dct:identifier">
@@ -40,25 +41,18 @@
         </dc:identifier>
       </xsl:for-each>
 
-      <!-- Change for CSW 2.0.2 - title is mandatory -->
-      <xsl:for-each select="../..//dcat:Dataset/dct:title|../..//dcat:DataService/dct:title">
+      <xsl:for-each select="ancestor::rdf:RDF//(dcat:Dataset|dcat:DataService)/dct:title">
         <dc:title>
           <xsl:value-of select="."/>
         </dc:title>
       </xsl:for-each>
 
-      <xsl:if test="//dcat:Dataset">
+      <xsl:if test="ancestor::rdf:RDF//dcat:Dataset">
         <dc:type>dataset</dc:type>
       </xsl:if>
-      <xsl:if test="//dcat:DataService">
+      <xsl:if test="ancestor::rdf:RDF//dcat:DataService">
         <dc:type>service</dc:type>
       </xsl:if>
-
-      <!-- GeoNetwork elements added when resultType is equal to results_with_summary -->
-      <xsl:if test="$displayInfo = 'true'">
-        <xsl:copy-of select="$info"/>
-      </xsl:if>
-
     </csw:BriefRecord>
   </xsl:template>
 

--- a/src/main/plugin/dcat-ap/present/csw/csw-brief.xsl
+++ b/src/main/plugin/dcat-ap/present/csw/csw-brief.xsl
@@ -24,30 +24,35 @@
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
-    xmlns:dc ="http://purl.org/dc/elements/1.1/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
     xmlns:dct="http://purl.org/dc/terms/"
     xmlns:dcat="http://www.w3.org/ns/dcat#"
     xmlns:geonet="http://www.fao.org/geonetwork">
 
   <xsl:param name="displayInfo"/>
 
-  <xsl:template match="dataset">
+  <xsl:template match="//dcat:Catalog/dcat:record/dcat:CatalogRecord">
     <xsl:variable name="info" select="geonet:info"/>
     <csw:BriefRecord>
       <xsl:for-each select="dct:identifier">
-        <dct:identifier><xsl:value-of select="."/></dct:identifier>
+        <dc:identifier>
+          <xsl:value-of select="."/>
+        </dc:identifier>
       </xsl:for-each>
 
-<!-- Change for CSW 2.0.2 - title is mandatory -->
-      <dc:title>
-      <xsl:for-each select="dc:title">
-        <xsl:value-of select="."/>
+      <!-- Change for CSW 2.0.2 - title is mandatory -->
+      <xsl:for-each select="../..//dcat:Dataset/dct:title|../..//dcat:DataService/dct:title">
+        <dc:title>
+          <xsl:value-of select="."/>
+        </dc:title>
       </xsl:for-each>
-      </dc:title>
 
-      <xsl:for-each select="dc:type">
-        <dc:type><xsl:value-of select="."/></dc:type>
-      </xsl:for-each>
+      <xsl:if test="//dcat:Dataset">
+        <dc:type>dataset</dc:type>
+      </xsl:if>
+      <xsl:if test="//dcat:DataService">
+        <dc:type>service</dc:type>
+      </xsl:if>
 
       <!-- GeoNetwork elements added when resultType is equal to results_with_summary -->
       <xsl:if test="$displayInfo = 'true'">
@@ -55,5 +60,9 @@
       </xsl:if>
 
     </csw:BriefRecord>
+  </xsl:template>
+
+  <xsl:template match="@*|node()" priority="0">
+    <xsl:apply-templates select="@*|node()"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/plugin/dcat-ap/present/csw/csw-full.xsl
+++ b/src/main/plugin/dcat-ap/present/csw/csw-full.xsl
@@ -33,17 +33,6 @@
 
   <xsl:param name="displayInfo"/>
 
-  <xsl:template match="dataset">
-    <xsl:variable name="info" select="geonet:info"/>
-    <csw:Record>
-      <xsl:apply-templates select="*[name(.)!='geonet:info']"/>
-      <xsl:apply-templates select="dct:spatial" mode="bbox"/>
-      <!-- GeoNetwork elements added when resultType is equal to results_with_summary -->
-      <xsl:if test="$displayInfo = 'true'">
-        <xsl:copy-of select="$info"/>
-      </xsl:if>
-    </csw:Record>
-  </xsl:template>
 
   <xsl:template match="@*|node()">
     <xsl:copy>

--- a/src/main/plugin/dcat-ap/present/csw/csw-summary.xsl
+++ b/src/main/plugin/dcat-ap/present/csw/csw-summary.xsl
@@ -23,104 +23,13 @@
   -->
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
-    xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:dcat="http://www.w3.org/ns/dcat#"
-    xmlns:dct="http://purl.org/dc/terms/"
     xmlns:geonet="http://www.fao.org/geonetwork">
 
   <xsl:param name="displayInfo"/>
-
-  <!-- ================================================================= -->
-
-  <xsl:template match="dataset">
-    <xsl:variable name="info" select="geonet:info"/>
-    <csw:SummaryRecord>
-
-      <xsl:for-each select="dc:identifier">
-        <dc:identifier><xsl:value-of select="."/></dc:identifier>
-      </xsl:for-each>
-
-<!-- Change for CSW 2.0.2 - title is mandatory -->
-      <dc:title>
-      <xsl:for-each select="dc:title">
-        <xsl:value-of select="."/>
-      </xsl:for-each>
-      </dc:title>
-
-      <xsl:for-each select="dc:type">
-        <dc:type><xsl:value-of select="."/></dc:type>
-      </xsl:for-each>
-
-      <xsl:for-each select="dc:subject">
-        <dc:subject><xsl:value-of select="."/></dc:subject>
-      </xsl:for-each>
-
-      <xsl:for-each select="dc:format">
-        <dc:format><xsl:value-of select="."/></dc:format>
-      </xsl:for-each>
-
-      <xsl:for-each select="dc:relation">
-        <dc:relation><xsl:value-of select="."/></dc:relation>
-      </xsl:for-each>
-
-      <xsl:for-each select="dct:modified">
-        <dct:modified><xsl:value-of select="substring-before(.,'T')"/></dct:modified>
-      </xsl:for-each>
-
-<!--
-      <xsl:for-each select="dct:modified">
-        <dct:modified><xsl:value-of select="."/></dct:modified>
-      </xsl:for-each>
--->
-      <xsl:for-each select="dct:abstract">
-        <dct:abstract><xsl:value-of select="."/></dct:abstract>
-      </xsl:for-each>
-
-      <xsl:for-each select="dc:creator">
-        <dc:creator><xsl:value-of select="."/></dc:creator>
-      </xsl:for-each>
-
-      <xsl:for-each select="dc:contributor">
-        <dc:contributor><xsl:value-of select="."/></dc:contributor>
-      </xsl:for-each>
-
-      <xsl:for-each select="dc:publisher">
-        <dc:publisher><xsl:value-of select="."/></dc:publisher>
-            </xsl:for-each>
-
-      <xsl:for-each select="dc:source">
-        <dc:source><xsl:value-of select="."/></dc:source>
-      </xsl:for-each>
-
-      <xsl:for-each select="dc:language">
-        <dc:language><xsl:value-of select="."/></dc:language>
-            </xsl:for-each>
-
-      <xsl:for-each select="dct:spatial">
-        <dct:spatial><xsl:value-of select="."/></dct:spatial>
-      </xsl:for-each>
-
-      <xsl:for-each select="dc:rights">
-        <dc:rights><xsl:value-of select="."/></dc:rights>
-            </xsl:for-each>
-
-      <!-- GeoNetwork elements added when resultType is equal to results_with_summary -->
-      <xsl:if test="$displayInfo = 'true'">
-        <xsl:copy-of select="$info"/>
-      </xsl:if>
-
-    </csw:SummaryRecord>
-  </xsl:template>
-
-  <!-- ================================================================= -->
 
   <xsl:template match="@*|node()">
     <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
   </xsl:template>
-
-  <!-- ================================================================= -->
-
 </xsl:stylesheet>


### PR DESCRIPTION
DCAT records could not be deleted by CSW calls due to the UUID not being parsed properly (dc:identifier should be present in the CSW document as I understand). This seems to fix the situation:
- added `dc:type` for dataset and service
- added `dc:identifier` based on fileidentifier, following iso19139

Not sure what to do with `geonet:info` which was present before, perhaps unused at this point.

This can be tested with the following CSW call (modify target uuid):

```
POST {{gn_host}}/srv/dut/csw-publication

<?xml version="1.0" encoding="UTF-8"?>
<csw:Transaction service="CSW" version="2.0.2" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
 xmlns:ogc="http://www.opengis.net/ogc"
 xmlns:apiso="http://www.opengis.net/cat/csw/apiso/1.0">
    <csw:Delete>
        <csw:Constraint version="1.0.0">
            <ogc:Filter>
                <ogc:PropertyIsLike wildCard="%" singleChar="_" escape="/">
                    <ogc:PropertyName>dc:identifier</ogc:PropertyName>
                    <ogc:Literal>c3dddf50-dffa-407f-abac-41dd8cfd3b50</ogc:Literal>
                </ogc:PropertyIsLike>
            </ogc:Filter>
        </csw:Constraint>
    </csw:Delete>
</csw:Transaction>
```