### PR TITLE
Duplicate multilingual elements due to missing language thesaurus - remainder

### DIFF
--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-service.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-service.xml
@@ -22,6 +22,7 @@
           <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
             <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
             <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
           </skos:Concept>
         </dct:language>
       </dcat:CatalogRecord>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-dataset.xml
@@ -22,6 +22,7 @@
           <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
             <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
             <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
           </skos:Concept>
         </dct:language>
       </dcat:CatalogRecord>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-service.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-service.xml
@@ -22,6 +22,7 @@
           <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
             <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
             <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
           </skos:Concept>
         </dct:language>
       </dcat:CatalogRecord>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
@@ -21,6 +21,7 @@
           <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
             <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
             <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
           </skos:Concept>
         </dct:language>
       </dcat:CatalogRecord>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
@@ -21,6 +21,7 @@
           <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
             <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
             <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
           </skos:Concept>
         </dct:language>
       </dcat:CatalogRecord>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat3-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat3-dataset.xml
@@ -21,6 +21,7 @@
           <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
             <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
             <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
           </skos:Concept>
         </dct:language>
       </dcat:CatalogRecord>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat3-service.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat3-service.xml
@@ -21,6 +21,7 @@
           <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
             <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
             <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
           </skos:Concept>
         </dct:language>
       </dcat:CatalogRecord>


### PR DESCRIPTION
Applying previous fix (https://github.com/metadata101/dcat-ap/pull/132) to the remaining templates.

