### PR TITLE
Adding OSLO standards as thesaurus

### DIFF
--- a/resources/thesauri/theme/oslo-datastandaarden.rdf
+++ b/resources/thesauri/theme/oslo-datastandaarden.rdf
@@ -16,6 +16,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/energiemanagementsysteem/">
@@ -23,6 +25,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-14</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-14</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Energiemanagementsysteem</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/inname-openbaar-domein/">
@@ -30,13 +34,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Inname openbaar domein</skos:prefLabel>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/aim-object/">
-    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
-    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
-    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel AIM Object</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/slimmeraadpleegomgeving">
@@ -44,13 +43,17 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-02-08</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-02-08</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Slimme Raadpleegomgeving</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/implementatiemodel/cultureel-erfgoed-basisregistratie">
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/aim-object/">
     <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-10-02</dcterms:modified>
-    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-10-02</dcterms:created>
-    <skos:prefLabel xml:lang="nl">Implementatiemodel Basisregistratie Cultureel Erfgoed</skos:prefLabel>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel AIM Object</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/bodem/">
@@ -58,13 +61,17 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Bodem</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/proeven-metingen/">
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/implementatiemodel/cultureel-erfgoed-basisregistratie">
     <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
-    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
-    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Proeven en metingen</skos:prefLabel>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-10-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-10-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Implementatiemodel Basisregistratie Cultureel Erfgoed</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/zaalreservatie/">
@@ -72,6 +79,17 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Zaalreservatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/proeven-metingen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Proeven en metingen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/software-hardware/">
@@ -79,6 +97,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Software en hardware</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/verlichtingsinstallatie/">
@@ -86,6 +106,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Verlichtingsinstallatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/fietstelinstallatie/">
@@ -93,6 +115,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Fietstelinstallatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/anpr-trajectcontrole/">
@@ -100,6 +124,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel ANPR en trajectcontrole</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/gebieden">
@@ -107,6 +133,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Gebieden</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/financiele-rapportering">
@@ -114,6 +142,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-03-17</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-03-17</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Financiële Rapportering</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/gebouwenregister/">
@@ -121,6 +151,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-08</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-08</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Gebouwenregister</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/verharding-wegfundering/">
@@ -128,6 +160,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Verharding en wegfundering</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/omgevingsvergunning">
@@ -135,6 +169,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-11-07</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-11-07</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Omgevingsvergunning</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/elektrische-componenten/">
@@ -142,6 +178,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Elektrische componenten</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/ventilatie/">
@@ -149,6 +187,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Ventilatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/logies-basis/">
@@ -156,6 +196,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-05</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-05</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Toeristische Logies Basis</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/vastgoed">
@@ -163,6 +205,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-06-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-06-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Vastgoed</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/fietsinfrastructuur">
@@ -170,6 +214,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-12-17</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-12-17</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Fietsinfrastructuur</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/begraafplaatsenbeheer">
@@ -177,6 +223,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Begraafplaatsenbeheer</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/leermiddelen">
@@ -184,6 +232,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-08-20</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-08-20</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Leermiddelen en doelen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/besluitvorming">
@@ -191,6 +241,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-02-04</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-02-04</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Besluitvorming</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/perceel/">
@@ -198,6 +250,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-06-18</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-06-18</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Perceel</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/onbegroeid-voorkomen/">
@@ -205,6 +259,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Onbegroeid Voorkomen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/dienstregeling-en-planning/tijdstabellen/">
@@ -212,6 +268,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteit: Dienstregeling en Planning Tijdstabellen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/cultureel-erfgoed-object">
@@ -219,6 +277,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Cultureel Erfgoed Object</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/generiek-basis/">
@@ -226,13 +286,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2017-03-23</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2017-03-23</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Generiek basis</skos:prefLabel>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/luidspreker-intercom/">
-    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
-    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
-    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Luidsprekers en intercom</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/hulp-dienstverlening-gedetineerden">
@@ -240,6 +295,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-18</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-18</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Hulp- en Dienstverlening aan Gedetineerden</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/leerprestatiecredential">
@@ -247,6 +304,17 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-20</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-20</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Leerprestatiecredential</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/luidspreker-intercom/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Luidsprekers en intercom</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/loongegevens">
@@ -254,6 +322,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-16</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-16</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel loongegevens</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/FeitelijkeVerenigingen/">
@@ -261,13 +331,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-02-03</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-02-03</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Feitelijke Verenigingen</skos:prefLabel>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/tunnelevacuatie/">
-    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
-    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
-    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Tunnelevacuatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/generieke-terugmeldfaciliteit/">
@@ -275,6 +340,17 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Generieke Terugmeldfaciliteit</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/tunnelevacuatie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Tunnelevacuatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/slimme-stadsdistributie">
@@ -282,6 +358,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-16</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-16</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel OSLO Slimme Stadsdistributie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/infrastructuurelementen/">
@@ -289,6 +367,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Infrastructuurelementen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bedrijventerrein/">
@@ -296,6 +376,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-06-18</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-06-18</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Bedrijventerrein</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bestuurlijk-sanctieregister">
@@ -303,10 +385,11 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-06-23</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-06-23</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Bestuurlijk Sanctieregister</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel">
-    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/cultureel-erfgoed-object"/>
     <skos:narrower rdf:resource="https://data.vlaanderen.be/ns/openbaardomein"/>
     <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/grondwatermeetnet/"/>
     <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/begroeid-voorkomen/"/>
