### PR TITLE
Virtual catalog / Ensure db UUID is set

### DIFF
--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -191,10 +191,11 @@
       <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
   </xsl:template>
-
-  <xsl:template match="dcat:Catalog[$isVirtualCatalog and not(dct:identifier)]" priority="10">
+  
+  <!-- Ensure virtual Catalog identifier is corresponding to the db UUID and the CatalogRecord one. -->
+  <xsl:template match="dcat:Catalog[$isVirtualCatalog]" priority="10">
     <xsl:copy>
-      <xsl:apply-templates select="@*|*"/>
+      <xsl:apply-templates select="@*|(* except dct:identifier)"/>
       <dct:identifier>
         <xsl:value-of select="$recordUUID"/>
       </dct:identifier>


### PR DESCRIPTION
The virtual catalog has a reference to the UUID in 
* `dcat:CatalogRecord/@rdf:about`
* `dcat:CatalogRecord/dct:identifier`
* `dcat:Catalog/dct:identifier`

Text fields were lost if a virtual catalog when importing from another catalogue because of the last item not updated (eg. when copy/paste in XML view).

Related to the language retrieval in https://github.com/metadata101/dcat-ap/blob/main/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl#L44

Test: 
* create a virtual catalog from a template,
* edit in XML view
* copy/paste an external record eg. https://metadata.beta-vlaanderen.be/srv/api/records/1bad3ae7-5f59-4c57-92e2-2dd402f21566/formatters/xml?&attachment=true
* save record 2 times = text fields were lost