### PR TITLE
Virtual catalog improvements

### DIFF
--- a/src/main/plugin/dcat-ap/extract-uuid.xsl
+++ b/src/main/plugin/dcat-ap/extract-uuid.xsl
@@ -28,8 +28,12 @@
                 xmlns:dcat="http://www.w3.org/ns/dcat#">
 
     <xsl:template match="/">
+      <xsl:variable name="isVirtualCatalog"
+                    select="exists(rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"/>
       <uuid>
-        <xsl:value-of select="rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:identifier"/>
+        <xsl:value-of select="if ($isVirtualCatalog)
+                                           then rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord[@rdf:about != ../dcat:Catalog/dcat:record/@rdf:resource]/dct:identifier
+                                           else rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:identifier"/>
       </uuid>
   </xsl:template>
 

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -1335,7 +1335,26 @@
       <tab id="tabCatalog" default="true" mode="flat" displayIfRecord="count(rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog) > 0" hideIfNotDisplayed="true">
         <section name="catalogInformation">
           <field xpath="/rdf:RDF/dcat:Catalog/dct:title"/>
+          <action type="add" or="title" in="/rdf:RDF/dcat:Catalog"
+                  if="count(rdf:RDF/dcat:Catalog/dct:title)=0">
+            <template>
+              <snippet>
+                <dct:title xml:lang=""/>
+              </snippet>
+            </template>
+          </action>
+
           <field xpath="/rdf:RDF/dcat:Catalog/dct:description"/>
+          <action type="add" or="description"
+                  in="/rdf:RDF/dcat:Catalog"
+                  if="count(rdf:RDF/dcat:Catalog/dct:description) = 0">
+            <template>
+              <snippet>
+                <dct:description xml:lang=""/>
+              </snippet>
+            </template>
+          </action>
+          
           <field xpath="/rdf:RDF/dcat:Catalog/dct:language"
                  or="language"
                  in="/rdf:RDF/dcat:Catalog"/>

--- a/src/main/plugin/dcat-ap/layout/layout.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout.xsl
@@ -446,8 +446,13 @@
 
         <xsl:choose>
           <xsl:when test="$recordTitle != ''">
-            <div class="col-sm-9 col-xs-11">
-              <input type="text" readonly="readonly" value="{$recordTitle}" class="form-control"/>
+            <div class="form-group gn-field ">
+              <label class="col-sm-2 form-label">
+                <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'dct:title', $labels, '', '', '')/label"/>
+              </label>
+              <div class="col-sm-9 col-xs-11">
+                <input type="text" readonly="readonly" value="{$recordTitle}" class="form-control"/>
+              </div>
             </div>
           </xsl:when>
           <xsl:otherwise>

--- a/src/main/plugin/dcat-ap/layout/layout.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout.xsl
@@ -326,6 +326,37 @@
             (name(..) = 'dcat:CatalogRecord' and not($isVirtualCatalogAssociatedRecord)) or
             (name(../../..) = 'dcat:CatalogRecord' and name(..) = 'dct:Standard')"/>
 
+
+      <xsl:if test="name(.) = 'dct:identifier' and $isVirtualCatalogAssociatedRecord">
+        <xsl:variable name="recordTitle"
+                      select="java:getIndexField(
+                                '',
+                                normalize-space(text()),
+                                'resourceTitleObject',
+                                '')"/>
+
+
+        <div class="form-group gn-field ">
+          <label class="col-sm-2 form-label">
+            <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'dct:title', $labels, '', '', '')/label"/>
+          </label>
+          <div class="col-sm-9 col-xs-11">
+            <xsl:choose>
+              <xsl:when test="$recordTitle != ''">
+                <input type="text" readonly="readonly" value="{$recordTitle}" class="form-control"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <div class="alert alert-danger">
+                  <strong><xsl:value-of select="$strings/virtualCatalogAssociatedRecordNotFound"/></strong><br/>
+                  <xsl:value-of select="$strings/virtualCatalogAssociatedRecordNotFound-help"/>
+                </div>
+              </xsl:otherwise>
+            </xsl:choose>
+          </div>
+        </div>
+      </xsl:if>
+
+
       <xsl:choose>
         <xsl:when test="count($fieldNode/*)>0 and $fieldNode/@templateModeOnly and not($isDisabled)">
           <xsl:variable name="del" select="'.'"/>