@@ -317,10 +400,12 @@
     <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/leerinschrijfcredential/"/>
     <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/FeitelijkeVerenigingen/"/>
     <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/waterkwaliteit"/>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
     <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/adresregister/"/>
     <skos:topConceptOf rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
     <skos:definition xml:lang="nl">Dit type document is een specificatie op basis van de termen uit een of meerdere vocabularia. Het geeft aan hoe data binnen een generiek applicatie domein dient gebruikt te worden.</skos:definition>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel</skos:prefLabel>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/cultureel-erfgoed-object"/>
     <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/ruimtelijke-indicatoren"/>
     <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/wegenregister/"/>
     <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/watervoorkomen/"/>
@@ -423,6 +508,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Begroeid Voorkomen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/meten-in-vlaanderen/">
@@ -430,6 +517,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Meten in Vlaanderen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/interpretaties/">
@@ -437,6 +526,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Bodem en Ondergrond Interpretaties</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/ruimtelijke-indicatoren">
@@ -444,6 +535,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-12-05</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-12-05</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Ruimtelijke Indicatoren</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/lokale-economie">
@@ -451,6 +544,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-01-17</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-01-17</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Lokale Economie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/thermografische-gebouwanalyse">
@@ -458,6 +553,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-22</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-22</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Thermografische Gebouwanalyse</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/notificatie-basis/">
@@ -465,6 +562,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Notificatie Basis</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/terreindelen/">
@@ -472,6 +571,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Terreindelen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/eenvoudige-datatypes/">
@@ -479,6 +580,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Eenvoudige datatypes</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/openbare-nutsvoorzieningkasten/">
@@ -486,6 +589,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-28</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-28</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Openbare Nutsvoorzieningkasten</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/complexe-datatypes/">
@@ -493,6 +598,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Complexe datatypes</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/watervoorkomen/">
@@ -500,6 +607,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Water voorkomen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://purl.eu/doc/applicationprofile/mobility/passenger-transport-hubs/index_en.html">
@@ -507,6 +616,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Passenger Transport Hubs</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/openbaar-domein/">
@@ -514,6 +625,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Openbaar Domein</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/draagconstructies/">
@@ -521,6 +634,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Draagconstructies</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/ecologische-maatregelen/">
@@ -528,6 +643,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Ecologische maatregelen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/signalisatie/">
@@ -535,6 +652,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Signalisatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/brandleiding/">
@@ -542,6 +661,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Brandleiding</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://productencatalogus.data.vlaanderen.be/doc/implementatiemodel/ipdc-lpdc">
@@ -549,6 +670,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-04</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-04</dcterms:created>
     <skos:prefLabel xml:lang="nl">Vocabularium en implementatiemodel IPDC - LPDC</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <skos:prefLabel xml:lang="nl">Implementatiemodel IPDC - LPDC</skos:prefLabel>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
@@ -557,6 +680,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-03</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-03</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Organisatie Basis</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit-trips-en-aanbod">
@@ -564,6 +689,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteit: Trips en Aanbod</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/GEODCAT-AP-VL/kandidaatstandaard/2025-12-09/">
@@ -571,6 +698,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-09-10</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-09-10</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel GeoDCAT-AP VL</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/waterdelen/">
@@ -578,6 +707,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Waterdelen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/verkeersborden/">
@@ -585,6 +716,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Verkeersborden</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/dienstencataloog/">
@@ -592,10 +725,11 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Dienstencataloog</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel">
-    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/kasten-cabines-behuizing/"/>
     <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/signalisatie/"/>
     <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/luidspreker-intercom/"/>
     <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/relaties/"/>
@@ -606,10 +740,12 @@
     <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/union-datatypes/"/>
     <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/aim-object/"/>
     <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/draagconstructies/"/>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
     <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/elektrische-componenten/"/>
     <skos:topConceptOf rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
     <skos:definition xml:lang="nl"> Dit Type document is een specificatie op basis van de termen uit een of meerdere vocabularia. Het heeft aan hoe data binnen een specifiek applicatiedomein dient gebruikt te worden. Dikwijls, maar niet verplicht, implementeert een implementatie model de afspraken van een bijhorend applicatieprofiel</skos:definition>
     <skos:prefLabel xml:lang="nl">Implementatiemodel</skos:prefLabel>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/kasten-cabines-behuizing/"/>
     <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/zone-30/"/>
     <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/tunnelevacuatie/"/>
     <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/meten-in-vlaanderen/"/>
@@ -643,6 +779,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Contactvoorkeuren</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/master/">
@@ -650,6 +788,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Master-implementatiemodel</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/vegetatie/">
@@ -657,6 +797,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Vegetatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/relaties/">
@@ -664,6 +806,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Relaties</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/sonderingen/">
@@ -671,6 +815,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-08-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-08-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Sonderingen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/vervoersknooppunten">
@@ -678,6 +824,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Vervoersknooppunten</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/ns/cultuurparticipatie">
@@ -685,6 +833,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:created>
     <skos:prefLabel xml:lang="nl">Vocabularium Cultuurparticipatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/observaties/">
