### PR TITLE
Duplicate multilingual elements due to missing language thesaurus

### DIFF
--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-dataset.xml
@@ -22,6 +22,7 @@
           <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
             <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
             <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
           </skos:Concept>
         </dct:language>
       </dcat:CatalogRecord>


### PR DESCRIPTION
Since commit https://github.com/metadata101/dcat-ap/commit/fb777bd682acb92b7ab42066563bd31c91231dce, the dcat-ap-vl2 template did not correctly behave in the editor. `inScheme` was missing for the language definition. The following behaviour broke the record:

- start a new record based on the template
- navigate to the Record tab (not sure why this specifically needs to happen, does it regenerate the language definition @fxprunayre ?)
- observe
  - all multilingual `nl` fields being duplicated upon each save
  - a new language definition being added that does contain `inScheme`

For now I'll fix the template, but we could make the multilingual behaviour a bit more robust.

<img width="1472" height="980" alt="image" src="https://github.com/user-attachments/assets/f8ec5f44-6d16-418a-b55a-af826bf6b881" />
<img width="869" height="995" alt="image" src="https://github.com/user-attachments/assets/10415885-f986-4a74-b003-06aa96c03f2b" />