@@ -435,36 +466,6 @@
           </xsl:for-each>
         </xsl:otherwise>
       </xsl:choose>
-
-      <xsl:if test="name(.) = 'dct:identifier' and $isVirtualCatalogAssociatedRecord">
-        <xsl:variable name="recordTitle"
-                      select="java:getIndexField(
-                                '',
-                                normalize-space(text()),
-                                'resourceTitleObject',
-                                '')"/>
-
-        <xsl:choose>
-          <xsl:when test="$recordTitle != ''">
-            <div class="form-group gn-field ">
-              <label class="col-sm-2 form-label">
-                <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'dct:title', $labels, '', '', '')/label"/>
-              </label>
-              <div class="col-sm-9 col-xs-11">
-                <input type="text" readonly="readonly" value="{$recordTitle}" class="form-control"/>
-              </div>
-            </div>
-          </xsl:when>
-          <xsl:otherwise>
-            <div class="col-sm-9 col-xs-11">
-              <div class="alert alert-danger">
-                <strong><xsl:value-of select="$strings/virtualCatalogAssociatedRecordNotFound"/></strong><br/>
-                <xsl:value-of select="$strings/virtualCatalogAssociatedRecordNotFound-help"/>
-              </div>
-            </div>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:if>
     </xsl:if>
   </xsl:template>
 

--- a/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
@@ -41,11 +41,14 @@
                   select="exists($metadata[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
                   as="xs:boolean"/>
 
+    <xsl:variable name="catalogIdentifier"
+                        select="$metadata/dcat:Catalog/dct:identifier"/>
+
     <xsl:variable name="languageIri"
                select="if ($languageIri)
                             then $languageIri
                             else if ($isVirtualCatalog)
-                            then $metadata/dcat:Catalog/dct:language[1]/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)
+                            then $metadata//dcat:CatalogRecord[dct:identifier = $catalogIdentifier]/dct:language[1]/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)
                             else $metadata//dcat:CatalogRecord/dct:language[1]/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)"/>
 
     <xsl:variable name="languageCode"
@@ -54,7 +57,7 @@
                               replace($languageIri, 'http://id.loc.gov/vocabulary/iso639-1/', ''),
                             'http://id.loc.gov/vocabulary/iso639-2/', ''),
                           'http://publications.europa.eu/resource/authority/language/', ''))"/>
-
+    
     <xsl:choose>
       <xsl:when test="string-length($languageCode) = 3">
         <xsl:value-of select="xslutil:twoCharLangCode($languageCode)"/>
@@ -77,9 +80,12 @@
                   select="exists($metadata[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
                   as="xs:boolean"/>
 
+    <xsl:variable name="catalogIdentifier"
+                  select="$metadata/dcat:Catalog/dct:identifier"/>
+
     <xsl:variable name="languageContainerElement"
                   select="if ($isVirtualCatalog)
-                              then $metadata/dcat:Catalog/dct:language
+                              then $metadata//dcat:CatalogRecord[dct:identifier = $catalogIdentifier]/dct:language
                               else $metadata//dcat:CatalogRecord/dct:language"/>
 
     <xsl:variable name="langURIs">

--- a/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
@@ -57,7 +57,7 @@
                               replace($languageIri, 'http://id.loc.gov/vocabulary/iso639-1/', ''),
                             'http://id.loc.gov/vocabulary/iso639-2/', ''),
                           'http://publications.europa.eu/resource/authority/language/', ''))"/>
-    
+
     <xsl:choose>
       <xsl:when test="string-length($languageCode) = 3">
         <xsl:value-of select="xslutil:twoCharLangCode($languageCode)"/>
@@ -94,10 +94,6 @@
           <xsl:value-of select="string()"/>
         </langURI>
       </xsl:for-each>
-      <langURI>http://publications.europa.eu/resource/authority/language/ENG</langURI>
-      <langURI>http://publications.europa.eu/resource/authority/language/NLD</langURI>
-      <langURI>http://publications.europa.eu/resource/authority/language/DEU</langURI>
-      <langURI>http://publications.europa.eu/resource/authority/language/FRA</langURI>
     </xsl:variable>
 
     <xsl:variable name="langs">

