### PR TITLE
Bugfix: can now add catalog children and dcat:next

### DIFF
--- a/src/main/plugin/dcat-ap/process/sibling-add.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-add.xsl
@@ -38,7 +38,7 @@
                                                      else concat($nodeUrl, 'api/records/', $catalogUuid, '#',$record/uuid)"/>
   </xsl:function>
 
-  <xsl:template match="dcat:Catalog[$associationType = 'catalog']">
+  <xsl:template match="dcat:Catalog[$associationType = 'isComposedOf']">
     <!-- All associated records and itself (to avoid linking to existing) -->
     <xsl:variable name="associatedUuids"
                   select="ancestor::rdf:RDF//dcat:CatalogRecord/dct:identifier/text()"/>


### PR DESCRIPTION
The associationType `catalog` filter was probably supposed to be `isComposedOf`, in line with previous work that allowed adding a record to a Catalog. Applying this fix, it's possible to both add 1) dcat:next and 2) catalog children. Before the fix, only 1) worked.