### PR TITLE
Added mandatory validation on dataservice

### DIFF
--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap.xml
@@ -4,7 +4,24 @@
   <required.language.title>Taal van een Catalogus Record.</required.language.title>
   <required.language.assert>Het Catalogus Record definieert geen taal.</required.language.assert>
   <required.language.report>Het Catalogus Record definieert ten minste één taal.</required.language.report>
+
   <required.catalogtitle.title>Titel van een Catalogus.</required.catalogtitle.title>
   <required.catalogtitle.assert>De Catalogus heeft geen titel.</required.catalogtitle.assert>
   <required.catalogtitle.report>De Catalogus heeft op zijn minst één dct:title.</required.catalogtitle.report>
+
+  <required.dataservicetitle.count.title>Een DataService heeft steeds minstens 1 titel.</required.dataservicetitle.count.title>
+  <required.dataservicetitle.count.assert>Titel niet opgegeven (dct:title).</required.dataservicetitle.count.assert>
+  <required.dataservicetitle.count.report>Titel werd opgegeven (dct:title).</required.dataservicetitle.count.report>
+
+  <required.dataservicetitle.uniquelang.title>Een DataService heeft maximaal één titel per taal.</required.dataservicetitle.uniquelang.title>
+  <required.dataservicetitle.uniquelang.assert>Meerdere titels gevonden voor eenzelfde taal.</required.dataservicetitle.uniquelang.assert>
+  <required.dataservicetitle.uniquelang.report>Uniciteit van titel is in orde.</required.dataservicetitle.uniquelang.report>
+
+  <required.dataservicetitle.validstring.title>Een DataService titel moet tekst bevatten.</required.dataservicetitle.validstring.title>
+  <required.dataservicetitle.validstring.assert>Een lege titel werd gevonden.</required.dataservicetitle.validstring.assert>
+  <required.dataservicetitle.validstring.report>Titel bevat tekst.</required.dataservicetitle.validstring.report>
+
+  <required.dataserviceendpointURL.validstring.title>De endpointURL van een DataService moet een IRI bevatten.</required.dataserviceendpointURL.validstring.title>
+  <required.dataserviceendpointURL.validstring.assert>De opgegeven endpointURL is geen geldige IRI.</required.dataserviceendpointURL.validstring.assert>
+  <required.dataserviceendpointURL.validstring.report>De endpointURL is een geldige IRI.</required.dataserviceendpointURL.validstring.report>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap.xml
@@ -4,7 +4,24 @@
   <required.language.title>Language of a CatalogRecord.</required.language.title>
   <required.language.assert>The CatalogRecord does not define a language.</required.language.assert>
   <required.language.report>The CatalogRecord has at least one dct:language.</required.language.report>
+
   <required.catalogtitle.title>Title of a Catalog.</required.catalogtitle.title>
   <required.catalogtitle.assert>The Catalog does not have a title.</required.catalogtitle.assert>
   <required.catalogtitle.report>The Catalog has at least one dct:title.</required.catalogtitle.report>
+
+  <required.dataservicetitle.count.title>A DataService always has at least one title.</required.dataservicetitle.count.title>
+  <required.dataservicetitle.count.assert>Title not provided (dct:title).</required.dataservicetitle.count.assert>
+  <required.dataservicetitle.count.report>Title was provided (dct:title).</required.dataservicetitle.count.report>
+
+  <required.dataservicetitle.uniquelang.title>A DataService has at most one title per language.</required.dataservicetitle.uniquelang.title>
+  <required.dataservicetitle.uniquelang.assert>Multiple titles found for the same language.</required.dataservicetitle.uniquelang.assert>
+  <required.dataservicetitle.uniquelang.report>Title uniqueness is correct.</required.dataservicetitle.uniquelang.report>
+
+  <required.dataservicetitle.validstring.title>A DataService title must contain text.</required.dataservicetitle.validstring.title>
+  <required.dataservicetitle.validstring.assert>An empty title was found.</required.dataservicetitle.validstring.assert>
+  <required.dataservicetitle.validstring.report>The title contains text.</required.dataservicetitle.validstring.report>
+
+  <required.dataserviceendpointURL.validstring.title>The endpointURL of a DataService must contain an IRI.</required.dataserviceendpointURL.validstring.title>
+  <required.dataserviceendpointURL.validstring.assert>The provided endpointURL is not a valid IRI.</required.dataserviceendpointURL.validstring.assert>
+  <required.dataserviceendpointURL.validstring.report>The endpointURL is a valid IRI.</required.dataserviceendpointURL.validstring.report>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap.xml
@@ -4,7 +4,24 @@
   <required.language.title>Langue d'une donnée catalogue.</required.language.title>
   <required.language.assert>L'enregistrement du catalogue ne définit pas de langue.</required.language.assert>
   <required.language.report>L'enregistrement du catalogue définit au moins une langue.</required.language.report>