--- a/src/main/plugin/dcat-ap/process/sibling-add.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-add.xsl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:geonet="http://www.fao.org/geonetwork"
                 xmlns:util="java:org.fao.geonet.util.XslUtil"
@@ -27,8 +26,9 @@
   <xsl:variable name="catalogUuid" select="/rdf:RDF/geonet:info/uuid"/>
 
   <xsl:template match="dcat:Catalog">
+    <!-- All associated records and itself (to avoid linking to existing) -->
     <xsl:variable name="associatedUuids"
-                  select="ancestor::rdf:RDF/dcat:CatalogRecord/dct:identifier/text()"/>
+                  select="ancestor::rdf:RDF//dcat:CatalogRecord/dct:identifier/text()"/>
 
     <xsl:variable name="uuidsToAdd" as="node()*">
       <xsl:for-each select="tokenize($uuids, ',')">

--- a/src/main/plugin/dcat-ap/process/sibling-add.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-add.xsl
@@ -7,6 +7,7 @@
                 xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
                 xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 exclude-result-prefixes="#all"
                 version="2.0">
 
@@ -26,29 +27,33 @@
   <xsl:variable name="catalogUuid" select="/rdf:RDF/geonet:info/uuid"/>
 
   <xsl:template match="dcat:Catalog">
+    <xsl:variable name="associatedUuids"
+                  select="ancestor::rdf:RDF/dcat:CatalogRecord/dct:identifier/text()"/>
+
+    <xsl:variable name="uuidsToAdd" as="node()*">
+      <xsl:for-each select="tokenize($uuids, ',')">
+        <xsl:variable name="uuid" select="tokenize(., '#')[1]"/>
+        <xsl:if test="$uuids != '' and not($uuid = $associatedUuids)">
+          <uuid><xsl:value-of select="$uuid"/></uuid>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
 
     <xsl:copy>
       <xsl:copy-of select="*"/>
 
-      <xsl:if test="$uuids != ''">
-        <xsl:for-each select="tokenize($uuids, ',')">
-          <xsl:variable name="tokens" select="tokenize(., '#')"/>
-          <dcat:record rdf:resource="{concat($nodeUrl, 'api/records/', $catalogUuid, '/', $tokens[1])}"/>
-        </xsl:for-each>
-      </xsl:if>
+      <xsl:for-each select="$uuidsToAdd">
+        <dcat:record rdf:resource="{concat($nodeUrl, 'api/records/', $catalogUuid, '/', current())}"/>
+      </xsl:for-each>
     </xsl:copy>
 
-    <xsl:if test="$uuids != ''">
-      <xsl:for-each select="tokenize($uuids, ',')">
-        <xsl:variable name="tokens" select="tokenize(., '#')"/>
-        <dcat:CatalogRecord rdf:about="{concat($nodeUrl, 'api/records/', $catalogUuid, '/', $tokens[1])}">
-          <dct:identifier><xsl:value-of select="$tokens[1]"/></dct:identifier>
-          <foaf:primaryTopic rdf:resource="{concat($nodeUrl, 'api/records/', $tokens[1])}"/>
-        </dcat:CatalogRecord>
-      </xsl:for-each>
-    </xsl:if>
+    <xsl:for-each select="$uuidsToAdd">
+      <dcat:CatalogRecord rdf:about="{concat($nodeUrl, 'api/records/', $catalogUuid, '/', current())}">
+        <dct:identifier><xsl:value-of select="current()"/></dct:identifier>
+        <foaf:primaryTopic rdf:resource="{concat($nodeUrl, 'api/records/', current())}"/>
+      </dcat:CatalogRecord>
+    </xsl:for-each>
   </xsl:template>
-
 
   <xsl:template match="@*|*|text()">
     <xsl:copy>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
@@ -4,6 +4,17 @@
          xmlns:dct="http://purl.org/dc/terms/"
          xmlns:dcat="http://www.w3.org/ns/dcat#">
   <dcat:Catalog rdf:about="https://metadata.vlaanderen.be/virtualcatalogtemplate">
