### PR TITLE
Unbounding some vcard cardinalities

### DIFF
--- a/src/main/plugin/dcat-ap/schema/vcard.xsd
+++ b/src/main/plugin/dcat-ap/schema/vcard.xsd
@@ -18,7 +18,7 @@
           <xs:sequence>
             <!-- optional properties-->
             <xs:element name="fn" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="organization-name" type="rdf:PlainLiteral" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="organization-name" type="rdf:PlainLiteral" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element ref="vcard:hasAddress" minOccurs="0" maxOccurs="1"/>
             <xs:element name="hasEmail" type="rdf:ResourceRef" minOccurs="0" maxOccurs="1"/>
             <xs:element name="hasURL" type="rdf:ResourceRef" minOccurs="0" maxOccurs="1"/>
@@ -37,10 +37,10 @@
         <xs:complexType>
           <xs:sequence>
             <!-- mandatory properties-->
-            <xs:element name="street-address" type="rdf:PlainLiteral" maxOccurs="1"/>
-            <xs:element name="locality" type="rdf:PlainLiteral" maxOccurs="1"/>
+            <xs:element name="street-address" type="rdf:PlainLiteral" maxOccurs="unbounded"/>
+            <xs:element name="locality" type="rdf:PlainLiteral" maxOccurs="unbounded"/>
             <xs:element name="postal-code" type="xs:string" maxOccurs="1"/>
-            <xs:element name="country-name" type="rdf:PlainLiteral" maxOccurs="1"/>
+            <xs:element name="country-name" type="rdf:PlainLiteral" maxOccurs="unbounded"/>
           </xs:sequence>
           <xs:attribute ref="rdf:about"/>
           <xs:attribute ref="rdf:nodeID"/>


### PR DESCRIPTION
We experienced some issues with vcard fields. As the schema is currently not used for cardinality checks (this is handled by the schematron files) we should set values to `unbounded`. Perhaps this can be done for the whole schema, but for now I'll modify the offending fields so we don't experience additional issues.