+
   <required.catalogtitle.title>Titre d'un catalogue.</required.catalogtitle.title>
   <required.catalogtitle.assert>Le catalogue n'a pas de titre.</required.catalogtitle.assert>
   <required.catalogtitle.report>Le catalogue contient au moins un dct:title.</required.catalogtitle.report>
+
+  <required.dataservicetitle.count.title>Un DataService a toujours au moins un titre.</required.dataservicetitle.count.title>
+  <required.dataservicetitle.count.assert>Titre non fourni (dct:title).</required.dataservicetitle.count.assert>
+  <required.dataservicetitle.count.report>Un titre a été fourni (dct:title).</required.dataservicetitle.count.report>
+
+  <required.dataservicetitle.uniquelang.title>Un DataService a au maximum un titre par langue.</required.dataservicetitle.uniquelang.title>
+  <required.dataservicetitle.uniquelang.assert>Plusieurs titres trouvés pour une même langue.</required.dataservicetitle.uniquelang.assert>
+  <required.dataservicetitle.uniquelang.report>L’unicité du titre est correcte.</required.dataservicetitle.uniquelang.report>
+
+  <required.dataservicetitle.validstring.title>Un titre de DataService doit contenir du texte.</required.dataservicetitle.validstring.title>
+  <required.dataservicetitle.validstring.assert>Un titre vide a été trouvé.</required.dataservicetitle.validstring.assert>
+  <required.dataservicetitle.validstring.report>Le titre contient du texte.</required.dataservicetitle.validstring.report>
+
+  <required.dataserviceendpointURL.validstring.title>L’endpointURL d’un DataService doit contenir un IRI.</required.dataserviceendpointURL.validstring.title>
+  <required.dataserviceendpointURL.validstring.assert>L’endpointURL fournie n’est pas un IRI valide.</required.dataserviceendpointURL.validstring.assert>
+  <required.dataserviceendpointURL.validstring.report>L’endpointURL est un IRI valide.</required.dataserviceendpointURL.validstring.report>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap.xml
@@ -4,7 +4,24 @@
   <required.language.title>Sprache eines Katalogeintrags.</required.language.title>
   <required.language.assert>Der Katalogdatensatz definiert keine Sprache.</required.language.assert>
   <required.language.report>Der Katalogdatensatz definiert mindestens eine Sprache.</required.language.report>
+
   <required.catalogtitle.title>Titel eines Katalogs.</required.catalogtitle.title>
   <required.catalogtitle.assert>Der Katalog hat keinen Titel.</required.catalogtitle.assert>
   <required.catalogtitle.report>Der Katalog hat mindestens einen dct:title.</required.catalogtitle.report>