+    <dcat:record>
+      <dcat:CatalogRecord>
+        <dct:conformsTo>
+          <dct:Standard rdf:about="https://joinup.ec.europa.eu/collection/semic-support-centre/solution/dcat-application-profile-data-portals-europe/release/200">
+            <dct:title>DCAT-AP</dct:title>
+            <dct:description xml:lang="nl">DCAT Application Profile</dct:description>
+            <owl:versionInfo>2.0.0</owl:versionInfo>
+          </dct:Standard>
+        </dct:conformsTo>
+      </dcat:CatalogRecord>
+    </dcat:record>
     <dct:description xml:lang="nl">Metadata Vlaanderen (agentschap Digitaal Vlaanderen)</dct:description>
     <dct:language>
       <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
@@ -2,6 +2,7 @@
          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
          xmlns:skos="http://www.w3.org/2004/02/skos/core#"
          xmlns:dct="http://purl.org/dc/terms/"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
          xmlns:dcat="http://www.w3.org/ns/dcat#">
   <dcat:Catalog rdf:about="https://metadata.vlaanderen.be/virtualcatalogtemplate">
     <dcat:record>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
@@ -1,16 +1,27 @@
-<rdf:RDF xmlns:schema="http://schema.org/"
+<rdf:RDF xmlns:mobilitydcatap="https://w3id.org/mobilitydcat-ap"
+         xmlns:schema="http://schema.org/"
          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
          xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-         xmlns:dct="http://purl.org/dc/terms/"
+         xmlns:spdx="http://spdx.org/rdf/terms#"
          xmlns:owl="http://www.w3.org/2002/07/owl#"
-         xmlns:dcat="http://www.w3.org/ns/dcat#">
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:adms="http://www.w3.org/ns/adms#"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:locn="http://www.w3.org/ns/locn#"
+         xmlns:mdcat="https://data.vlaanderen.be/ns/metadata-dcat#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/"
+         xmlns:dct="http://purl.org/dc/terms/"
+         xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+         xmlns:dcat="http://www.w3.org/ns/dcat#"
+         xmlns:dcatap="http://data.europa.eu/r5r/">
   <dcat:Catalog rdf:about="https://metadata.vlaanderen.be/virtualcatalogtemplate">
     <dcat:record>
       <dcat:CatalogRecord>
+        <dct:modified>2025-06-18</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://joinup.ec.europa.eu/collection/semic-support-centre/solution/dcat-application-profile-data-portals-europe/release/200">
-            <dct:title>DCAT-AP</dct:title>
-            <dct:description xml:lang="nl">DCAT Application Profile</dct:description>
+            <dct:identifier>https://joinup.ec.europa.eu/collection/semic-support-centre/solution/dcat-application-profile-data-portals-europe/release/200</dct:identifier>
+            <dct:title xml:lang="nl">DCAT-AP</dct:title>
             <owl:versionInfo>2.0.0</owl:versionInfo>
           </dct:Standard>
         </dct:conformsTo>
@@ -18,12 +29,13 @@
           <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
             <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
             <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
           </skos:Concept>
         </dct:language>
-        <dct:identifier>3b066851-89b8-488f-ab67-3deb52442022</dct:identifier>
+        <dct:identifier>94ae7a9f-a6ad-4087-82cd-464c34dd9dde</dct:identifier>
       </dcat:CatalogRecord>
     </dcat:record>
-    <dct:description xml:lang="nl">Metadata Vlaanderen (agentschap Digitaal Vlaanderen)</dct:description>
+    <dct:identifier>94ae7a9f-a6ad-4087-82cd-464c34dd9dde</dct:identifier>
     <dct:language>
       <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
         <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
@@ -14,6 +14,13 @@
             <owl:versionInfo>2.0.0</owl:versionInfo>
           </dct:Standard>
         </dct:conformsTo>
+        <dct:language>
+          <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
+            <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
+            <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+          </skos:Concept>
+        </dct:language>
+        <dct:identifier>3b066851-89b8-488f-ab67-3deb52442022</dct:identifier>
       </dcat:CatalogRecord>
     </dcat:record>
     <dct:description xml:lang="nl">Metadata Vlaanderen (agentschap Digitaal Vlaanderen)</dct:description>
