### PR TITLE
Virtual Catalogue / Associated record / Add possibility to link to remote records.

### DIFF
--- a/src/main/java/org/fao/geonet/schema/dcatap/DCATAPSchemaPlugin.java
+++ b/src/main/java/org/fao/geonet/schema/dcatap/DCATAPSchemaPlugin.java
@@ -52,6 +52,7 @@ import org.jdom.filter.ElementFilter;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  *
@@ -105,13 +106,20 @@ public class DCATAPSchemaPlugin extends SchemaPlugin implements AssociatedResour
                     xpathForAggregationInfo,
                     allNamespaces.asList());
 
+            SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
+            String baseURL = settingManager.getBaseURL();
+
+
             for (Object o : sibs) {
                 if (o instanceof Element) {
                     Element sib = (Element) o;
                     String url = sib.getAttributeValue("resource", DCATAPNamespaces.RDF);
                     if (StringUtils.isNotEmpty(url)) {
+                        boolean isRemote = !url.startsWith(baseURL);
                         AssociatedResource resource =
-                            new AssociatedResource(url.substring(url.lastIndexOf('/') + 1), "", "isComposedOf", url, "");
+                            new AssociatedResource(
+                                isRemote ? url : url.substring(url.lastIndexOf('/') + 1),
+                                "", "isComposedOf", url, "");
                         listOfResources.add(resource);
                     }
                 }

--- a/src/main/java/org/fao/geonet/schema/dcatap/DCATAPSchemaPlugin.java
+++ b/src/main/java/org/fao/geonet/schema/dcatap/DCATAPSchemaPlugin.java
@@ -116,10 +116,18 @@ public class DCATAPSchemaPlugin extends SchemaPlugin implements AssociatedResour
                     String url = sib.getAttributeValue("resource", DCATAPNamespaces.RDF);
                     if (StringUtils.isNotEmpty(url)) {
                         boolean isRemote = !url.startsWith(baseURL);
+
+                        List<?> titleNode = Xml
+                            .selectNodes(
+                                metadata,
+                                String.format("dcat:CatalogRecord[@rdf:about='%s']/dct:title", url),
+                                allNamespaces.asList());
+
                         AssociatedResource resource =
                             new AssociatedResource(
                                 isRemote ? url : url.substring(url.lastIndexOf('/') + 1),
-                                "", "isComposedOf", url, "");
+                                "", "isComposedOf", url,
+                                titleNode == null || titleNode.isEmpty() ? "" : ((Element) titleNode.get(0)).getTextNormalize());
                         listOfResources.add(resource);
                     }
                 }

--- a/src/main/plugin/dcat-ap/config/associated-panel/dcatapcatalog.json
+++ b/src/main/plugin/dcat-ap/config/associated-panel/dcatapcatalog.json
@@ -13,6 +13,9 @@
               "params": {
                 "isTemplate": "n"
               }
+            },
+            "remoteurl": {
+              "multiple": false
             }
           }
         }

--- a/src/main/plugin/dcat-ap/config/associated-panel/default.json
+++ b/src/main/plugin/dcat-ap/config/associated-panel/default.json
@@ -17,9 +17,6 @@
                 ],
                 "isTemplate": "n"
               }
-            },
-            "remoteurl": {
-              "multiple": false
             }
           }
         }
@@ -37,9 +34,6 @@
                 ],
                 "isTemplate": "n"
               }
-            },
-            "remoteurl": {
-              "multiple": false
             }
           }
         }

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -1354,7 +1354,7 @@
               </snippet>
             </template>
           </action>
-          
+
           <field xpath="/rdf:RDF/dcat:Catalog/dct:language"
                  or="language"
                  in="/rdf:RDF/dcat:Catalog"/>
@@ -1383,6 +1383,7 @@
           <section forEach="/rdf:RDF/dcat:CatalogRecord[@rdf:about = ../dcat:Catalog/dcat:record/@rdf:resource]"
                         name="associatedRecord"
                         del=".">
+            <field xpath="dct:title" or="title" in="."/>
             <field xpath="dct:identifier"/>
             <field xpath="mdcat:stars" or="stars" in="."/>
           </section>

