### PR TITLE
Mobility dcat:theme validation

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -772,6 +772,14 @@
             </template>
           </action>
 
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme"
+                 or="theme"
+                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:keyword"
+                 or="keyword"
+                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
+
           <section xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:publisher"/>
           <action type="add" or="publisher" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
                        if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:publisher) = 0">
@@ -795,10 +803,6 @@
             </template>
           </action>
 
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:keyword"
-                 or="keyword"
-                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
-
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:identifier"
                  or="identifier"
                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
@@ -818,6 +822,7 @@
               </snippet>
             </template>
           </action>-->
+
         </section>
 
         <section name="vl-section-metadatadcat"
@@ -860,10 +865,6 @@
               </snippet>
             </template>
           </action>
-
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme"
-                 or="theme"
-                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
 
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme"
                  if="$p2 = ('DCAT-AP-VL', 'metadata-dcat')"

--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-mobility-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-mobility-rec.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>Mobiliteit - Aanbevolen</schematron.title>
+  <recommended.dcat_theme_tran.title>DCAT thema</recommended.dcat_theme_tran.title>
+  <recommended.dcat_theme_tran.report>Het Transport thema werd gebruikt</recommended.dcat_theme_tran.report>
+  <recommended.dcat_theme_tran.assert>In de meeste gevallen wordt aangenomen dat de relevante waarde voor het thema van dataportalen in het domein Mobiliteit "Transport" is.</recommended.dcat_theme_tran.assert>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-mobility.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-mobility.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>Mobility - Mandatory</schematron.title>
-  <required.dcat_theme_tran.title>DCAT theme</required.dcat_theme_tran.title>
-  <required.dcat_theme_tran.report>DCAT theme is set to Transport</required.dcat_theme_tran.report>
-  <required.dcat_theme_tran.assert>In most cases, it is assumed that the relevant value for mobility data portals theme is Transport. Check the DCAT theme.</required.dcat_theme_tran.assert>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-mobility-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-mobility-rec.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>Mobility - Recommended</schematron.title>
+  <recommended.dcat_theme_tran.title>DCAT theme</recommended.dcat_theme_tran.title>
+  <recommended.dcat_theme_tran.report>The Transport theme was used</recommended.dcat_theme_tran.report>
+  <recommended.dcat_theme_tran.assert>In most cases, it is assumed that the relevant value for mobility data portals theme is Transport. Check the DCAT theme.</recommended.dcat_theme_tran.assert>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-mobility.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-mobility.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>Mobility - Mandatory</schematron.title>
-  <required.dcat_theme_tran.title>DCAT theme</required.dcat_theme_tran.title>
-  <required.dcat_theme_tran.report>DCAT theme is set to Transport</required.dcat_theme_tran.report>
-  <required.dcat_theme_tran.assert>In most cases, it is assumed that the relevant value for mobility data portals theme is Transport. Check the DCAT theme.</required.dcat_theme_tran.assert>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-mobility-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-mobility-rec.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>Mobility - Recommandé</schematron.title>
+  <recommended.dcat_theme_tran.title>DCAT thème</recommended.dcat_theme_tran.title>
+  <recommended.dcat_theme_tran.report>Le thème Transport a été utilisé</recommended.dcat_theme_tran.report>
+  <recommended.dcat_theme_tran.assert>Dans la plupart des cas, on considère que la valeur pertinente pour le sujet des portails de données dans le domaine de la mobilité est «Transport».</recommended.dcat_theme_tran.assert>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-mobility.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-mobility.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>Mobility - Mandatory</schematron.title>
-  <required.dcat_theme_tran.title>DCAT theme</required.dcat_theme_tran.title>
-  <required.dcat_theme_tran.report>DCAT theme is set to Transport</required.dcat_theme_tran.report>
-  <required.dcat_theme_tran.assert>In most cases, it is assumed that the relevant value for mobility data portals theme is Transport. Check the DCAT theme.</required.dcat_theme_tran.assert>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-mobility-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-mobility-rec.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>Mobility - Empfohlen</schematron.title>
+  <recommended.dcat_theme_tran.title>DCAT Thema</recommended.dcat_theme_tran.title>
+  <recommended.dcat_theme_tran.report>Das Thema Transport wurde verwendet</recommended.dcat_theme_tran.report>
+  <recommended.dcat_theme_tran.assert>In den meisten Fällen wird davon ausgegangen, dass der relevante Wert für das Thema Datenportale im Mobilitätsbereich „Transport“ lautet.</recommended.dcat_theme_tran.assert>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-mobility.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-mobility.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
   <schematron.title>Mobility - Mandatory</schematron.title>
-  <required.dcat_theme_tran.title>DCAT theme</required.dcat_theme_tran.title>
-  <required.dcat_theme_tran.report>DCAT theme is set to Transport</required.dcat_theme_tran.report>
-  <required.dcat_theme_tran.assert>In most cases, it is assumed that the relevant value for mobility data portals theme is Transport. Check the DCAT theme.</required.dcat_theme_tran.assert>
 </strings>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-mobility-rec.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-mobility-rec.sch
@@ -24,4 +24,13 @@
   <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
 
   <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
+
+  <sch:pattern id="recommended_theme">
+    <sch:title>$loc/strings/recommended.dcat_theme_tran.title</sch:title>
+    <sch:rule context="//dcat:Dataset|//dcat:DataService">
+      <sch:let name="tranDcatTheme" value="dcat:theme[skos:Concept/@rdf:about='http://vocab.belgif.be/auth/datatheme/TRAN' or skos:Concept/@rdf:about='http://publications.europa.eu/resource/authority/data-theme/TRAN']"/>
+      <sch:assert test="count($tranDcatTheme) = 1">$loc/strings/recommended.dcat_theme_tran.assert</sch:assert>
+      <sch:report test="count($tranDcatTheme) = 1">$loc/strings/recommended.dcat_theme_tran.report</sch:report>
+    </sch:rule>
+  </sch:pattern>
 </sch:schema>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-mobility.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-mobility.sch
@@ -25,12 +25,4 @@
 
   <sch:title xmlns="http://www.w3.org/2001/XMLSchema">{$loc/strings/schematron.title}</sch:title>
 
-  <sch:pattern id="required_theme">
-    <sch:title>$loc/strings/required.dcat_theme_tran.title</sch:title>
-    <sch:rule context="//dcat:Dataset|//dcat:DataService">
-      <sch:let name="tranDcatTheme" value="dcat:theme[skos:Concept/@rdf:about='http://vocab.belgif.be/auth/datatheme/TRAN']"/>
-      <sch:assert test="count($tranDcatTheme) = 1">$loc/strings/required.dcat_theme_tran.assert</sch:assert>
-      <sch:report test="count($tranDcatTheme) = 1">$loc/strings/required.dcat_theme_tran.report</sch:report>
-    </sch:rule>
-  </sch:pattern>
 </sch:schema>


### PR DESCRIPTION
This PR fixes the following issues:
- `dcat:theme` could not be set in the editor without conforming to dcat-ap-vl, e.g., only conforming to mobility would not allow you to set the theme
- the mandatory check on dcat:theme=Transport for mobility was weakened to a recommendation, aligning with the documentation
 
<img width="1087" height="216" alt="image" src="https://github.com/user-attachments/assets/8e90de68-d5be-4412-a587-59a3d898784c" />