@@ -692,13 +842,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Bodem en Ondergrond Observaties</skos:prefLabel>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/slagboom-doorsteek/">
-    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
-    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
-    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Slagbomen en doorsteken</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/watervoorkomen">
@@ -706,6 +851,17 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Watervoorkomen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/slagboom-doorsteek/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Slagbomen en doorsteken</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/optisch-transport-netwerk/">
@@ -713,6 +869,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Optisch transport netwerk</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/statistiek">
@@ -720,6 +878,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel OSLO Statistiek</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/waterdelen">
@@ -727,6 +887,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Waterdelen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit-intelligente-toegang">
@@ -734,6 +896,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-11-08</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-11-08</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteit: Intelligente Toegang</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/lijnvormige-elementen/">
@@ -741,6 +905,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Lijnvormige elementen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/inbreuken-zwaar-vervoer/">
@@ -748,6 +914,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Inbreuken zwaar vervoer</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/">
@@ -755,6 +923,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-20</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-20</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Besluit Publicatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/publicatie-advertentie/">
@@ -762,6 +932,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-11-09</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-11-09</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Publicatie-Advertentie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/">
@@ -769,6 +941,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Bodem en Ondergrond</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/dynamische-borden/">
@@ -776,6 +950,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Dynamische borden</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/voorwaarden-dienstverlening/">
@@ -783,6 +959,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-07-11</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-07-11</dcterms:created>
     <skos:prefLabel xml:lang="nl">OSLO Voorwaarden Dienstverlening</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/incentiveringsplatform">
@@ -790,6 +968,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-03-21</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-03-21</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Incentiveringsplatform</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/rooilijnplannen/">
@@ -797,6 +977,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Rooilijnplannen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/verkeersmetingen">
@@ -804,6 +986,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-12-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-12-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Verkeersmetingen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/terreindelen">
@@ -811,6 +995,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Terreindelen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/persoon-basis/">
@@ -818,6 +1004,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Persoon basis</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/hulpposten/">
@@ -825,6 +1013,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Hulpposten</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/openbaar-domein">
@@ -832,6 +1022,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Basisprofiel Openbaar Domein</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/grondboringen/">
@@ -839,6 +1031,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Grondboringen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/vrachtwagenparkeren">
@@ -846,6 +1040,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Vrachtwagenparkeren</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/vegetatie-elementen/">
@@ -853,6 +1049,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Vegetatie-elementen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/waterkwaliteit">
@@ -860,6 +1058,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel OSLO Waterkwaliteit</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://implementatie.data.vlaanderen.be/doc/implementatiemodel/kwaliteit-wegen-en-wegmarkeringen/">
@@ -867,6 +1067,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-07-24</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-07-24</dcterms:created>
     <skos:prefLabel xml:lang="nl">Implementatiemodel Kwaliteit Wegen en Wegmarkeringen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/vlaamse-codex/">
@@ -874,6 +1076,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Vlaamse Codex</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/issue-tracking-voor-burgers-en-organisaties/">
@@ -881,6 +1085,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Issue tracking voor burgers en organisaties</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/camerainstallatie/">
@@ -888,6 +1094,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Camerainstallatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/cultureel-erfgoed-event">
@@ -895,6 +1103,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Cultureel Erfgoed Event</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/">
@@ -902,13 +1112,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel metadata DCAT</skos:prefLabel>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/union-datatypes/">
-    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
-    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
-    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Union datatypes</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/energiehuis">
@@ -916,6 +1121,17 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-19</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-19</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Energiehuis</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/union-datatypes/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Union datatypes</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/adresregister/">
@@ -923,6 +1139,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Adresregister</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL">
@@ -930,6 +1148,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel DCAT-AP VL 2.0</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/grondwatermeetnet/">
@@ -937,6 +1157,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-08-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-08-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Grondwatermeetnet</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteitsbudget/">
@@ -944,6 +1166,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-11-10</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-11-10</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteitsbudget</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/overlijdensaangifte">
@@ -951,6 +1175,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-02-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-02-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Overlijdensaangifte</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/dienst-transactiemodel/">
@@ -958,6 +1184,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Dienst Transactiemodel</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/wegenregister/">
@@ -965,6 +1193,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Wegenregister</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/datakwaliteit">
@@ -972,6 +1202,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel OSLO Datakwaliteit</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/onbegroeid-voorkomen">
@@ -979,6 +1211,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Onbegroeid Voorkomen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/verkeersregelinstallatie/">
@@ -986,6 +1220,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Verkeersregelinstallatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/begroeid-voorkomen/">
@@ -993,6 +1229,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Begroeid Voorkomen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/subsidieregister/">
@@ -1000,13 +1238,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-01-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-01-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Besluit Subsidies</skos:prefLabel>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/luchtkwaliteit/">
-    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
-    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
-    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Luchtkwaliteit</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/observaties-en-metingen/">
@@ -1014,6 +1247,17 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Observaties en Metingen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/luchtkwaliteit/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Luchtkwaliteit</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/schuldbeheer">
@@ -1021,6 +1265,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-15</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-15</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Schuldbeheer</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/infrastructuurelementen">
@@ -1028,6 +1274,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Infrastructuurelementen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/ruimtelijke-bereiken/">
@@ -1035,6 +1283,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Ruimtelijke Bereiken</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/dienstregeling-en-planning/stopplaatsen/">
@@ -1042,6 +1292,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteit: Dienstregeling en Planning Stopplaatsen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/riolering/">
@@ -1049,6 +1301,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Riolering</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/implementatiemodel/verkeersmeldingen/">
@@ -1056,6 +1310,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-04</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-04</dcterms:created>
     <skos:prefLabel xml:lang="nl">Implementatiemodel Verkeersmeldingen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/cultuurparticipatie">
