### PR TITLE
Template title cleanup

### DIFF
--- a/src/main/plugin/dcat-ap/templates/dcat-ap-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-dataset.xml
@@ -18,7 +18,9 @@
     </dcat:record>
     <dcat:dataset>
       <dcat:Dataset>
-        <dct:title xml:lang="nl">DCAT-AP dataset</dct:title>
+        <dct:title xml:lang="en">Generic DCAT-AP dataset</dct:title>
+        <dct:title xml:lang="nl">Generieke DCAT-AP dataset</dct:title>
+        <dct:description xml:lang="en"/>
         <dct:description xml:lang="nl"/>
       </dcat:Dataset>
     </dcat:dataset>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-service.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-service.xml
@@ -18,7 +18,9 @@
     </dcat:record>
     <dcat:service>
       <dcat:DataService>
-        <dct:title xml:lang="nl">DCAT-AP service</dct:title>
+        <dct:title xml:lang="en">Generic DCAT-AP service</dct:title>
+        <dct:title xml:lang="nl">Generieke DCAT-AP service</dct:title>
+        <dct:description xml:lang="en"/>
         <dct:description xml:lang="nl"/>
       </dcat:DataService>
     </dcat:service>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-dataset.xml
@@ -14,7 +14,7 @@
         <dct:modified>2020-06-09</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2019-10-03">
-            <dct:title>Dcat-ap-vl</dct:title>
+            <dct:title>DCAT-AP Vlaanderen</dct:title>
             <dct:description xml:lang="nl">Dit applicatieprofiel beschrijft Open Data Catalogi in Vlaanderen. DCAT-AP Vlaanderen (DCAT-AP VL) is een verdere specialisatie van DCAT-AP. De applicatie waarop dit profiel betrekking heeft is een Open Data Portaal in Vlaanderen. Open Data portalen zijn catalogussen van Open Data datasets. Ze hebben als belangrijkste doelstelling het vindbaar maken van data en hierdoor het hergebruik ervan te stimuleren. Open Data portalen vervullen een centrale rol in de overheidsopdracht om de toegankelijkheid tot overheidsinformatie te realiseren. Met dit applicatieprofiel bevorderen we de uniformiteit van de beschikbare informatie over datasets. Tevens vereenvoudigen we het aggregatie proces van meerdere Open Data Catalogi. Dit document bevat de verplichte elementen en bijkomende elementen waarover DCAT-AP Vlaanderen een uitspraak doet. Aanbevolen en optionele informatie waarvoor geen bijkomende afspraken in de context van DCAT-AP Vlaanderen zijn, zijn niet opgenomen in dit document. Hiervoor verwijzen we naar de DCAT-AP specificatie zelf.</dct:description>
             <owl:versionInfo>2.0</owl:versionInfo>
           </dct:Standard>
@@ -29,7 +29,8 @@
     </dcat:record>
     <dcat:dataset>
       <dcat:Dataset>
-        <dct:title xml:lang="nl">&lt;span id="template2">&lt;strong&gt;Open data&lt;/strong&gt; (niet-geo): Sjabloon voor Metadata van Generieke Open data, conform DCAT-AP VL v2.0&lt;/span></dct:title>
+        <dct:title xml:lang="nl">Generieke Open data, conform DCAT-AP VL v2.0</dct:title>
+        <dct:title xml:lang="en">Generic Open data, conforming to DCAT-AP VL v2.0</dct:title>
         <dct:description xml:lang="nl"/>
         <dcat:contactPoint>
           <vcard:Organization>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-service.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-service.xml
@@ -14,7 +14,7 @@
         <dct:modified>2020-06-09</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2019-10-03">
