### PR TITLE
Disallow multiple mdcat:stars

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -1498,7 +1498,14 @@
                         del=".">
             <field xpath="dct:title" or="title" in="."/>
             <field xpath="dct:identifier"/>
-            <field xpath="mdcat:stars" or="stars" in="."/>
+            <field xpath="mdcat:stars" in="."/>
+            <action type="add" in="." or="stars" if="count(mdcat:stars)=0">
+              <template>
+                <snippet>
+                  <mdcat:stars>1</mdcat:stars>
+                </snippet>
+              </template>
+            </action>
           </section>
         </section>
       </tab>


### PR DESCRIPTION
Multiple additions of mdcat:stars element were possible through the editor, breaking the view. This PR limits the amount to 1. Additional finetuning is necessary through validation though, but as we are now using this element as a test property for the subcatalog functionality it's best to keep it consistent.

<img width="317" height="671" alt="image" src="https://github.com/user-attachments/assets/b1e804c5-dc45-49be-b966-32326723c4c4" />