@@ -1063,6 +1319,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Cultuurparticipatie</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/begraafplaatsen">
@@ -1070,6 +1328,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Begraafplaatsen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/vegetatie-elementen">
@@ -1077,6 +1337,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Vegetatie-elementen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/kandidaatstandaard/2025-12-09/">
@@ -1084,6 +1346,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-09-10</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-09-10</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel DCAT-AP VL</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/begraafplaatsenbeheer/">
@@ -1091,13 +1355,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
     <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Begraafplaatsenbeheer</skos:prefLabel>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/zone-30/">
-    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
-    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
-    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Zone 30</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/dienstregeling-en-planning/voertuigplanning/">
@@ -1105,6 +1364,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteit: Dienstregeling en Planning Voertuigplanning</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/cultuur-en-jeugd/infrastructuur">
@@ -1112,6 +1373,17 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-03-21</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-03-21</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Cultuur- en Jeugdinfrastructuur</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/zone-30/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Zone 30</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/ldes">
@@ -1119,6 +1391,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel LDES</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/id/conceptscheme/StandaardType">
@@ -1134,6 +1408,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-20</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-20</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Mandatendatabank</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/sensoren-en-bemonstering/">
@@ -1141,6 +1417,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Sensoren en Bemonstering</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DigitaleWatermeter">
@@ -1148,6 +1426,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-04-30</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-04-30</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Digitale Watermeter</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/kasten-cabines-behuizing/">
@@ -1155,6 +1435,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
     <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Kasten, cabines, behuizing</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/erosiepoel">
@@ -1162,6 +1444,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-23</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-23</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Erosiepoel</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/dossier">
@@ -1169,6 +1453,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-25</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-25</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Dossier</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-mobiliteit/">
@@ -1176,6 +1462,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-06-01</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-06-01</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Besluit Mobiliteit</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/leerinschrijfcredential/">
@@ -1183,6 +1471,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-04-08</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-04-08</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Leerinschrijfcredential</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/dienstverlening-aan-personen/">
@@ -1190,6 +1480,8 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-03-19</dcterms:modified>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-03-19</dcterms:created>
     <skos:prefLabel xml:lang="nl">Applicatieprofiel Dienstverlening Aan Personen</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:broader rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
   </rdf:Description>
 </rdf:RDF>