--- a/src/main/plugin/dcat-ap/process/sibling-add.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-add.xsl
@@ -26,13 +26,13 @@
   <xsl:variable name="catalogUuid" select="/rdf:RDF/geonet:info/uuid"/>
 
   <xsl:function name="dcat:get-resource-iri" as="xs:string">
-    <xsl:param name="recordUuid" as="xs:string"/>
+    <xsl:param name="record" as="node()"/>
     <xsl:param name="catalogUuid" as="xs:string"/>
     <xsl:param name="nodeUrl" as="xs:string"/>
 
-    <xsl:sequence select="if(starts-with($recordUuid, 'http'))
-                                                     then $recordUuid
-                                                     else concat($nodeUrl, 'api/records/', $catalogUuid, '/',$recordUuid)"/>
+    <xsl:sequence select="if(starts-with($record/url, 'http'))
+                                                     then $record/url
+                                                     else concat($nodeUrl, 'api/records/', $catalogUuid, '/',$record/uuid)"/>
   </xsl:function>
 
   <xsl:template match="dcat:Catalog">
@@ -42,9 +42,14 @@
 
     <xsl:variable name="uuidsToAdd" as="node()*">
       <xsl:for-each select="tokenize($uuids, ',')">
-        <xsl:variable name="uuid" select="tokenize(., '#')[1]"/>
+        <xsl:variable name="uuidTypesTitleAndURL" select="tokenize(., '#')"/>
+        <xsl:variable name="uuid" select="$uuidTypesTitleAndURL[1]"/>
         <xsl:if test="$uuids != '' and not($uuid = $associatedUuids)">
-          <uuid><xsl:value-of select="$uuid"/></uuid>
+          <record>
+            <uuid><xsl:value-of select="$uuid"/></uuid>
+            <title><xsl:value-of select="$uuidTypesTitleAndURL[4]"/></title>
+            <url><xsl:value-of select="$uuidTypesTitleAndURL[5]"/></url>
+          </record>
         </xsl:if>
       </xsl:for-each>
     </xsl:variable>
@@ -59,8 +64,11 @@
 
     <xsl:for-each select="$uuidsToAdd">
       <dcat:CatalogRecord rdf:about="{dcat:get-resource-iri(current(), $catalogUuid, $nodeUrl)}">
-        <dct:identifier><xsl:value-of select="current()"/></dct:identifier>
-        <foaf:primaryTopic rdf:resource="{concat($nodeUrl, 'api/records/', current())}"/>
+        <dct:identifier><xsl:value-of select="current()/uuid"/></dct:identifier>
+        <foaf:primaryTopic rdf:resource="{dcat:get-resource-iri(current(), $catalogUuid, $nodeUrl)}"/>
+        <xsl:if test="current()/title != ''">
+          <dct:title><xsl:value-of select="current()/title"/></dct:title>
+        </xsl:if>
       </dcat:CatalogRecord>
     </xsl:for-each>
   </xsl:template>

--- a/src/main/plugin/dcat-ap/process/sibling-add.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-add.xsl
@@ -25,6 +25,16 @@
 
   <xsl:variable name="catalogUuid" select="/rdf:RDF/geonet:info/uuid"/>
 
+  <xsl:function name="dcat:get-resource-iri" as="xs:string">
+    <xsl:param name="recordUuid" as="xs:string"/>
+    <xsl:param name="catalogUuid" as="xs:string"/>
+    <xsl:param name="nodeUrl" as="xs:string"/>
+
+    <xsl:sequence select="if(starts-with($recordUuid, 'http'))
+                                                     then $recordUuid
+                                                     else concat($nodeUrl, 'api/records/', $catalogUuid, '/',$recordUuid)"/>
+  </xsl:function>
+
   <xsl:template match="dcat:Catalog">
     <!-- All associated records and itself (to avoid linking to existing) -->
     <xsl:variable name="associatedUuids"
@@ -43,12 +53,12 @@
       <xsl:copy-of select="*"/>
 
       <xsl:for-each select="$uuidsToAdd">
-        <dcat:record rdf:resource="{concat($nodeUrl, 'api/records/', $catalogUuid, '/', current())}"/>
+        <dcat:record rdf:resource="{dcat:get-resource-iri(current(), $catalogUuid, $nodeUrl)}"/>
       </xsl:for-each>
     </xsl:copy>
 
     <xsl:for-each select="$uuidsToAdd">
