### PR TITLE
Editor / Keywords / Use keyword id when available.

### DIFF
--- a/src/main/plugin/dcat-ap/layout/layout-custom-fields-concepts.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout-custom-fields-concepts.xsl
@@ -144,6 +144,9 @@
         </xsl:choose>
       </xsl:variable>
 
+      <xsl:variable name="keywordIds"
+                    select="string-join($keywords/(@rdf:resource|*/@rdf:about), ',')"/>
+
       <xsl:variable name="transformation" select="if ($config/useReference = 'true')
                                                 then 'to-dcat-ap-concept-reference'
                                                 else 'to-dcat-ap-concept'"/>
@@ -161,6 +164,7 @@
            data-thesaurus-title="{($strings/*[name() = $config/labelKey], $labels/element[@name = $config/@name]/label)[1]}"
            data-thesaurus-key="{$config/thesaurus}"
            data-keywords="{$values}"
+           data-keyword-ids="{$keywordIds}"
            data-transformations="{$transformation}"
            data-current-transformation="{$transformation}"
            data-max-tags="{$config/max}"


### PR DESCRIPTION
Add support for https://github.com/geonetwork/core-geonetwork/pull/8973

This makes the editor more robust for multilingual editing or when UI language is not the record language and avoid to display the alert box when keywords are not found in the UI language.

In DCAT keyword ids are stored in `@rdf:resource` or `*/@rdf:about` depending if the thesaurus is configured with `useReference` or not.