@@ -21,9 +28,6 @@
       <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
         <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
         <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
-        <skos:prefLabel xml:lang="en">Dutch</skos:prefLabel>
-        <skos:prefLabel xml:lang="de">Niederländisch</skos:prefLabel>
-        <skos:prefLabel xml:lang="fr">néerlandais</skos:prefLabel>
         <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
       </skos:Concept>
     </dct:language>

--- a/src/main/plugin/dcat-ap/update-fixed-info-variables.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info-variables.xsl
@@ -40,6 +40,10 @@
   <xsl:variable name="iso2letterLanguageCode" select="lower-case(java:twoCharLangCode(/root/gui/language))"/>
   <xsl:variable name="resourcePrefix" select="$env/metadata/resourceIdentifierPrefix"/>
 
+  <xsl:variable name="isVirtualCatalog"
+                select="exists(/root/rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
+                as="xs:boolean"/>
+
   <xsl:variable name="metadata"
                 select="/root/rdf:RDF"/>
 
@@ -59,10 +63,6 @@
 
   <xsl:variable name="editorConfig"
                 select="document('layout/config-editor.xml')"/>
-
-  <xsl:variable name="isVirtualCatalog"
-                      select="exists(/root/rdf:RDF[not(//(dcat:Dataset|dcat:DataService))]/dcat:Catalog)"
-                      as="xs:boolean"/>
 
   <xsl:variable name="resourceType">
     <xsl:choose>

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -316,10 +316,12 @@
     </dcat:Catalog>
   </xsl:template>
 
-  
+
   <!-- Virtual catalog contains additional CatalogRecord for all associated resources.
   Only alter the one matching the Catalog instance. -->
-  <xsl:template match="dcat:CatalogRecord[$isVirtualCatalog and not(@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource)]" priority="2">
+  <xsl:template match="dcat:CatalogRecord[$isVirtualCatalog
+                                        and (count(../dcat:Catalog/dcat:record/@rdf:resource) = 0
+                                                or not(@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource))]" priority="2">
     <xsl:copy copy-namespaces="no">
       <xsl:call-template name="handle-record-id"/>
       <dct:modified>
@@ -331,10 +333,12 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Remove all record not matching a CatalogRecord -->
-  <xsl:template match="dcat:Catalog/dcat:record[$isVirtualCatalog and not(@rdf:resource = ../../dcat:CatalogRecord/@rdf:about)]" priority="2"/>
+  <!-- Remove all record not matching a CatalogRecord. Associated record are added using sibling-add.xsl process
+   but removing the CatalogRecord from the main form need to also remove the corresponding dcat:record element.
+   -->
+  <xsl:template match="dcat:Catalog/dcat:record[$isVirtualCatalog and @rdf:resource and not(@rdf:resource = ../../dcat:CatalogRecord/@rdf:about)]" priority="2"/>
 
-  
+
   <xsl:template match="dcat:Dataset|dcat:DataService" priority="10">
      <xsl:copy copy-namespaces="no">
        <xsl:call-template name="handle-resource-id"/>

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -316,10 +316,10 @@
     </dcat:Catalog>
   </xsl:template>
 
-
+  
   <!-- Virtual catalog contains additional CatalogRecord for all associated resources.
   Only alter the one matching the Catalog instance. -->
-  <xsl:template match="dcat:CatalogRecord[not(@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource)]" priority="2">
+  <xsl:template match="dcat:CatalogRecord[$isVirtualCatalog and not(@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource)]" priority="2">
     <xsl:copy copy-namespaces="no">
       <xsl:call-template name="handle-record-id"/>
       <dct:modified>
@@ -331,8 +331,8 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Remove all dcat:record not matching a CatalogRecord -->
-  <xsl:template match="dcat:Catalog/dcat:record[not(@rdf:resource = ../../dcat:CatalogRecord/@rdf:about)]" priority="2"/>
+  <!-- Remove all record not matching a CatalogRecord -->
+  <xsl:template match="dcat:Catalog/dcat:record[$isVirtualCatalog and not(@rdf:resource = ../../dcat:CatalogRecord/@rdf:about)]" priority="2"/>
 
   
   <xsl:template match="dcat:Dataset|dcat:DataService" priority="10">

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -316,8 +316,8 @@
   </xsl:template>
 
 
