### PR TITLE
VL-specific: simplified template titles

### DIFF
--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -1065,7 +1065,7 @@
     <btnLabel>Ontwikkelingstoestand</btnLabel>
   </element>
   <element name="mdcat:stars">
-    <label>Sterren</label>
+    <label>Beoordeling</label>
     <description>Rating van 1-5 sterren</description>
     <btnLabel>Sterren</btnLabel>
   </element>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-dataset.xml
@@ -20,8 +20,8 @@
     </dcat:record>
     <dcat:dataset>
       <dcat:Dataset>
-        <dct:title xml:lang="en">Generic DCAT-AP dataset</dct:title>
-        <dct:title xml:lang="nl">Generieke DCAT-AP dataset</dct:title>
+        <dct:title xml:lang="en">Dataset</dct:title>
+        <dct:title xml:lang="nl">Dataset</dct:title>
         <dct:description xml:lang="en"/>
         <dct:description xml:lang="nl"/>
       </dcat:Dataset>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-service.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-service.xml
@@ -20,8 +20,8 @@
     </dcat:record>
     <dcat:service>
       <dcat:DataService>
-        <dct:title xml:lang="en">Generic DCAT-AP service</dct:title>
-        <dct:title xml:lang="nl">Generieke DCAT-AP service</dct:title>
+        <dct:title xml:lang="en">Dataservice</dct:title>
+        <dct:title xml:lang="nl">Dataservice</dct:title>
         <dct:description xml:lang="en"/>
         <dct:description xml:lang="nl"/>
       </dcat:DataService>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-dataset.xml
@@ -29,8 +29,8 @@
     </dcat:record>
     <dcat:dataset>
       <dcat:Dataset>
-        <dct:title xml:lang="nl">Generieke Open data, conform DCAT-AP VL v2.0</dct:title>
-        <dct:title xml:lang="en">Generic Open data, conforming to DCAT-AP VL v2.0</dct:title>
+        <dct:title xml:lang="nl">Open dataset</dct:title>
+        <dct:title xml:lang="en">Open dataset</dct:title>
         <dct:description xml:lang="nl"/>
         <dcat:contactPoint>
           <vcard:Organization>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-service.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-service.xml
@@ -29,8 +29,8 @@
     </dcat:record>
     <dcat:service>
       <dcat:DataService>
-        <dct:title xml:lang="nl">Generieke Open API's, conform DCAT-AP VL v2.0</dct:title>
-        <dct:title xml:lang="en">Generic Open API's, conforming to DCAT-AP VL v2.0</dct:title>
+        <dct:title xml:lang="nl">Open dataservice</dct:title>
+        <dct:title xml:lang="en">Open dataservice</dct:title>
         <dct:description/>
         <dct:publisher>
           <foaf:Agent>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
@@ -47,7 +47,7 @@
         <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
       </skos:Concept>
     </dct:language>
-    <dct:title xml:lang="nl">Virtuele catalogus</dct:title>
-    <dct:title xml:lang="en">Virtual catalog</dct:title>
+    <dct:title xml:lang="nl">Subcatalogus</dct:title>
+    <dct:title xml:lang="en">Subcatalogue</dct:title>
   </dcat:Catalog>
 </rdf:RDF>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-dataset.xml
@@ -29,8 +29,8 @@
     </dcat:record>
     <dcat:dataset>
       <dcat:Dataset>
-        <dct:title xml:lang="nl">Generieke Open data, conform DCAT-AP VL v3.0</dct:title>
-        <dct:title xml:lang="en">Generic Open data, conforming to DCAT-AP VL v3.0</dct:title>
+        <dct:title xml:lang="nl">Open dataset</dct:title>
+        <dct:title xml:lang="en">Open dataset</dct:title>
         <dct:description xml:lang="nl"/>
         <dcat:contactPoint>
           <vcard:Organization>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-service.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-service.xml
@@ -29,8 +29,8 @@
     </dcat:record>
     <dcat:service>
       <dcat:DataService>
-        <dct:title xml:lang="nl">Generieke Open API's, conform DCAT-AP VL v3.0</dct:title>
-        <dct:title xml:lang="en">Generic Open API's, conforming to DCAT-AP VL v3.0</dct:title>
+        <dct:title xml:lang="nl">Open dataservice</dct:title>
+        <dct:title xml:lang="en">Open dataservice</dct:title>
         <dct:description/>
         <dct:publisher>
           <foaf:Agent>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap3-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap3-dataset.xml