-            <dct:title>Dcat-ap-vl</dct:title>
+            <dct:title>DCAT-AP Vlaanderen</dct:title>
             <dct:description>Dit applicatieprofiel beschrijft Open Data Catalogi in Vlaanderen. DCAT-AP Vlaanderen (DCAT-AP VL) is een verdere specialisatie van DCAT-AP. De applicatie waarop dit profiel betrekking heeft is een Open Data Portaal in Vlaanderen. Open Data portalen zijn catalogussen van Open Data datasets. Ze hebben als belangrijkste doelstelling het vindbaar maken van data en hierdoor het hergebruik ervan te stimuleren. Open Data portalen vervullen een centrale rol in de overheidsopdracht om de toegankelijkheid tot overheidsinformatie te realiseren. Met dit applicatieprofiel bevorderen we de uniformiteit van de beschikbare informatie over datasets. Tevens vereenvoudigen we het aggregatie proces van meerdere Open Data Catalogi. Dit document bevat de verplichte elementen en bijkomende elementen waarover DCAT-AP Vlaanderen een uitspraak doet. Aanbevolen en optionele informatie waarvoor geen bijkomende afspraken in de context van DCAT-AP Vlaanderen zijn, zijn niet opgenomen in dit document. Hiervoor verwijzen we naar de DCAT-AP specificatie zelf.</dct:description>
             <owl:versionInfo>2.0</owl:versionInfo>
           </dct:Standard>
@@ -29,7 +29,8 @@
     </dcat:record>
     <dcat:service>
       <dcat:DataService>
-        <dct:title xml:lang="nl">&lt;span id="template2">&lt;strong&gt;Open data&lt;/strong&gt; (niet-geo): Sjabloon voor Metadata van Generieke Open API's, conform DCAT-AP VL v2.0&lt;/span></dct:title>
+        <dct:title xml:lang="nl">Generieke Open API's, conform DCAT-AP VL v2.0</dct:title>
+        <dct:title xml:lang="en">Generic Open API's, conforming to DCAT-AP VL v2.0</dct:title>
         <dct:description/>
         <dct:publisher>
           <foaf:Agent>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
@@ -15,6 +15,7 @@
         <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
       </skos:Concept>
     </dct:language>
-    <dct:title xml:lang="nl">Virtual catalog template</dct:title>
+    <dct:title xml:lang="nl">Virtuele catalogus</dct:title>
+    <dct:title xml:lang="en">Virtual catalog</dct:title>
   </dcat:Catalog>
 </rdf:RDF>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
@@ -13,8 +13,8 @@
         <dct:modified>2020-04-16</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22">
-            <dct:title>Metadata-dcat</dct:title>
-            <dct:description xml:lang="nl">Het applicatieprofiel “metadata dcat”. Dit is een applicatieprofiel gebaseerd op DCAT en richt zich op het verzamelen van informatie over generieke datasets, distributies en services die door een overheid beschikbaar gesteld worden. De datasets en services omvatten zowel publiek toegankelijke als afgeschermde data en diensten (ontwikkeld in en voor eender welk technisch perspectief). Het samenbrengen van al deze informatie in een catalogus laat toe om de vindbaarheid van deze datasets en services te verhogen. Dit applicatieprofiel is het generieke basisprofiel. Afgeleide profielen kunnen zeker aangemaakt worden voor specifieke domeinen of communities. Bijvoorbeeld is DCAT-AP-VL zo’n afgeleid applicatieprofiel, specifiek voor het Open data domein en bijhorende community.</dct:description>
+            <dct:title>Metadata DCAT</dct:title>
+            <dct:description xml:lang="nl">Het applicatieprofiel “Metadata DCAT”. Dit is een applicatieprofiel gebaseerd op DCAT en richt zich op het verzamelen van informatie over generieke datasets, distributies en services die door een overheid beschikbaar gesteld worden. De datasets en services omvatten zowel publiek toegankelijke als afgeschermde data en diensten (ontwikkeld in en voor eender welk technisch perspectief). Het samenbrengen van al deze informatie in een catalogus laat toe om de vindbaarheid van deze datasets en services te verhogen. Dit applicatieprofiel is het generieke basisprofiel. Afgeleide profielen kunnen zeker aangemaakt worden voor specifieke domeinen of communities. Bijvoorbeeld is DCAT-AP-VL zo’n afgeleid applicatieprofiel, specifiek voor het Open data domein en bijhorende community.</dct:description>
             <owl:versionInfo>2.0</owl:versionInfo>
           </dct:Standard>
         </dct:conformsTo>
