### PR TITLE
Fixed empty accrualPeriodicity after edit

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -944,7 +944,7 @@
               <snippet>
                 <dct:accrualPeriodicity>
                   <skos:Concept rdf:about="">
-                    <skos:prefLabel/>
+                    <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/frequency"/>
                   </skos:Concept>
                 </dct:accrualPeriodicity>
               </snippet>


### PR DESCRIPTION
After clicking "+ accrualPeriodicity" in the editor, a spurious empty element was created. After selecting a value for the periocity, one would end up with two periodicities, which does not validate correctly.

Including `inScheme` in the editor snippet fixes this behaviour: the empty element is now correctly coupled to the editor component.

<img width="1063" height="271" alt="image" src="https://github.com/user-attachments/assets/d7eb637f-e15d-44b4-84ef-a0dbee6c8f33" />
