### PR TITLE
Bump to GeoNetwork 4.4.9-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>gn-schemas</artifactId>
     <groupId>org.geonetwork-opensource.schemas</groupId>
-    <version>4.4.8-SNAPSHOT</version>
+    <version>4.4.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Updating `main` to the latest GN version (4.4.9-SNAPSHOT).