@@ -28,7 +28,8 @@
     </dcat:record>
     <dcat:dataset>
       <dcat:Dataset>
-        <dct:title xml:lang="nl">&lt;span id="template3">&lt;strong&gt;Andere gegevens&lt;/strong&gt; (niet-open en niet-geo): Sjabloon voor Metadata van Generieke Gesloten data, conform metadata-DCAT v2.0&lt;/span></dct:title>
+        <dct:title xml:lang="nl">Generieke Gesloten data, conform metadata-DCAT v2.0</dct:title>
+        <dct:title xml:lang="en">Generic Closed data, conforming to metadata-DCAT v2.0</dct:title>
         <dct:description xml:lang="nl"/>
         <dcat:contactPoint>
           <vcard:Organization>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
@@ -13,8 +13,8 @@
         <dct:modified>2020-04-16</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22">
-            <dct:title>Metadata-dcat</dct:title>
-            <dct:description xml:lang="nl">Het applicatieprofiel “metadata dcat”. Dit is een applicatieprofiel gebaseerd op DCAT en richt zich op het verzamelen van informatie over generieke datasets, distributies en services die door een overheid beschikbaar gesteld worden. De datasets en services omvatten zowel publiek toegankelijke als afgeschermde data en diensten (ontwikkeld in en voor eender welk technisch perspectief). Het samenbrengen van al deze informatie in een catalogus laat toe om de vindbaarheid van deze datasets en services te verhogen. Dit applicatieprofiel is het generieke basisprofiel. Afgeleide profielen kunnen zeker aangemaakt worden voor specifieke domeinen of communities. Bijvoorbeeld is DCAT-AP-VL zo’n afgeleid applicatieprofiel, specifiek voor het Open data domein en bijhorende community.</dct:description>
+            <dct:title>Metadata DCAT</dct:title>
+            <dct:description xml:lang="nl">Het applicatieprofiel “Metadata DCAT”. Dit is een applicatieprofiel gebaseerd op DCAT en richt zich op het verzamelen van informatie over generieke datasets, distributies en services die door een overheid beschikbaar gesteld worden. De datasets en services omvatten zowel publiek toegankelijke als afgeschermde data en diensten (ontwikkeld in en voor eender welk technisch perspectief). Het samenbrengen van al deze informatie in een catalogus laat toe om de vindbaarheid van deze datasets en services te verhogen. Dit applicatieprofiel is het generieke basisprofiel. Afgeleide profielen kunnen zeker aangemaakt worden voor specifieke domeinen of communities. Bijvoorbeeld is DCAT-AP-VL zo’n afgeleid applicatieprofiel, specifiek voor het Open data domein en bijhorende community.</dct:description>
             <owl:versionInfo>2.0</owl:versionInfo>
           </dct:Standard>
         </dct:conformsTo>
@@ -28,12 +28,13 @@
     </dcat:record>
     <dcat:service>
       <dcat:DataService>
-        <dct:title xml:lang="nl">&lt;span id="template3">&lt;strong&gt;Andere gegevens&lt;/strong&gt; (niet-open en niet-geo): Sjabloon voor Metadata van Generieke Gesloten services, conform metadata-DCAT v2.0&lt;/span></dct:title>
+        <dct:title xml:lang="nl">Generieke Gesloten services, conform metadata-DCAT v2.0</dct:title>
+        <dct:title xml:lang="en">Generic Closed services, conforming to metadata-DCAT v2.0</dct:title>
         <dct:description/>
         <dct:publisher>
-          <foaf:Agent>
+          <foaf:Agentk>
             <foaf:name xml:lang="nl"/>
-          </foaf:Agent>
+          </foaf:Agentk>
         </dct:publisher>
         <dcat:endpointURL rdf:resource=""/>
         <dcat:endpointDescription rdf:resource=""/>


### PR DESCRIPTION
- Removed html that was present due to a bind-html modification in the flemish geonetwork fork, which renders nicely in flanders but doesn't render at all in core geonetwork. We decided to handle this in a different way locally, potentially to be replaced by a better / generic core approach.
- Added multilingual values for the template titles so that they can be used for displaying translated titles.