-  <!-- Virtual catalog contains additional CatalogRecord for all associated resources.
-  Only alter the one matching the Catalog instance. Create the dcat:record for the Catalog if it does not exist. -->
+  <!-- Virtual catalog contains additional CatalogRecords for all associated resources. Only alter the one matching the
+  Catalog instance. Create the dcat:record for the Catalog if it does not exist. -->
   <xsl:template match="dcat:CatalogRecord[$isVirtualCatalog
                                         and (count(../dcat:Catalog/dcat:record/@rdf:resource) = 0
                                                 or not(@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource))]" priority="2">
@@ -332,11 +332,9 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Remove all record not matching a CatalogRecord. Associated record are added using sibling-add.xsl process
-   but removing the CatalogRecord from the main form need to also remove the corresponding dcat:record element.
-   -->
+  <!-- Remove all records that don't match a CatalogRecord. Associated records are added using the sibling-add.xsl
+  process. Removing the CatalogRecord from the main form needs to also remove the corresponding dcat:record element. -->
   <xsl:template match="dcat:Catalog/dcat:record[$isVirtualCatalog and @rdf:resource and not(@rdf:resource = ../../dcat:CatalogRecord/@rdf:about)]" priority="2"/>
-
 
   <xsl:template match="dcat:Dataset|dcat:DataService" priority="10">
      <xsl:copy copy-namespaces="no">

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -160,7 +160,6 @@
   </xsl:template>
 
   <xsl:template match="/root">
-
     <xsl:variable name="updated">
       <xsl:apply-templates select="//rdf:RDF"/>
     </xsl:variable>
@@ -318,7 +317,7 @@
 
 
   <!-- Virtual catalog contains additional CatalogRecord for all associated resources.
-  Only alter the one matching the Catalog instance. -->
+  Only alter the one matching the Catalog instance. Create the dcat:record for the Catalog if it does not exist. -->
   <xsl:template match="dcat:CatalogRecord[$isVirtualCatalog
                                         and (count(../dcat:Catalog/dcat:record/@rdf:resource) = 0
                                                 or not(@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource))]" priority="2">

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -331,6 +331,10 @@
     </xsl:copy>
   </xsl:template>
 
+  <!-- Remove all dcat:record not matching a CatalogRecord -->
+  <xsl:template match="dcat:Catalog/dcat:record[not(@rdf:resource = ../../dcat:CatalogRecord/@rdf:about)]" priority="2"/>
+
+  
   <xsl:template match="dcat:Dataset|dcat:DataService" priority="10">
      <xsl:copy copy-namespaces="no">
        <xsl:call-template name="handle-resource-id"/>

--- a/src/main/resources/config-spring-geonetwork.xml
+++ b/src/main/resources/config-spring-geonetwork.xml
@@ -39,6 +39,7 @@
       <util:list value-type="java.lang.String">
         <value>dcat:Catalog/dcat:dataset/dcat:Dataset/dct:title</value>
         <value>dcat:Catalog/dcat:service/dcat:DataService/dct:title</value>
+        <value>dcat:Catalog[not(//dcat:Dataset) and not(//dcat:DataService)]/dct:title</value>
       </util:list>
     </property>
     <property name="savedQueries">


### PR DESCRIPTION
* Register title xpath (used to set title on creation).
* Do not allow adding twice the same record or linking record to itself.
* Add label to associated record title.

![image](https://github.com/user-attachments/assets/a7ceb5c1-62ac-494b-8991-b187ced7cae1)

* Template / Add conformity statement

![image](https://github.com/user-attachments/assets/bc1b0a68-acc3-454b-a5d7-c2dfe3158185)


* Retrieve virtual catalog record language in corresponding CatalogRecord (and not in Catalog language)
* Editor / Add action for title or description if missing

![image](https://github.com/user-attachments/assets/64ceddcf-ee2f-4f11-b7f1-16c1afbfa935)

* Remove dcat:record not referenced as CatalogRecord (fix removal of associated record from the main form)