### PR TITLE
Indexing / Fix resourceIdentifier to use the first available

### DIFF
--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -203,7 +203,7 @@
 
         <resourceIdentifier type="object">
           {
-          "code": "<xsl:value-of select="dct:identifier[0]/string()"/>",
+          "code": "<xsl:value-of select="dct:identifier[1]/string()"/>",
           "codeSpace": "",
           "link": "<xsl:value-of select="@rdf:about"/>"
           }


### PR DESCRIPTION
When using the default angular JS view, the resource identifier was missing because the field was not properly indexed. In XSL, position starts at 1.

<img width="445" height="251" alt="image" src="https://github.com/user-attachments/assets/367a3f34-e497-4c02-860f-15b8d4201773" />