--- a/resources/thesauri/theme/oslo-datastandaarden.rdf
+++ b/resources/thesauri/theme/oslo-datastandaarden.rdf
@@ -1,0 +1,1195 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:adms="http://www.w3.org/ns/adms#"
+    xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:dvcs="https://data.vlaanderen.be/id/conceptscheme/"
+    xmlns:dcat="http://www.w3.org/ns/dcat#"
+    xmlns:m8g="http://data.europa.eu/m8g/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#" > 
+  <rdf:Description rdf:about="https://data.vlaanderen.be/ns/openbaardomein">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/energiemanagementsysteem/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-14</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-14</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Energiemanagementsysteem</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/inname-openbaar-domein/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Inname openbaar domein</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/aim-object/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel AIM Object</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/slimmeraadpleegomgeving">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-02-08</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-02-08</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Slimme Raadpleegomgeving</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/implementatiemodel/cultureel-erfgoed-basisregistratie">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-10-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-10-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Implementatiemodel Basisregistratie Cultureel Erfgoed</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/bodem/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Bodem</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/proeven-metingen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Proeven en metingen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/zaalreservatie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Zaalreservatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/software-hardware/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Software en hardware</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/verlichtingsinstallatie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Verlichtingsinstallatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/fietstelinstallatie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Fietstelinstallatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/anpr-trajectcontrole/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel ANPR en trajectcontrole</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/gebieden">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Gebieden</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/financiele-rapportering">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-03-17</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-03-17</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Financiële Rapportering</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/gebouwenregister/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-08</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-08</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Gebouwenregister</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/verharding-wegfundering/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Verharding en wegfundering</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/omgevingsvergunning">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-11-07</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-11-07</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Omgevingsvergunning</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/elektrische-componenten/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Elektrische componenten</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/ventilatie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Ventilatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/logies-basis/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-05</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-05</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Toeristische Logies Basis</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/vastgoed">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-06-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-06-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Vastgoed</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/fietsinfrastructuur">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-12-17</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-12-17</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Fietsinfrastructuur</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/begraafplaatsenbeheer">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Begraafplaatsenbeheer</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/leermiddelen">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-08-20</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-08-20</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Leermiddelen en doelen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/besluitvorming">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-02-04</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-02-04</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Besluitvorming</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/perceel/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-06-18</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-06-18</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Perceel</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/onbegroeid-voorkomen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Onbegroeid Voorkomen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/dienstregeling-en-planning/tijdstabellen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteit: Dienstregeling en Planning Tijdstabellen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/cultureel-erfgoed-object">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Cultureel Erfgoed Object</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/generiek-basis/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2017-03-23</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2017-03-23</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Generiek basis</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/luidspreker-intercom/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Luidsprekers en intercom</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/hulp-dienstverlening-gedetineerden">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-18</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-18</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Hulp- en Dienstverlening aan Gedetineerden</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/leerprestatiecredential">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-20</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-20</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Leerprestatiecredential</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/loongegevens">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-16</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-16</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel loongegevens</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/FeitelijkeVerenigingen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-02-03</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-02-03</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Feitelijke Verenigingen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/tunnelevacuatie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Tunnelevacuatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/generieke-terugmeldfaciliteit/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Generieke Terugmeldfaciliteit</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/slimme-stadsdistributie">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-16</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-16</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel OSLO Slimme Stadsdistributie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/infrastructuurelementen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Infrastructuurelementen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bedrijventerrein/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-06-18</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-06-18</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Bedrijventerrein</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bestuurlijk-sanctieregister">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-06-23</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-06-23</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Bestuurlijk Sanctieregister</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel">
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/cultureel-erfgoed-object"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/ns/openbaardomein"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/grondwatermeetnet/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/begroeid-voorkomen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/subsidieregister/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/vegetatie-elementen"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/issue-tracking-voor-burgers-en-organisaties/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteitsbudget/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/leerinschrijfcredential/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/FeitelijkeVerenigingen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/waterkwaliteit"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/adresregister/"/>
+    <skos:topConceptOf rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:definition xml:lang="nl">Dit type document is een specificatie op basis van de termen uit een of meerdere vocabularia. Het geeft aan hoe data binnen een generiek applicatie domein dient gebruikt te worden.</skos:definition>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel</skos:prefLabel>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/ruimtelijke-indicatoren"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/wegenregister/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/watervoorkomen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/lokale-economie"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/verkeersborden/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/openbaar-domein"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/mandatendatabank/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/ldes"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/contactvoorkeuren/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/statistiek"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/generieke-terugmeldfaciliteit/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/kandidaatstandaard/2025-12-09/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/sonderingen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/loongegevens"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/generiek-basis/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/interpretaties/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/voorwaarden-dienstverlening/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit-trips-en-aanbod"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/openbare-nutsvoorzieningkasten/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/dienstregeling-en-planning/voertuigplanning/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/financiele-rapportering"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/infrastructuurelementen"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/observaties-en-metingen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/besluitvorming"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/watervoorkomen"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/grondboringen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/cultuurparticipatie"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/openbaar-domein/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/begraafplaatsenbeheer/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/erosiepoel"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/GEODCAT-AP-VL/kandidaatstandaard/2025-12-09/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/waterdelen"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/dossier"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/begraafplaatsenbeheer"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/vlaamse-codex/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/energiehuis"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/energiemanagementsysteem/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/overlijdensaangifte"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/gebieden"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/hulp-dienstverlening-gedetineerden"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/onbegroeid-voorkomen"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/vegetatie-elementen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/terreindelen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/dienst-transactiemodel/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/omgevingsvergunning"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/perceel/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/vervoersknooppunten"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/dienstverlening-aan-personen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-mobiliteit/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/ns/cultuurparticipatie"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/dienstencataloog/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/observaties/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/persoon-basis/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/infrastructuurelementen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/waterdelen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/sensoren-en-bemonstering/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/incentiveringsplatform"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/leerprestatiecredential"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/dienstregeling-en-planning/tijdstabellen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/onbegroeid-voorkomen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/begroeid-voorkomen"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/bedrijventerrein/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/DigitaleWatermeter"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/leermiddelen"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/begraafplaatsen"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/bestuurlijk-sanctieregister"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/rooilijnplannen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/thermografische-gebouwanalyse"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/bodem/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/publicatie-advertentie/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/organisatie-basis/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/gebouwenregister/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/slimme-stadsdistributie"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/fietsinfrastructuur"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/datakwaliteit"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/notificatie-basis/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/schuldbeheer"/>
+    <skos:narrower rdf:resource="https://purl.eu/doc/applicationprofile/mobility/passenger-transport-hubs/index_en.html"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/logies-basis/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/cultureel-erfgoed-event"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/terreindelen"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/dienstregeling-en-planning/stopplaatsen/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/verkeersmetingen"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/cultuur-en-jeugd/infrastructuur"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/slimmeraadpleegomgeving"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/vrachtwagenparkeren"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/inname-openbaar-domein/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/vastgoed"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/ruimtelijke-bereiken/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit-intelligente-toegang"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/applicatieprofiel/zaalreservatie/"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/begroeid-voorkomen">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Begroeid Voorkomen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/meten-in-vlaanderen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Meten in Vlaanderen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/interpretaties/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Bodem en Ondergrond Interpretaties</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/ruimtelijke-indicatoren">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-12-05</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-12-05</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Ruimtelijke Indicatoren</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/lokale-economie">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-01-17</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-01-17</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Lokale Economie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/thermografische-gebouwanalyse">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-22</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-22</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Thermografische Gebouwanalyse</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/notificatie-basis/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Notificatie Basis</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/terreindelen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Terreindelen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/eenvoudige-datatypes/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Eenvoudige datatypes</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/openbare-nutsvoorzieningkasten/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-28</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-28</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Openbare Nutsvoorzieningkasten</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/complexe-datatypes/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Complexe datatypes</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/watervoorkomen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Water voorkomen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://purl.eu/doc/applicationprofile/mobility/passenger-transport-hubs/index_en.html">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Passenger Transport Hubs</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/openbaar-domein/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Openbaar Domein</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/draagconstructies/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Draagconstructies</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/ecologische-maatregelen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Ecologische maatregelen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/signalisatie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Signalisatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/brandleiding/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Brandleiding</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://productencatalogus.data.vlaanderen.be/doc/implementatiemodel/ipdc-lpdc">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-04</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-04</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Vocabularium en implementatiemodel IPDC - LPDC</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Implementatiemodel IPDC - LPDC</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/organisatie-basis/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-03</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-03</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Organisatie Basis</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit-trips-en-aanbod">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteit: Trips en Aanbod</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/GEODCAT-AP-VL/kandidaatstandaard/2025-12-09/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-09-10</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-09-10</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel GeoDCAT-AP VL</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/waterdelen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Waterdelen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/verkeersborden/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-04-23</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Verkeersborden</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/dienstencataloog/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Dienstencataloog</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel">
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/kasten-cabines-behuizing/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/signalisatie/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/luidspreker-intercom/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/relaties/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/riolering/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/verharding-wegfundering/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/slagboom-doorsteek/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/brandleiding/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/union-datatypes/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/aim-object/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/draagconstructies/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/elektrische-componenten/"/>
+    <skos:topConceptOf rdf:resource="https://data.vlaanderen.be/id/conceptscheme/StandaardType"/>
+    <skos:definition xml:lang="nl"> Dit Type document is een specificatie op basis van de termen uit een of meerdere vocabularia. Het heeft aan hoe data binnen een specifiek applicatiedomein dient gebruikt te worden. Dikwijls, maar niet verplicht, implementeert een implementatie model de afspraken van een bijhorend applicatieprofiel</skos:definition>
+    <skos:prefLabel xml:lang="nl">Implementatiemodel</skos:prefLabel>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/zone-30/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/tunnelevacuatie/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/meten-in-vlaanderen/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/dynamische-borden/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/eenvoudige-datatypes/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/vegetatie/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/lijnvormige-elementen/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/anpr-trajectcontrole/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/verlichtingsinstallatie/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/complexe-datatypes/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/verkeersregelinstallatie/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/software-hardware/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/fietstelinstallatie/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/inbreuken-zwaar-vervoer/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/ventilatie/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/implementatiemodel/cultureel-erfgoed-basisregistratie"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/camerainstallatie/"/>
+    <skos:narrower rdf:resource="https://implementatie.data.vlaanderen.be/doc/implementatiemodel/kwaliteit-wegen-en-wegmarkeringen/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/hulpposten/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/ecologische-maatregelen/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/master/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/luchtkwaliteit/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/proeven-metingen/"/>
+    <skos:narrower rdf:resource="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/optisch-transport-netwerk/"/>
+    <skos:narrower rdf:resource="https://data.vlaanderen.be/doc/implementatiemodel/verkeersmeldingen/"/>
+    <skos:narrower rdf:resource="https://productencatalogus.data.vlaanderen.be/doc/implementatiemodel/ipdc-lpdc"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/contactvoorkeuren/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Contactvoorkeuren</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/master/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Master-implementatiemodel</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/vegetatie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Vegetatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/relaties/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Relaties</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/sonderingen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-08-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-08-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Sonderingen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/vervoersknooppunten">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Vervoersknooppunten</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/ns/cultuurparticipatie">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Vocabularium Cultuurparticipatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/observaties/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Bodem en Ondergrond Observaties</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/slagboom-doorsteek/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Slagbomen en doorsteken</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/watervoorkomen">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Watervoorkomen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/optisch-transport-netwerk/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Optisch transport netwerk</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/statistiek">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel OSLO Statistiek</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/waterdelen">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Waterdelen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit-intelligente-toegang">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-11-08</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-11-08</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteit: Intelligente Toegang</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/lijnvormige-elementen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Lijnvormige elementen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/inbreuken-zwaar-vervoer/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Inbreuken zwaar vervoer</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-20</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-20</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Besluit Publicatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/publicatie-advertentie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-11-09</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-11-09</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Publicatie-Advertentie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Bodem en Ondergrond</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/dynamische-borden/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Dynamische borden</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/voorwaarden-dienstverlening/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-07-11</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-07-11</dcterms:created>
+    <skos:prefLabel xml:lang="nl">OSLO Voorwaarden Dienstverlening</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/incentiveringsplatform">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-03-21</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-03-21</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Incentiveringsplatform</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/rooilijnplannen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Rooilijnplannen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/verkeersmetingen">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-12-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-12-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Verkeersmetingen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/terreindelen">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Terreindelen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/persoon-basis/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Persoon basis</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/hulpposten/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Hulpposten</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/openbaar-domein">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Basisprofiel Openbaar Domein</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/grondboringen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Grondboringen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/vrachtwagenparkeren">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-07-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Vrachtwagenparkeren</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/vegetatie-elementen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Vegetatie-elementen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/waterkwaliteit">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel OSLO Waterkwaliteit</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://implementatie.data.vlaanderen.be/doc/implementatiemodel/kwaliteit-wegen-en-wegmarkeringen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-07-24</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-07-24</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Implementatiemodel Kwaliteit Wegen en Wegmarkeringen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/vlaamse-codex/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Vlaamse Codex</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/issue-tracking-voor-burgers-en-organisaties/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Issue tracking voor burgers en organisaties</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/camerainstallatie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Camerainstallatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/cultureel-erfgoed-event">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Cultureel Erfgoed Event</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-04-22</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel metadata DCAT</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/union-datatypes/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Union datatypes</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/energiehuis">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-19</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-19</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Energiehuis</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/adresregister/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Adresregister</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel DCAT-AP VL 2.0</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/bodem-en-ondergrond/grondwatermeetnet/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-08-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-08-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Grondwatermeetnet</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteitsbudget/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-11-10</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-11-10</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteitsbudget</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/overlijdensaangifte">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-02-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-02-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Overlijdensaangifte</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/dienst-transactiemodel/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-02-07</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Dienst Transactiemodel</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/wegenregister/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-10</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Wegenregister</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/datakwaliteit">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-06-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel OSLO Datakwaliteit</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/onbegroeid-voorkomen">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Onbegroeid Voorkomen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/verkeersregelinstallatie/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Verkeersregelinstallatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/begroeid-voorkomen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Begroeid Voorkomen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/subsidieregister/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-01-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-01-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Besluit Subsidies</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/luchtkwaliteit/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Luchtkwaliteit</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/observaties-en-metingen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Observaties en Metingen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/schuldbeheer">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-15</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-15</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Schuldbeheer</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/infrastructuurelementen">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Infrastructuurelementen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/ruimtelijke-bereiken/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Ruimtelijke Bereiken</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/dienstregeling-en-planning/stopplaatsen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteit: Dienstregeling en Planning Stopplaatsen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/riolering/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Riolering</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/implementatiemodel/verkeersmeldingen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-04</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-06-04</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Implementatiemodel Verkeersmeldingen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/cultuurparticipatie">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Cultuurparticipatie</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/begraafplaatsen">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Begraafplaatsen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/vegetatie-elementen">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-09-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein 2.0.0 - Applicatieprofiel Vegetatie-elementen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/kandidaatstandaard/2025-12-09/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-09-10</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-09-10</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel DCAT-AP VL</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/begraafplaatsenbeheer/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-11-27</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Openbaar Domein - Applicatieprofiel Begraafplaatsenbeheer</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/zone-30/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Zone 30</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mobiliteit/dienstregeling-en-planning/voertuigplanning/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-21</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Mobiliteit: Dienstregeling en Planning Voertuigplanning</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/cultuur-en-jeugd/infrastructuur">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-03-21</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-03-21</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Cultuur- en Jeugdinfrastructuur</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/ldes">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-12-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel LDES</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/id/conceptscheme/StandaardType">
+    <skos:prefLabel xml:lang="nl">StandaardType</skos:prefLabel>
+    <skos:definition xml:lang="nl">Informatie over het type van de standaard</skos:definition>
+    <skos:hasTopConcept rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:title>OSLO Standaardenregister</dcterms:title>
+    <skos:hasTopConcept rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/mandatendatabank/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-20</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-07-20</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Mandatendatabank</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/sensoren-en-bemonstering/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-09-05</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Sensoren en Bemonstering</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DigitaleWatermeter">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-04-30</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-04-30</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Digitale Watermeter</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://wegenenverkeer.data.vlaanderen.be/doc/implementatiemodel/kasten-cabines-behuizing/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-12-02</dcterms:created>
+    <skos:prefLabel xml:lang="nl">wegenenverkeer implementatiemodel Kasten, cabines, behuizing</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/erosiepoel">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-23</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-07-23</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Erosiepoel</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/dossier">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-25</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-25</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Dossier</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-mobiliteit/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-06-01</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-06-01</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Besluit Mobiliteit</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/leerinschrijfcredential/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-04-08</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-04-08</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Leerinschrijfcredential</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/dienstverlening-aan-personen/">
+    <dcterms:type rdf:resource="https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-03-19</dcterms:modified>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-03-19</dcterms:created>
+    <skos:prefLabel xml:lang="nl">Applicatieprofiel Dienstverlening Aan Personen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/utility/thesaurus/update-oslo-datastandaarden.sh
+++ b/utility/thesaurus/update-oslo-datastandaarden.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+TEMP_FILE=update-oslo-datastandaarden-temp.rdf
+TARGET_FILE=../../resources/thesauri/theme/oslo-datastandaarden.rdf
+SPARQL_FILE=update-oslo-datastandaarden.sparql
+
+# execute sparql query to retrieve latest information
+sparql \
+  --graph https://data.vlaanderen.be/doc/concept/StandaardType/Applicatieprofiel.ttl \
+  --graph https://data.vlaanderen.be/doc/concept/StandaardType/Implementatiemodel.ttl \
+  --graph https://data.vlaanderen.be/id/conceptscheme/StandaardType.ttl \
+  --graph https://data.vlaanderen.be/standaarden \
+  --query $SPARQL_FILE --results RDF/XML > $TEMP_FILE
+# reformat to xml-abbrev to prevent nested xml output
+riot --output=RDF/XML-ABBREV $TEMP_FILE > $TARGET_FILE

