### PR TITLE
Virtual catalog - VL integration

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -509,6 +509,7 @@
       <name>vcard:fn</name>
       <name>skos:inScheme</name>
       <name>skos:notation</name>
+      <name>mdcat:stars</name>
     </exclude>
   </multilingualFields>
 

--- a/src/main/plugin/dcat-ap/schema/dcat.xsd
+++ b/src/main/plugin/dcat-ap/schema/dcat.xsd
@@ -44,7 +44,6 @@
   <xs:import namespace="http://data.europa.eu/r5r/" schemaLocation="profiles/eu-dcat-ap-hvd.xsd"/>
   <xs:import namespace="https://w3id.org/mobilitydcat-ap" schemaLocation="profiles/eu-dcat-ap-mobility.xsd"/>
 
-
   <xs:element name="Catalog" type="dcat:Catalog_type"/>
 
   <!-- dcat:Catalog-->
@@ -95,43 +94,41 @@
     </xs:complexContent>
   </xs:complexType>
 
+  <xs:element name="CatalogRecord" type="dcat:CatalogRecord_type"/>
+
   <!-- dcat:CatalogRecord-->
   <xs:complexType name="CatalogRecord_type">
-    <xs:sequence>
-      <xs:element name="CatalogRecord">
-        <xs:complexType>
-          <xs:complexContent>
-            <xs:extension base="rdf:Resource">
-              <xs:sequence>
-                <!-- dcat -->
-                <xs:element ref="foaf:primaryTopic" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:modified" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:conformsTo" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="adms:status" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:issued" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:title" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:description" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:source" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:language" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="dct:rights" minOccurs="0" maxOccurs="unbounded"/>
-                <!-- additionally, required by GeoNetwork for identification -->
-                <xs:element ref="dct:identifier" minOccurs="0" maxOccurs="unbounded"/> <!-- Required by GeoNetwork for MD identifications -->
+    <xs:complexContent>
+      <xs:extension base="rdf:Resource">
+        <xs:sequence>
+          <!-- dcat -->
+          <xs:element ref="foaf:primaryTopic" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:modified" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:conformsTo" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="adms:status" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:issued" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:title" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:description" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:source" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:language" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="dct:rights" minOccurs="0" maxOccurs="unbounded"/>
+          <!-- additionally, required by GeoNetwork for identification -->
+          <xs:element ref="dct:identifier" minOccurs="0"
+                      maxOccurs="unbounded"/> <!-- Required by GeoNetwork for MD identifications -->
 
-                <!-- Profile / dcat-ap-vl & metadata-dcat -->
-                <xs:element ref="adms:identifier" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="mdcat:stars" minOccurs="0"/>
+          <!-- Profile / dcat-ap-vl & metadata-dcat -->
+          <xs:element ref="adms:identifier" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="mdcat:stars" minOccurs="0" maxOccurs="unbounded"/>
 
-                <!-- Profile / mobilityDCAT-AP -->
-                <!-- Mandatory -->
-                <xs:element ref="dct:created" minOccurs="0" maxOccurs="unbounded"/>
-                <!-- Optional -->
-                <xs:element ref="dct:publisher" minOccurs="0" maxOccurs="unbounded"/>
-              </xs:sequence>
-            </xs:extension>
-          </xs:complexContent>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
+          <!-- Profile / mobilityDCAT-AP -->
+          <!-- Mandatory -->
+          <xs:element ref="dct:created" minOccurs="0" maxOccurs="unbounded"/>
+          <!-- Optional -->
+          <xs:element ref="dct:publisher" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute ref="rdf:resource"/>
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 
   <!-- dcat:Dataset-->

--- a/src/main/plugin/dcat-ap/schema/profiles/mdcat.xsd
+++ b/src/main/plugin/dcat-ap/schema/profiles/mdcat.xsd
@@ -32,7 +32,7 @@
   <xs:element name="statuut" type="dct:subject"/>
 
   <!-- 5 stars evaluation between 1 and 5 -->
-  <xs:element name="stars" type="xs:integer">
+  <xs:element name="stars">
     <xs:simpleType>
       <xs:restriction base="xs:integer">
         <xs:minInclusive value="1"/>

--- a/src/main/plugin/dcat-ap/schema/rdf.xsd
+++ b/src/main/plugin/dcat-ap/schema/rdf.xsd
@@ -104,9 +104,10 @@ The Resource Description Framework [RDF] is defined to have an extensible system
   </xs:complexType>
   <!-- CatalogRoot -->
   <xs:complexType name="CatalogRoot">
-    <xs:choice>
+    <xs:sequence>
       <xs:element ref="dcat:Catalog"/>
-    </xs:choice>
+      <xs:element ref="dcat:CatalogRecord" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
   </xs:complexType>
   <!-- individual elements -->
   <xs:element name="type" type="rdf:ResourceRef"/>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-cardinalities.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-cardinalities.sch
@@ -68,13 +68,13 @@
     <sch:param name="max" value="1"/>
   </sch:pattern>
   <sch:pattern is-a="CardinalityCheck" id="Catalog_publisher">
-    <sch:param name="context" value="//dcat:Catalog"/>
+    <sch:param name="context" value="//dcat:Catalog[dcat:dataset or dcat:dataservice]"/>
     <sch:param name="element" value="dct:publisher"/>
     <sch:param name="min" value="1"/>
     <sch:param name="max" value="1"/>
   </sch:pattern>
   <sch:pattern is-a="CardinalityCheck" id="Catalog_record">