@@ -18,7 +18,7 @@
     </dcat:record>
     <dcat:dataset>
       <dcat:Dataset>
-        <dct:title xml:lang="nl">DCAT-AP 3 dataset</dct:title>
+        <dct:title xml:lang="nl">Dataset</dct:title>
         <dct:description xml:lang="nl"/>
       </dcat:Dataset>
     </dcat:dataset>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap3-series.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap3-series.xml
@@ -18,7 +18,8 @@
     </dcat:record>
     <dcat:dataset>
       <dcat:DatasetSeries>
-        <dct:title>DCAT-AP 3 series</dct:title>
+        <dct:title xml:lang="en">Series of datasets</dct:title>
+        <dct:title xml:lang="nl">Serie van datasets</dct:title>
         <dct:description/>
       </dcat:DatasetSeries>
     </dcat:dataset>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap3-service.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap3-service.xml
@@ -18,7 +18,7 @@
     </dcat:record>
     <dcat:service>
       <dcat:DataService>
-        <dct:title xml:lang="nl">DCAT-AP 3 service</dct:title>
+        <dct:title xml:lang="nl">Dataservice</dct:title>
         <dct:description xml:lang="nl"/>
       </dcat:DataService>
     </dcat:service>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
@@ -28,8 +28,8 @@
     </dcat:record>
     <dcat:dataset>
       <dcat:Dataset>
-        <dct:title xml:lang="nl">Generieke Gesloten data, conform metadata-DCAT v2.0</dct:title>
-        <dct:title xml:lang="en">Generic Closed data, conforming to metadata-DCAT v2.0</dct:title>
+        <dct:title xml:lang="nl">Dataset</dct:title>
+        <dct:title xml:lang="en">Dataset</dct:title>
         <dct:description xml:lang="nl"/>
         <dcat:contactPoint>
           <vcard:Organization>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
@@ -28,8 +28,8 @@
     </dcat:record>
     <dcat:service>
       <dcat:DataService>
-        <dct:title xml:lang="nl">Generieke Gesloten services, conform metadata-DCAT v2.0</dct:title>
-        <dct:title xml:lang="en">Generic Closed services, conforming to metadata-DCAT v2.0</dct:title>
+        <dct:title xml:lang="nl">Dataservice</dct:title>
+        <dct:title xml:lang="en">Dataservice</dct:title>
         <dct:description/>
         <dct:publisher>
           <foaf:Agent>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat3-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat3-dataset.xml
@@ -28,8 +28,8 @@
     </dcat:record>
     <dcat:dataset>
       <dcat:Dataset>
-        <dct:title xml:lang="nl">Generieke Gesloten data, conform metadata-DCAT v3.0</dct:title>
-        <dct:title xml:lang="en">Generic Closed data, conforming to metadata-DCAT v3.0</dct:title>
+        <dct:title xml:lang="nl">Dataset</dct:title>
+        <dct:title xml:lang="en">Dataset</dct:title>
         <dct:description xml:lang="nl"/>
         <dcat:contactPoint>
           <vcard:Organization>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat3-service.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat3-service.xml
@@ -28,8 +28,8 @@
     </dcat:record>
     <dcat:service>
       <dcat:DataService>
-        <dct:title xml:lang="nl">Generieke Gesloten services, conform metadata-DCAT v3.0</dct:title>
-        <dct:title xml:lang="en">Generic Closed services, conforming to metadata-DCAT v3.0</dct:title>
+        <dct:title xml:lang="nl">Dataservice</dct:title>
+        <dct:title xml:lang="en">Dataservice</dct:title>
         <dct:description/>
         <dct:publisher>
           <foaf:Agent>


### PR DESCRIPTION
Simplifying template titles for use in the VL fork. The goal is to add additional information in the form of descriptions and badges, cleaning up the titles themselves. Sneak peak:

<img width="853" height="705" alt="image" src="https://github.com/user-attachments/assets/48bcd507-dd57-441a-8f7e-beb3b6b8834c" />