--- a/utility/thesaurus/update-oslo-datastandaarden.sparql
+++ b/utility/thesaurus/update-oslo-datastandaarden.sparql
@@ -1,0 +1,47 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX dvcs: <https://data.vlaanderen.be/id/conceptscheme/>
+
+# execute on the graph
+# sparql --graph https://data.vlaanderen.be/doc/concept/StandaardType/Vocabularium --graph https://data.vlaanderen.be/doc/concept/StandaardType/TechnischeStandaard --graph https://data.vlaanderen.be/doc/concept/StandaardType/Applicatieprofiel --graph https://data.vlaanderen.be/id/conceptscheme/StandaardType --graph https://data.vlaanderen.be/standaarden --query test.sparql --results RDF/XML
+
+CONSTRUCT {
+  # conceptscheme
+  ?cs a skos:ConceptScheme .
+  ?cs skos:prefLabel ?cslabel .
+  ?cs skos:definition ?csdefinition .
+  ?cs skos:hasTopConcept ?c1 .
+  ?cs dcterms:title "OSLO Standaardenregister" .
+  # standaardtype
+  ?c1 a skos:Concept .
+  ?c1 skos:prefLabel ?c1label .
+  ?c1 skos:definition ?c1definition .
+  ?c1 skos:topConceptOf ?cs .
+  ?c1 skos:narrower ?c2 .
+  # standaard
+  ?c2 a skos:Concept .
+  ?c2 dcterms:type ?c1 .
+  ?c2 dcterms:modified ?c2modified.
+  ?c2 dcterms:created ?c2created.
+  ?c2 skos:prefLabel ?c2title .
+}
+WHERE {
+  # conceptscheme
+  ?cs rdf:type skos:ConceptScheme .
+  ?cs skos:prefLabel ?cslabel .
+  ?cs skos:definition ?csdefinition .
+  # standaardtype
+  ?c1 skos:topConceptOf ?cs .
+  ?c1 skos:prefLabel ?c1label .
+  ?c1 skos:definition ?c1definition .
+  # standaard
+  ?c2 dcterms:type ?c1 .
+  ?c2 dcterms:modified ?c2modified.
+  ?c2 dcterms:created ?c2created.
+  ?c2 dcterms:title ?c2title .
+  # filter on types
+  FILTER (?c1 in (<https://data.vlaanderen.be/id/concept/StandaardType/Implementatiemodel>,<https://data.vlaanderen.be/id/concept/StandaardType/Applicatieprofiel>))
+}

--- a/utility/thesaurus/update-oslo-datastandaarden.sparql
+++ b/utility/thesaurus/update-oslo-datastandaarden.sparql
@@ -5,9 +5,6 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX dvcs: <https://data.vlaanderen.be/id/conceptscheme/>
 
-# execute on the graph
-# sparql --graph https://data.vlaanderen.be/doc/concept/StandaardType/Vocabularium --graph https://data.vlaanderen.be/doc/concept/StandaardType/TechnischeStandaard --graph https://data.vlaanderen.be/doc/concept/StandaardType/Applicatieprofiel --graph https://data.vlaanderen.be/id/conceptscheme/StandaardType --graph https://data.vlaanderen.be/standaarden --query test.sparql --results RDF/XML
-
 CONSTRUCT {
   # conceptscheme
   ?cs a skos:ConceptScheme .
@@ -21,12 +18,15 @@ CONSTRUCT {
   ?c1 skos:definition ?c1definition .
   ?c1 skos:topConceptOf ?cs .
   ?c1 skos:narrower ?c2 .
+  ?c1 skos:inScheme ?cs .
   # standaard
   ?c2 a skos:Concept .
   ?c2 dcterms:type ?c1 .
   ?c2 dcterms:modified ?c2modified.
   ?c2 dcterms:created ?c2created.
   ?c2 skos:prefLabel ?c2title .
+  ?c2 skos:inScheme ?cs .
+  ?c2 skos:broader ?c1 .
 }
 WHERE {
   # conceptscheme


### PR DESCRIPTION
Adding a thesaurus that contains the VL OSLO datastandards. To be analysed how this can be integrated properly (additional support for dct:Standard based on a thesaurus? would a conditional configuration work in config-editor.xsl?). For now, an illustration is made on how to display a thesaurus based on the currently published graph of standards. The thesaurus is usable in ISO records where the skos-browser can be used to add keywords based on its values.

A utility function was added which can produce the relevant thesaurus, which could be become an automated action.

Producing RDF:
```bash
sparql --graph https://data.vlaanderen.be/doc/concept/StandaardType/Vocabularium --graph https://data.vlaanderen.be/doc/concept/StandaardType/TechnischeStandaard --graph https://data.vlaanderen.be/doc/concept/StandaardType/Applicatieprofiel --graph https://data.vlaanderen.be/id/conceptscheme/StandaardType --graph https://data.vlaanderen.be/standaarden --query test.sparql --results RDF/XML > /tmp/temp.xml
riot --output=RDF/XML-ABBREV /tmp/temp.xml > /tmp/standaarden.rdf
```

<img width="334" height="340" alt="image" src="https://github.com/user-attachments/assets/fc683aa0-da57-4f88-a96d-8d6197549bbe" />