-    <sch:param name="context" value="//dcat:Catalog"/>
+    <sch:param name="context" value="//dcat:Catalog[dcat:dataset or dcat:dataservice]"/>
     <sch:param name="element" value="dcat:record"/>
     <sch:param name="min" value="1"/>
     <sch:param name="max" value="1"/>
@@ -98,7 +98,7 @@
     <sch:param name="max" value="n"/>
   </sch:pattern>
   <sch:pattern is-a="CardinalityCheck" id="Catalog_modified">
-    <sch:param name="context" value="//dcat:Catalog"/>
+    <sch:param name="context" value="//dcat:Catalog[dcat:dataset or dcat:dataservice]"/>
     <sch:param name="element" value="dct:modified"/>
     <sch:param name="min" value="0"/>
     <sch:param name="max" value="n"/>
@@ -141,7 +141,7 @@
     <sch:param name="max" value="1"/>
   </sch:pattern>
   <sch:pattern is-a="CardinalityCheck" id="CatalogRecord_modified">
-    <sch:param name="context" value="dcat:CatalogRecord"/>
+    <sch:param name="context" value="dcat:CatalogRecord[ancestor::dcat:Catalog[dcat:dataset or dcat:dataservice]]"/>
     <sch:param name="element" value="dct:modified"/>
     <sch:param name="min" value="1"/>
     <sch:param name="max" value="1"/>


### PR DESCRIPTION
@fxprunayre I'm attempting to test the virtualcatalog PR in our fork but was hitting some validation errors. Hereby my attempts to fix the issues. I still have the following questions:
- view is not loading, will take a look at that
- getting an XSD error on a catalog record with 2 records attached (see screenshot below). Not sure why, as the elements in my test record (see below) correspond with that the xsd expects as far as I can see.
![image](https://github.com/user-attachments/assets/8cee82c9-02d6-4d9f-b04a-004d98b1c973)

Also an additional question: is `dcat:Catalog/dcat:record/dcat:CatalogRecord` meant to describe the inclusion of the catalog record (e.g. a virtualcatalog for a dataspace) within the parent catalog (e.g. Metadata Vlaanderen)? Currently there's a `foaf:primaryTopic/@rdf:resource=/catalog/183d2401-81fc-4064-86f9-7e4539ff7576` present in my test record, but the uuid of the catalog is not the one of my local source.

Would it be easier to handle the inclusion of the `dcat:Catalog`?
- can't we add rdf:about on dcat:Catalog? `http://localhost:8080/srv/api/records/<the-catalog-record's-uuid>`?
- having `dct:language` and `dct:identifier` straight below `dcat:Catalog` should already be covered by the schema
- `dct:modified` on the catalogrecord level doesn't the same semantic meaning as having it on `dcat:Catalog` level right?

Below the XML record I'm using for testing, as generated by starting from the virtualcatalog template and then adding two test links:
```xml
<rdf:RDF xmlns:dcat="http://www.w3.org/ns/dcat#"
         xmlns:mobilitydcatap="https://w3id.org/mobilitydcat-ap"
         xmlns:schema="http://schema.org/"
         xmlns:dc="http://purl.org/dc/elements/1.1/"
         xmlns:mdcat="https://data.vlaanderen.be/ns/metadata-dcat#"
         xmlns:spdx="http://spdx.org/rdf/terms#"
         xmlns:owl="http://www.w3.org/2002/07/owl#"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:adms="http://www.w3.org/ns/adms#"
         xmlns:locn="http://www.w3.org/ns/locn#"
         xmlns:foaf="http://xmlns.com/foaf/0.1/"
         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
         xmlns:dcatap="http://data.europa.eu/r5r/"
         xmlns:dct="http://purl.org/dc/terms/"
         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
         xmlns:vcard="http://www.w3.org/2006/vcard/ns#">
  <dcat:Catalog>
      <dcat:record>
         <dcat:CatalogRecord rdf:about="http://localhost:8080/srv/api/records/1d5b264c-6b74-45f1-8d34-9e67c0237928">
            <foaf:primaryTopic rdf:resource="http://localhost:8080/srv/resources/catalog/183d2401-81fc-4064-86f9-7e4539ff7576"/>
            <dct:modified>2025-05-30</dct:modified>
            <dct:language>
               <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
                  <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
                  <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
                  <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
               </skos:Concept>
            </dct:language>
            <dct:identifier>1d5b264c-6b74-45f1-8d34-9e67c0237928</dct:identifier>
         </dcat:CatalogRecord>
      </dcat:record>
      <dcat:record rdf:resource="http://localhost:8080/srv/api/records/1d5b264c-6b74-45f1-8d34-9e67c0237928/b6934c23-bffa-40de-ac34-7f1f6e1dbdf1"/>
      <dct:description xml:lang="nl">Metadata Vlaanderen (agentschap Digitaal Vlaanderen)</dct:description>
      <dct:language>
         <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
            <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
            <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
         </skos:Concept>
      </dct:language>
      <dct:title xml:lang="nl">Virtual catalog template</dct:title>
   </dcat:Catalog>
  <dcat:CatalogRecord rdf:about="http://localhost:8080/srv/api/records/1d5b264c-6b74-45f1-8d34-9e67c0237928/b6934c23-bffa-40de-ac34-7f1f6e1dbdf1">
      <foaf:primaryTopic rdf:resource="http://localhost:8080/srv/api/records/b6934c23-bffa-40de-ac34-7f1f6e1dbdf1"/>
      <dct:identifier>b6934c23-bffa-40de-ac34-7f1f6e1dbdf1</dct:identifier>
   </dcat:CatalogRecord>
</rdf:RDF>
```