+
+  <required.dataservicetitle.count.title>Ein DataService hat immer mindestens einen Titel.</required.dataservicetitle.count.title>
+  <required.dataservicetitle.count.assert>Titel nicht angegeben (dct:title).</required.dataservicetitle.count.assert>
+  <required.dataservicetitle.count.report>Titel wurde angegeben (dct:title).</required.dataservicetitle.count.report>
+
+  <required.dataservicetitle.uniquelang.title>Ein DataService hat höchstens einen Titel pro Sprache.</required.dataservicetitle.uniquelang.title>
+  <required.dataservicetitle.uniquelang.assert>Mehrere Titel für dieselbe Sprache gefunden.</required.dataservicetitle.uniquelang.assert>
+  <required.dataservicetitle.uniquelang.report>Die Einzigartigkeit des Titels ist in Ordnung.</required.dataservicetitle.uniquelang.report>
+
+  <required.dataservicetitle.validstring.title>Ein DataService-Titel muss Text enthalten.</required.dataservicetitle.validstring.title>
+  <required.dataservicetitle.validstring.assert>Ein leerer Titel wurde gefunden.</required.dataservicetitle.validstring.assert>
+  <required.dataservicetitle.validstring.report>Der Titel enthält Text.</required.dataservicetitle.validstring.report>
+
+  <required.dataserviceendpointURL.validstring.title>Die EndpointURL eines DataService muss eine IRI enthalten.</required.dataserviceendpointURL.validstring.title>
+  <required.dataserviceendpointURL.validstring.assert>Die angegebene EndpointURL ist keine gültige IRI.</required.dataserviceendpointURL.validstring.assert>
+  <required.dataserviceendpointURL.validstring.report>Die EndpointURL ist eine gültige IRI.</required.dataserviceendpointURL.validstring.report>
 </strings>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap.sch
@@ -43,5 +43,42 @@
     </sch:rule>
   </sch:pattern>
 
+  <!-- DataService title should be present and have valid content. -->
+  <sch:pattern>
+    <sch:title>$loc/strings/required.dataservicetitle.count.title</sch:title>
+    <sch:rule context="//dcat:DataService">
+      <sch:let name="validMin" value="count(dct:title) &gt;= 1"/>
+      <sch:assert test="$validMin">$loc/strings/required.dataservicetitle.count.assert</sch:assert>
+      <sch:report test="$validMin">$loc/strings/required.dataservicetitle.count.report</sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern>
+    <sch:title>$loc/strings/required.dataservicetitle.uniquelang.title</sch:title>
+    <sch:rule context="//dcat:DataService/dct:title">
+      <sch:let name="current" value="."/>
+      <sch:let name="isUniqueLang" value="count(preceding-sibling::dct:title[string() = string($current) and @xml:lang = $current/@xml:lang]) = 0"/>
+      <sch:assert test="$isUniqueLang">$loc/strings/required.dataservicetitle.uniquelang.assert</sch:assert>
+      <sch:report test="$isUniqueLang">$loc/strings/required.dataservicetitle.uniquelang.report</sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern>
+    <sch:title>$loc/strings/required.dataservicetitle.validstring.title</sch:title>
+    <sch:rule context="//dcat:DataService/dct:title">
+      <sch:let name="isLiteral" value="normalize-space(.) != ''"/>
+      <sch:let name="hasLang" value="normalize-space(@xml:lang) != ''"/>
+      <sch:assert test="$isLiteral and $hasLang">$loc/strings/required.dataservicetitle.validstring.assert</sch:assert>
+      <sch:report test="$isLiteral and $hasLang">$loc/strings/required.dataservicetitle.validstring.report</sch:report>
+    </sch:rule>
+  </sch:pattern>
 
+  <!-- DataService should have a valid endpointURL. -->
+  <sch:pattern>
+    <sch:title>$loc/strings/required.dataserviceendpointURL.validstring.title</sch:title>
+    <sch:rule context="//dcat:DataService/dcat:endpointURL">
+      <sch:let name="resource" value="@rdf:resource"/>
+      <sch:let name="validClass" value="matches($resource, '^\w+:(/?/?)[^\s]+$')"/>
+      <sch:assert test="$validClass">$loc/strings/required.dataserviceendpointURL.validstring.assert</sch:assert>
+      <sch:report test="$validClass">$loc/strings/required.dataserviceendpointURL.validstring.report</sch:report>
+    </sch:rule>
+  </sch:pattern>
 </sch:schema>


### PR DESCRIPTION
Previously, not much testing was done on DataServices. Validation still has to be implemented correctly (based on the SHACL files provided), so for now this PR already tests for the absolute minimum for DataServices:

- title
- endpointURL

To be replaced in the future by a more solid solution.