-      <dcat:CatalogRecord rdf:about="{concat($nodeUrl, 'api/records/', $catalogUuid, '/', current())}">
+      <dcat:CatalogRecord rdf:about="{dcat:get-resource-iri(current(), $catalogUuid, $nodeUrl)}">
         <dct:identifier><xsl:value-of select="current()"/></dct:identifier>
         <foaf:primaryTopic rdf:resource="{concat($nodeUrl, 'api/records/', current())}"/>
       </dcat:CatalogRecord>

--- a/src/main/plugin/dcat-ap/process/sibling-remove.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-remove.xsl
@@ -14,7 +14,9 @@
   <xsl:variable name="nodeUrl" select="util:getSettingValue('nodeUrl')"/>
 
   <xsl:template match="dcat:Catalog/dcat:record[@rdf:resource = concat($nodeUrl, 'api/records/', $catalogUuid, '/', $uuidref)]|
-                                     dcat:CatalogRecord[@rdf:about = concat($nodeUrl, 'api/records/', $catalogUuid, '/', $uuidref)]"/>
+                                     dcat:CatalogRecord[@rdf:about = concat($nodeUrl, 'api/records/', $catalogUuid, '/', $uuidref)]|
+                                     dcat:Catalog/dcat:record[starts-with(@rdf:resource, 'http') and @rdf:resource = $uuidref]|
+                                     dcat:CatalogRecord[starts-with(@rdf:about, 'http') and @rdf:about = $uuidref]"/>
 
   <xsl:template match="@*|*|text()">
     <xsl:copy>


### PR DESCRIPTION
<img width="1028" height="292" alt="image" src="https://github.com/user-attachments/assets/2504ed4e-eda5-4e83-a340-975667b951bd" />


Encoding:

* When linking to an HTML page https://metadata.vlaanderen.be/srv/api/records/99954c0a-4ac4-56ad-a75e-a730d778ebaf (Title is extracted)


```xml
  <dcat:record rdf:resource="https://metadata.vlaanderen.be/srv/api/records/99954c0a-4ac4-56ad-a75e-a730d778ebaf"/>

<dcat:CatalogRecord rdf:about="https://metadata.vlaanderen.be/srv/api/records/99954c0a-4ac4-56ad-a75e-a730d778ebaf">
      <foaf:primaryTopic rdf:resource="https://metadata.vlaanderen.be/srv/api/records/99954c0a-4ac4-56ad-a75e-a730d778ebaf"/>
      <dct:title xml:lang="nl">Het digitale bouwaanvragen archief</dct:title>
      <dct:identifier>https://metadata.vlaanderen.be/srv/api/records/99954c0a-4ac4-56ad-a75e-a730d778ebaf</dct:identifier>
   </dcat:CatalogRecord>

```

* When linking from an XML ISO document https://metadata.vlaanderen.be/srv/api/records/c3a1ece2-53de-4037-ab01-eabf13beb64c/formatters/xml (UUID and title are extracted) 

```xml

   <dcat:record rdf:resource="https://metadata.vlaanderen.be/srv/api/records/c3a1ece2-53de-4037-ab01-eabf13beb64c/formatters/xml"/>

   <dcat:CatalogRecord rdf:about="https://metadata.vlaanderen.be/srv/api/records/c3a1ece2-53de-4037-ab01-eabf13beb64c/formatters/xml">
      <foaf:primaryTopic rdf:resource="https://metadata.vlaanderen.be/srv/api/records/c3a1ece2-53de-4037-ab01-eabf13beb64c/formatters/xml"/>
      <dct:title xml:lang="nl">Vlaamse Hydrografische Atlas - Waterlopen  toestand 07/08/2025</dct:title>
      <dct:identifier>c3a1ece2-53de-4037-ab01-eabf13beb64c</dct:identifier>
   </dcat:CatalogRecord>

```

In the editor, compared to local record, only the link is displayed

<img width="1060" height="318" alt="image" src="https://github.com/user-attachments/assets/46d5aa7c-ed99-4e38-afcd-9f46b60b9fbe" />


In the record view, those remote records are also not listed as part of the grid/table view which is based on local records available from the search.

