### PR TITLE
Improved labels in the mobility view

### DIFF
--- a/resources/thesauri/theme/mobility-georeferencing-method.rdf
+++ b/resources/thesauri/theme/mobility-georeferencing-method.rdf
@@ -46,9 +46,10 @@
     <skos:inScheme
       xmlns:terms="http://purl.org/dc/terms/"
                    rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">ALERT-C
-    </skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">ALERT-C (LCL)</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">ALERT-C (LCL)</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">ALERT-C (LCL)</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">ALERT-C (LCL)</skos:prefLabel>
     <skos:topConceptOf
       xmlns:terms="http://purl.org/dc/terms/"
                        rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
@@ -58,9 +59,10 @@
     <skos:inScheme
       xmlns:terms="http://purl.org/dc/terms/"
                    rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Geocoordinates
-    </skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Geocoordinates</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Geocoördinaten</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Coordonnées géographiques</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Geokoördinaten</skos:prefLabel>
     <skos:topConceptOf
       xmlns:terms="http://purl.org/dc/terms/"
                        rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
@@ -70,9 +72,10 @@
     <skos:inScheme
       xmlns:terms="http://purl.org/dc/terms/"
                    rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">GML
-    </skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">GML</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">GML</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">GML</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">GML</skos:prefLabel>
     <skos:topConceptOf
       xmlns:terms="http://purl.org/dc/terms/"
                        rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
@@ -82,9 +85,10 @@
     <skos:inScheme
       xmlns:terms="http://purl.org/dc/terms/"
                    rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">ISO 19148
-    </skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">ISO 19148</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">ISO 19148</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">ISO 19148</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">ISO 19148</skos:prefLabel>
     <skos:topConceptOf
       xmlns:terms="http://purl.org/dc/terms/"
                        rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
@@ -94,9 +98,10 @@
     <skos:inScheme
       xmlns:terms="http://purl.org/dc/terms/"
                    rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">OpenLR
-    </skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">OpenLR</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">OpenLR</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">OpenLR</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">OpenLR</skos:prefLabel>
     <skos:topConceptOf
       xmlns:terms="http://purl.org/dc/terms/"
                        rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
@@ -106,9 +111,10 @@
     <skos:inScheme
       xmlns:terms="http://purl.org/dc/terms/"
                    rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Other
-    </skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Other</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Andere</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Autre</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Anderen</skos:prefLabel>
     <skos:topConceptOf
       xmlns:terms="http://purl.org/dc/terms/"
                        rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
@@ -118,9 +124,10 @@
     <skos:inScheme
       xmlns:terms="http://purl.org/dc/terms/"
                    rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">TPEG-LOC
-    </skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">TPEG-LOC</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">TPEG-LOC</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">TPEG-LOC</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">TPEG-LOC</skos:prefLabel>
     <skos:topConceptOf
       xmlns:terms="http://purl.org/dc/terms/"
       rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>

--- a/resources/thesauri/theme/mobility-network-coverage.rdf
+++ b/resources/thesauri/theme/mobility-network-coverage.rdf
@@ -1,204 +1,125 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <skos:ConceptScheme xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                      rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage">
-    <terms:creator xmlns:terms="http://purl.org/dc/terms/"
-                   xml:lang="en">Mario Scrocca (Cefriel)
-    </terms:creator>
-    <terms:creator xmlns:terms="http://purl.org/dc/terms/"
-                   xml:lang="en">Peter Lubrich (BASt)
-    </terms:creator>
-    <terms:description xmlns:terms="http://purl.org/dc/terms/"
-                       xml:lang="en">Controlled vocabulary for the transport network coverage of a dataset.
-    </terms:description>
-    <terms:license xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-    <terms:publisher xmlns:terms="http://purl.org/dc/terms/"
-                     xml:lang="en">NAPCORE SubWG4.4
-    </terms:publisher>
-    <terms:title xmlns:terms="http://purl.org/dc/terms/"
-                 xml:lang="en">Network Coverage
-    </terms:title>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/air-network"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/metro-subway-tram-or-light-rail-network"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/motorways"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/other"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/other-public-transport-network"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/rail-network"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/regional-roads"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/state-roads-or-federal-roads"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/ten-network"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/tern-network"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/urban-and-local-roads"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/waterways"/>
+  <skos:ConceptScheme xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage">
+    <terms:creator xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Mario Scrocca (Cefriel)</terms:creator>
+    <terms:creator xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Peter Lubrich (BASt)</terms:creator>
+    <terms:description xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Controlled vocabulary for the transport network coverage of a dataset.</terms:description>
+    <terms:description xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Gecontroleerd vocabularium voor de dekking van het transportnetwerk in een dataset.</terms:description>
+    <terms:description xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Vocabulaire contrôlé pour la couverture du réseau de transport d'un ensemble de données.</terms:description>
+    <terms:description xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Kontrolliertes Vokabular für die Abdeckung des Transportnetzes in einem Datensatz.</terms:description>
+    <terms:license xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+    <terms:publisher xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">NAPCORE SubWG4.4</terms:publisher>
+    <terms:title xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Network Coverage</terms:title>
+    <terms:title xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Netwerkdekking</terms:title>
+    <terms:title xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Couverture du réseau</terms:title>
+    <terms:title xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Netzabdeckung</terms:title>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/air-network"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/metro-subway-tram-or-light-rail-network"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/motorways"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/other"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/other-public-transport-network"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/rail-network"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/regional-roads"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/state-roads-or-federal-roads"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/ten-network"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/tern-network"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/urban-and-local-roads"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/waterways"/>
   </skos:ConceptScheme>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/air-network">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Air network
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/air-network">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">Air network</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Réseau aérien</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Luchtnetwerk</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Luftnetz</skos:prefLabel>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/metro-subway-tram-or-light-rail-network">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Metro, subway, tram or light-rail network
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/metro-subway-tram-or-light-rail-network">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">Metro, subway, tram or light-rail network</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Réseau de métro, tram ou ferroviaire léger</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Metro, tram of light-rail netwerk</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">U-Bahn-, Straßenbahn- oder Stadtbahnnetz</skos:prefLabel>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/motorways">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Motorways
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/motorways">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">Motorways</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Autoroutes</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Autosnelwegen </skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Autobahnen </skos:prefLabel>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/other">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Other
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/other">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">Other</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Autre</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Andere</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Andere</skos:prefLabel>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/other-public-transport-network">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Other public transport network
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/other-public-transport-network">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">Other public transport network</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Autre réseau de transport public</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Andere openbaar vervoersnetwerk</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Andere öffentliche Verkehrsnetz</skos:prefLabel>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/rail-network">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Rail network
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/rail-network">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">Rail network</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Réseau ferroviaire</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Spoorwegnet</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Schienennetz</skos:prefLabel>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/regional-roads">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Regional roads
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/regional-roads">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">Regional roads</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Routes régionales</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Regionale wegen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Regionalstraßen</skos:prefLabel>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/state-roads-or-federal-roads">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">State roads or federal roads
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/state-roads-or-federal-roads">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">National roads</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Routes nationales</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Nationale wegen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Nationalstraßen</skos:prefLabel>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/ten-network">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">TEN Network
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/ten-network">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">Trans-European Transport Network (TEN-T)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Réseau transeuropéen de transport (TEN-T)</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Trans-Europese transport Netwerk (TEN-T)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Transeuropäische Verkehrsnetz (TEN-T)</skos:prefLabel>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/tern-network">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">TERN Network
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/tern-network">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">Trans-European Road Network (TERN)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Réseau routier transeuropéen (TERN)</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Trans-Europese wegennet (TERN)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Transeuropäischen Straßennetz (TERN)</skos:prefLabel>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/urban-and-local-roads">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Urban and local roads
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/urban-and-local-roads">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">Urban and local roads</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Routes urbaines et locales</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Stedelijke en lokale wegen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Städtische und lokale Straßen</skos:prefLabel>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/waterways">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Waterways
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-      rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/network-coverage/waterways">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
+    <skos:prefLabel xml:lang="en">Waterways</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Voies navigables</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Waterwegen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Wasserstraßen</skos:prefLabel>
   </skos:Concept>
 </rdf:RDF>
-

--- a/resources/thesauri/theme/mobility-theme.rdf
+++ b/resources/thesauri/theme/mobility-theme.rdf
@@ -1,2616 +1,1323 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <skos:ConceptScheme xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                      rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme">
-    <terms:creator xmlns:terms="http://purl.org/dc/terms/"
-                   xml:lang="en">Mario Scrocca (Cefriel)
-    </terms:creator>
-    <terms:creator xmlns:terms="http://purl.org/dc/terms/"
-                   xml:lang="en">Peter Lubrich (BASt)
-    </terms:creator>
-    <terms:description xmlns:terms="http://purl.org/dc/terms/"
-                       xml:lang="en">Controlled vocabulary for the classification of the theme for a mobility dataset.
-    </terms:description>
-    <terms:license xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-    <terms:publisher xmlns:terms="http://purl.org/dc/terms/"
-                     xml:lang="en">NAPCORE SubWG4.4
-    </terms:publisher>
-    <terms:title xmlns:terms="http://purl.org/dc/terms/"
-                 xml:lang="en">Mobility Theme
-    </terms:title>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+  <skos:ConceptScheme xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme">
+    <terms:creator xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Mario Scrocca (Cefriel)</terms:creator>
+    <terms:creator xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Peter Lubrich (BASt)</terms:creator>
+    <terms:description xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Controlled vocabulary for the classification of the theme for a mobility dataset.</terms:description>
+    <terms:license xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+    <terms:publisher xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">NAPCORE SubWG4.4</terms:publisher>
+    <terms:title xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Mobility Theme</terms:title>
+    <terms:title xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Mobiliteitsthema</terms:title>
+    <terms:title xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Thème de la mobilité</terms:title>
+    <terms:title xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Thema Mobilität</terms:title>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
   </skos:ConceptScheme>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/accesibility-information-for-vehicles">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Accesibility information for vehicles
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/accidents-and-incidents">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-events-and-conditions"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Accidents and incidents
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/address-identifiers">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Address identifiers
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/air-and-space-travel">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Air and space travel
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/applicable-road-user-charges-and-payment-methods">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Applicable road user charges and payment methods
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-charging-points-for-electric-vehicles">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Availability of charging points for electric vehicles
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-delivery-areas">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-and-logistics"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Availability of delivery areas
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-filling-stations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Availability of filling stations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-commercial-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Basic commercial conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-common-standard-fares">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Basic common standard fares
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-availability">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Bike-hiring Availability
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-stations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Bike-hiring Stations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-parking-locations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Bike-parking locations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-availability">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Bike sharing Availability
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-locations-and-stations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Bike-sharing Locations and stations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-access-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Bridge access conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-closures-and-access-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Bridge closures and access conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-availability">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Car-hiring Availability
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-stations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Car-hiring Stations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-availability">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Car parking availability
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-locations-and-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Car parking locations and conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-availability">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Car-sharing Availability
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-locations-and-stations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Car-sharing Locations and stations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/common-fare-products">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Common fare products
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/connection-links">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Connection links
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/current-travel-times">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Current travel times
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/cycle-network-data">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-closures-diversions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-detailed-attributes"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-geometry-and-lane-character"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Cycle network data
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/air-and-space-travel"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/cycle-network-data"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-and-logistics"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-data"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-events-and-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-work-information"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/waterways-and-water-bodies"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Data content category
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/accesibility-information-for-vehicles"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/accidents-and-incidents"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/address-identifiers"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/applicable-road-user-charges-and-payment-methods"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-charging-points-for-electric-vehicles"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-delivery-areas"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-filling-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-commercial-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-common-standard-fares"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-parking-locations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-locations-and-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-access-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-closures-and-access-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-locations-and-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-locations-and-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/common-fare-products"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/connection-links"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/current-travel-times"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/direction-of-travel-on-reversible-lanes"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/disruptions-delays-cancellations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-overtaking-bans-on-heavy-goods-vehicles"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-locations-and-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/environmental-standards-for-vehicles"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/expected-delays"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/fares"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-delivery-regulations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/geometry"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/gradients"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/hours-of-operation"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/identification-of-tolled-roads"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/junctions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/lane-closures-and-access-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-charging-points"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-filling-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-length-of-queues"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-delivery-areas"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-tolling-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/locations-and-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/long-term-road-works"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-closures-diversions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-detailed-attributes"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-geometry-and-lane-character"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-topology-and-routes-lines"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/number-of-lanes"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/operational-calendar"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-access-restrictions-and-traffic-regulations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-static-traffic-signs"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-temporary-traffic-management-measures-or-plans"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-traffic-regulations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-costs"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-environmental-factors"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/park-and-ride-stops"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/passenger-classes"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods-for-tolls"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-accessibility-facilities"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-geometry"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/permanent-access-restrictions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/planned-interchanges-between-scheduled-services"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/points-of-interest"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/poor-road-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/predicted-travel-times"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/provider-data"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/purchase-information"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-estimated-departure-and-arrival-times"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/reservation-and-purchase-options"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-classification"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-closures-and-access-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-weather-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-width"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-locations-and-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-areas-and-service-times"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/short-term-road-works"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/special-fare-products"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/speed"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/speed-limits"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-accessibility-and-paths-within-facility"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-geometry-and-map-layout"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-location-and-features"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-status-of-features"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/timetables-static"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/topographic-places"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-circulation-plans"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-data-at-border-crossings-to-third-countries"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-volume"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/transport-operators"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-locations-and-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-access-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-closures-and-access-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/vehicle-details"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/waiting-time-at-border-crossings-to-non-eu-member-states"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Data content sub-category
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/direction-of-travel-on-reversible-lanes">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Direction of travel on reversible lanes
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/disruptions-delays-cancellations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Disruptions, delays, cancellations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-overtaking-bans-on-heavy-goods-vehicles">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Dynamic overtaking bans on heavy goods vehicles
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Dynamic speed limits
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-closures-and-access-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/direction-of-travel-on-reversible-lanes"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-overtaking-bans-on-heavy-goods-vehicles"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/lane-closures-and-access-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-access-restrictions-and-traffic-regulations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-temporary-traffic-management-measures-or-plans"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-closures-and-access-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-closures-and-access-conditions"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Dynamic traffic signs and regulations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-availability">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">E-scooter-sharing Availability
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-locations-and-stations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">E-scooter-sharing Locations and stations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/environmental-standards-for-vehicles">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Environmental standards for vehicles
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/expected-delays">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Expected delays
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/fares">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Fares
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-charging-points-for-electric-vehicles"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-filling-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-charging-points"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-filling-stations"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Filling and charging stations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-and-logistics">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-delivery-areas"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-delivery-regulations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-delivery-areas"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Freight and logistics
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-delivery-regulations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-and-logistics"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Freight delivery regulations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/address-identifiers"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-costs"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-environmental-factors"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/points-of-interest"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/topographic-places"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">General information for trip-planning
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/geometry">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Geometry
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/gradients">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Gradients
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/hours-of-operation">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Hours of operation
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/identification-of-tolled-roads">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Identification of tolled roads
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/junctions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Junctions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/lane-closures-and-access-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Lane closures and access conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-charging-points">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Location and conditions of charging points
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-filling-stations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Location and conditions of filling stations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-length-of-queues">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Location and length of queues
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-delivery-areas">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-and-logistics"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Location of delivery areas
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-tolling-stations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Location of tolling stations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/locations-and-stations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Locations and stations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/long-term-road-works">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-work-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Long-term road works
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/network-closures-diversions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/cycle-network-data"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Network closures/diversions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/network-detailed-attributes">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/cycle-network-data"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Network detailed attributes
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/network-geometry-and-lane-character">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/cycle-network-data"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Network geometry and lane character
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/network-topology-and-routes-lines">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Network topology and routes/lines
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/number-of-lanes">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Number of lanes
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/operational-calendar">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Operational Calendar
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/other">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Other
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/other-access-restrictions-and-traffic-regulations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Other access restrictions and traffic regulations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/other-static-traffic-signs">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Other static traffic signs
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/other-temporary-traffic-management-measures-or-plans">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Other temporary traffic management measures or plans
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/other-traffic-regulations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Other traffic regulations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-costs">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Parameters needed to calculate costs
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-environmental-factors">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Parameters needed to calculate environmental factors
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/park-and-ride-stops">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Park and Ride stops
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-parking-locations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-locations-and-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/park-and-ride-stops"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-locations-and-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-locations-and-conditions"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Parking, service and rest area information
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/passenger-classes">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Passenger classes
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Payment methods
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods-for-tolls">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Payment methods for tolls
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-accessibility-facilities">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Pedestrian accessibility facilities
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-data">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-accessibility-facilities"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-geometry"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Pedestrian network data
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-geometry">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Pedestrian network geometry
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/permanent-access-restrictions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Permanent access restrictions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/planned-interchanges-between-scheduled-services">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Planned interchanges between scheduled services
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/points-of-interest">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Points of interest
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/poor-road-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-events-and-conditions"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Poor road conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/predicted-travel-times">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Predicted travel times
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/provider-data">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Provider data
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/accesibility-information-for-vehicles"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/environmental-standards-for-vehicles"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/fares"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/locations-and-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/provider-data"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/reservation-and-purchase-options"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-areas-and-service-times"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Public transport non-scheduled transport
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-commercial-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-common-standard-fares"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/common-fare-products"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/connection-links"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/disruptions-delays-cancellations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/environmental-standards-for-vehicles"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/hours-of-operation"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-topology-and-routes-lines"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/operational-calendar"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/passenger-classes"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/planned-interchanges-between-scheduled-services"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/purchase-information"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-estimated-departure-and-arrival-times"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/special-fare-products"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-accessibility-and-paths-within-facility"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-geometry-and-map-layout"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-location-and-features"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-status-of-features"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/timetables-static"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/transport-operators"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/vehicle-details"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Public transport scheduled transport
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/purchase-information">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Purchase information
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-estimated-departure-and-arrival-times">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Real-time estimated departure and arrival times
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/current-travel-times"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/expected-delays"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-length-of-queues"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/predicted-travel-times"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/speed"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-data-at-border-crossings-to-third-countries"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-volume"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/waiting-time-at-border-crossings-to-non-eu-member-states"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Real-time traffic data
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/reservation-and-purchase-options">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Reservation and purchase options
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-classification">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Road classification
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-closures-and-access-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Road closures and access conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-events-and-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/accidents-and-incidents"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/poor-road-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-weather-conditions"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Road events and conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-weather-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-events-and-conditions"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Road weather conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-width">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Road width
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-work-information">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/long-term-road-works"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/short-term-road-works"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Road work information
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-availability">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Service and rest area availability
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-locations-and-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Service and rest area locations and conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/service-areas-and-service-times">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Service areas and service times
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-locations-and-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-locations-and-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-availability"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-locations-and-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/environmental-standards-for-vehicles"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Sharing and Hiring Services
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/short-term-road-works">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-work-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Short-term road works
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/special-fare-products">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Special Fare Products
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/speed">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Speed
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/speed-limits">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Speed limits
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/geometry"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/gradients"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/junctions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/number-of-lanes"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-classification"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-width"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Static road network data
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-access-conditions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-static-traffic-signs"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-traffic-regulations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/permanent-access-restrictions"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/speed-limits"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-circulation-plans"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-access-conditions"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Static traffic signs and regulations
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-accessibility-and-paths-within-facility">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Stop facilities accessibility and paths within facility
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-geometry-and-map-layout">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Stop facilities geometry and map layout
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-location-and-features">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Stop facilities location and features
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-status-of-features">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Stop facilities status of features
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/timetables-static">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Timetables static
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/applicable-road-user-charges-and-payment-methods"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/identification-of-tolled-roads"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-tolling-stations"/>
-    <skos:narrower
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods-for-tolls"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Toll information
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/topographic-places">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Topographic places
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-circulation-plans">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Traffic circulation plans
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-data-at-border-crossings-to-third-countries">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Traffic data at border crossings to third countries
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-volume">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Traffic volume
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/transport-operators">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Transport operators
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-availability">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Truck parking availability
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-locations-and-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Truck parking locations and conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-access-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Tunnel access conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-closures-and-access-conditions">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Tunnel closures and access conditions
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/vehicle-details">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Vehicle details
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/waiting-time-at-border-crossings-to-non-eu-member-states">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-                    xml:lang="en">Waiting time at border crossings to non-EU Member States
-    </skos:prefLabel>
-  </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/waterways-and-water-bodies">
-    <skos:broader
-      xmlns:terms="http://purl.org/dc/terms/"
-                  rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/"
-      xml:lang="en">Waterways and water bodies
-    </skos:prefLabel>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/accesibility-information-for-vehicles">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Accesibility information for vehicles</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Informations sur l'accessibilité des véhicules</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Toegankelijkheid voertuigen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Zugänglichkeitsinformationen für Fahrzeuge</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/accidents-and-incidents">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-events-and-conditions"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Accidents and incidents</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Accidents et incidents</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Ongevallen en incidenten</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Unfälle und Störungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/address-identifiers">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Address identifiers</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Adresses</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Adresgegevens</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Adressen </skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/air-and-space-travel">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Air and space travel</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Transport aérien et spatial</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Lucht- en ruimtevaart</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Luft- und Raumfahrt</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/applicable-road-user-charges-and-payment-methods">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Applicable road user charges and payment methods</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Redevances fixes applicables aux usagers de la route et modes de paiement</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Heffingen van toepassing voor weggebruikers en betaalmethoden</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geltende Benutzungsgebühren und Zahlungsmöglichkeiten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-charging-points-for-electric-vehicles">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Availability of charging points for electric vehicles</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Disponibilité des points de recharge pour véhicules électriques</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Beschikbaarheid laadpunten elektrische voertuigen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verfügbarkeit von Ladepunkten für Elektrofahrzeuge</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-delivery-areas">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-and-logistics"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Availability of delivery areas</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Disponibilité des zones de livraison</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Beschikbaarheid leverzones</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verfügbarkeit von Lieferzonen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-filling-stations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Availability of filling stations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Disponibilité des stations de ravitaillement</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Beschikbaarheid tankstations</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verfügbarkeit von Tankstellen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-commercial-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Basic commercial conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Conditions commerciales de base</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Belangrijkste commerciële voorwaarden</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Grundlegende Geschäftsbedingungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-common-standard-fares">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Basic common standard fares</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Tarifs standards communs de base</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Algemene basistarieven</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Grunddaten zu normalen Standardtarifen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-availability">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Bike-hiring availability</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Disponibilité de vélos en libre service</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Beschikbaarheid huurfietsen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verfügbarkeit von Leihfahrrädern</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-stations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Bike-hiring stations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Stations de vélos en libre service</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Standplaatsen fietsverhuur</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Stellplätze für Leihfahrrädern</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-parking-locations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Bike-parking locations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Stationnements pour vélos</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Fietsenstallingen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Fahrradstellplätze</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-availability">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Bike sharing availability</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Disponibilité des vélos partagés</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Beschikbaarheid deelfietsen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verfügbarkeit von gemeinsam genutzter Fahrräder (Bike-sharing)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-locations-and-stations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Bike sharing locations and stations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation et stations de vélos partagés</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie en standplaatsen deelfietsen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standorte und Stellplätze für gemeinsam genutzte Fahrräder (Bike-sharing)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-access-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Bridge access conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Conditions d'accès aux ponts</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Toegangsvoorwaarden voor bruggen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Zufahrtsbedingungen für Brücken</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-closures-and-access-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Bridge closures and access conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Fermetures de ponts et conditions d'accès</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Sluitings- en toegangsvoorwaarden voor bruggen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Brückensperrungen und Zufahrtsbedingungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-availability">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Car-hiring availability</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Disponibilité des locations de voiture</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Beschikbaarheid huurauto’s</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verfügbarkeit von Mietwagen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-stations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Car-hiring stations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Stations de location de voitures</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Standplaatsen huurauto’s</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Stellplätze für Mietwagen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-availability">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Car parking availability</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Places de parking disponibles</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Beschikbaarheid parkeerplaatsen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verfügbare Pkw-Parkplätze</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-locations-and-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Car parking locations and conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation et conditions des parkings</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie en voorwaarden parkkeerterreinen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standort und Bedingungen von Pkw-Parkplätze</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-availability">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Car-sharing availability</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Disponibilité des voitures partagées</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Beschikbaarheid deelauto's</skos:prefLabel>
+    <skos:prefLabel xml:lang="de"> Verfügbarkeit gemeinsam genutzter Pkw (Car-sharing)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-locations-and-stations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Car-sharing locations and stations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation et stations de voitures partagées</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie en standplaatsen deelauto's</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standorte und Stellplätze für gemeinsam genutzter Pkw (Car-Sharing)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/common-fare-products">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Common fare products</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Produits tarifaires communs</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Gemeenschappelijke tariefformules</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Normaltarifprodukte</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/connection-links">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Connection links</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Points d’échange avec possibilité de correspondances</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Knooppunten waar kan worden overgestapt</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Anschlussverbindungen an Verkehrsknotenpunkten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/current-travel-times">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Current travel times</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Temps de parcours actuels</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Huidige reistijd</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Aktuelle Reisezeiten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/cycle-network-data">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-closures-diversions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-detailed-attributes"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-geometry-and-lane-character"/>
+    <skos:prefLabel xml:lang="en">Cycle network data</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Données sur le réseau cyclable</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Fietsnetwerk informatie</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Daten zum Fahrradnetzwerk</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/air-and-space-travel"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/cycle-network-data"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-and-logistics"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-data"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-events-and-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-work-information"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/waterways-and-water-bodies"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Data content category</skos:prefLabel>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/accesibility-information-for-vehicles"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/accidents-and-incidents"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/address-identifiers"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/applicable-road-user-charges-and-payment-methods"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-charging-points-for-electric-vehicles"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-delivery-areas"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-filling-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-commercial-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-common-standard-fares"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-parking-locations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-locations-and-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-access-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-closures-and-access-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-locations-and-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-locations-and-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/common-fare-products"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/connection-links"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/current-travel-times"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/direction-of-travel-on-reversible-lanes"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/disruptions-delays-cancellations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-overtaking-bans-on-heavy-goods-vehicles"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-locations-and-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/environmental-standards-for-vehicles"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/expected-delays"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/fares"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-delivery-regulations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/geometry"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/gradients"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/hours-of-operation"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/identification-of-tolled-roads"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/junctions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/lane-closures-and-access-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-charging-points"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-filling-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-length-of-queues"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-delivery-areas"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-tolling-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/locations-and-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/long-term-road-works"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-closures-diversions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-detailed-attributes"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-geometry-and-lane-character"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-topology-and-routes-lines"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/number-of-lanes"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/operational-calendar"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-access-restrictions-and-traffic-regulations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-static-traffic-signs"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-temporary-traffic-management-measures-or-plans"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-traffic-regulations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-costs"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-environmental-factors"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/park-and-ride-stops"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/passenger-classes"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods-for-tolls"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-accessibility-facilities"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-geometry"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/permanent-access-restrictions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/planned-interchanges-between-scheduled-services"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/points-of-interest"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/poor-road-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/predicted-travel-times"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/provider-data"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/purchase-information"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-estimated-departure-and-arrival-times"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/reservation-and-purchase-options"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-classification"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-closures-and-access-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-weather-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-width"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-locations-and-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-areas-and-service-times"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/short-term-road-works"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/special-fare-products"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/speed"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/speed-limits"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-accessibility-and-paths-within-facility"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-geometry-and-map-layout"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-location-and-features"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-status-of-features"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/timetables-static"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/topographic-places"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-circulation-plans"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-data-at-border-crossings-to-third-countries"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-volume"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/transport-operators"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-locations-and-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-access-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-closures-and-access-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/vehicle-details"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/waiting-time-at-border-crossings-to-non-eu-member-states"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Data content sub-category</skos:prefLabel>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/direction-of-travel-on-reversible-lanes">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Direction of travel on reversible lanes</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Sens de la circulation sur les voies réversibles</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Rijrichting van rijstroken met omkeerbare rijrichting</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Fahrtrichtung auf Fahrbahnen für beide Richtungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/disruptions-delays-cancellations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Disruptions, delays, cancellations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Perturbations, retards, annulations</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Storingen, vertragingen, uitval</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Störungen, Verspätungen, Ausfälle</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-overtaking-bans-on-heavy-goods-vehicles">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Dynamic overtaking bans on heavy goods vehicles</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Interdictions dynamiques de dépassement pour les poids lourds</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Dynamische inhaalverboden voor vrachtwagens</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Dynamische  Überholverbote für schwere Nutzfahrzeuge</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Dynamic speed limits</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Limitations de vitesse dynamiques</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Dynamische snelheidsbeperkingen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Dynamische Geschwindigkeitsbegrenzungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-closures-and-access-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/direction-of-travel-on-reversible-lanes"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-overtaking-bans-on-heavy-goods-vehicles"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/lane-closures-and-access-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-access-restrictions-and-traffic-regulations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-temporary-traffic-management-measures-or-plans"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-closures-and-access-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-closures-and-access-conditions"/>
+    <skos:prefLabel xml:lang="en">Dynamic traffic signs and regulations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Panneaux routiers et réglementations dynamiques</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Dynamische verkeerssignalisatie en verkeersregels</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Dynamische Verkehrszeichen und -regelungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-availability">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">E-scooter sharing availability</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Disponibilité des trottinettes électriques partagées</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Beschikbaarheid deelscooters</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verfügbarkeit gemeinsam genutzter E-Roller (E-scooter sharing)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-locations-and-stations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">E-scooter sharing locations and stations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation et stations de trottinettes électriques partagées</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie en standplaatsen deelscooters</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standorte und Stellplätze für gemeinsam genutzter E-Roller (E-scooter sharing)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/environmental-standards-for-vehicles">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Environmental standards for vehicles</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Normes environnementales pour les véhicules</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Milieuparameters voertuigen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Umweltstandards für Fahrzeuge</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/expected-delays">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Expected delays</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Retards prévus</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Verwachte vertragingen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Erwartete Verspätungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/fares">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Fares</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Tarifs</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Tarieven</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Tarifen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-charging-points-for-electric-vehicles"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-filling-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-charging-points"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-filling-stations"/>
+    <skos:prefLabel xml:lang="en">Filling and charging stations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Stations-services et de recharge</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Tankstations en laadpunten</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Tankstellen und Ladestationen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-and-logistics">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/availability-of-delivery-areas"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-delivery-regulations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-delivery-areas"/>
+    <skos:prefLabel xml:lang="en">Freight and logistics</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Marchandises et logistique</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Goederen en logistiek</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Waren und Logistik</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-delivery-regulations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-and-logistics"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Freight delivery regulations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Réglementations sur la livraison de fret</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Regels voor het leveren van goederen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Lieferverkehrsbestimmungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/address-identifiers"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-costs"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-environmental-factors"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/points-of-interest"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/topographic-places"/>
+    <skos:prefLabel xml:lang="en">General information for trip-planning</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Informations générales pour la planification des déplacements</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Algemene informatie voor routeplanning</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Allgemeine Informationen zu Routenplanung</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/geometry">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Geometry</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Géométrie</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Geometrie</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geometrie</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/gradients">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Gradients</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Pentes</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Hellingen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Steigungen/Gefälle</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/hours-of-operation">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Hours of operation</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Horaires d'exploitation</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Bedrijfsuren</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Betriebszeiten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/identification-of-tolled-roads">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Identification of tolled roads</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Identification des routes à péage</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Identificatie van tolwegen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Ausweisung von Mautstraßen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/junctions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Junctions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Jonctions</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Knooppunten</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Kreuzungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/lane-closures-and-access-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Lane closures and access conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Fermetures de voies et conditions d'accès</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Sluitings- en toegangsvoorwaarden voor rijstroken</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Fahrstreifensperrungen und Zufahrtsbedingungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-charging-points">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Location and conditions of charging points</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation des points de recharge et conditions de leur utilisation</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie en gebruiksvoorwaarden laadpunten elektrische voertuigen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standort von Ladestationen und ihre Nutzungsbedingungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-conditions-of-filling-stations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/filling-and-charging-stations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Location and conditions of filling stations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation des stations de ravitaillement et conditions de leur utilisation</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie en gebruiksvoorwaarden tankstations</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standort von Tankstellen und ihre Nutzungsbedingungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-length-of-queues">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Location and length of queues</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation et longueur des embouteillages</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Plaats en lengte van files</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Lage und Länge von Verkehrsstaus</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-delivery-areas">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/freight-and-logistics"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Location of delivery areas</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation des zones de livraison</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie leverzones</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standort von Lieferzonen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-tolling-stations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Location of tolling stations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation des postes de péage</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie tolstations</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standort der Mautstationen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/locations-and-stations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Locations and stations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisations et stations</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locaties en haltes</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standorte und Stellplätze</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/long-term-road-works">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-work-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Long-term road works</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Travaux routiers de longue durée</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Langetermijn wegenwerken</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Langfristige Straßenbauarbeiten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/network-closures-diversions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/cycle-network-data"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Network closures/diversions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Fermetures/déviations du réseau</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Fietsroutenetwerk afsluitingen/omleidingen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Netzsperrungen/Umleitungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/network-detailed-attributes">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/cycle-network-data"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Network detailed attributes</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Caractéristiques des réseaux cyclables</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Exacte kenmerken fietsroutenetwerk</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Ausführliche Angaben zum Radwegenetz</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/network-geometry-and-lane-character">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/cycle-network-data"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Network geometry and lane character</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Géométrie du réseau et caractéristiques des voies</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Fietsnetwerk geometrie en karakter</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Netzgeometrie und Fahrbahnbeschaffenheit</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/network-topology-and-routes-lines">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Network topology and routes/lines</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Topologie du réseau et itinéraires/lignes</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Netwerktopologie en -routes/lijnen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Netztopologie und Routen/Strecken</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/number-of-lanes">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Number of lanes</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Nombre de voies</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Aantal rijstroken</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Anzahl der Fahrstreifen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/operational-calendar">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Operational Calendar</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Calendrier opérationnel</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Exploitatieplanning</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Betriebskalender </skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/other">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Other</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Autres</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Andere</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Anderen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/other-access-restrictions-and-traffic-regulations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Other access restrictions and traffic regulations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Autres restrictions d'accès et règles de circulation</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Andere toegangsbeperkingen en verkeersregelingen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Sonstige Zufahrtsbeschränkungen und Straßenverkehrsvorschriften</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/other-static-traffic-signs">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Other static traffic signs</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Autres panneaux de signalisation statique</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Andere statische verkeersborden</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Sonstige statische Verkehrszeichen </skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/other-temporary-traffic-management-measures-or-plans">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Other temporary traffic management measures or plans</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Autres mesures ou plans temporaires de gestion de la circulation</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Andere tijdelijke verkeerbeheersmaatregelen of -plannen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Sonstige befristete Verkehrsmanagementmaßnahmen oder -pläne</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/other-traffic-regulations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Other traffic regulations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Autres règles de circulation</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Andere verkeersregelingen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Sonstige Straßenverkehrsvorschriften </skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-costs">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Parameters needed to calculate costs</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Paramètres nécessaires pour calculer des coûts</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Parameters voor berekening kosten</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Parameter zur Berechnung von Kosten </skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/parameters-needed-to-calculate-environmental-factors">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Parameters needed to calculate environmental factors</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Paramètres nécessaires pour calculer un facteur environnemental</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Parameters voor berekening milieueffecten</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Parameter zur Berechnung von Umweltfaktoren</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/park-and-ride-stops">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Park and ride stops</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Parkings de délestage</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Park&amp;Ride-haltes</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">"Park &amp; Ride"-Standorte</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-parking-locations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-parking-locations-and-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/park-and-ride-stops"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-locations-and-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-locations-and-conditions"/>
+    <skos:prefLabel xml:lang="en">Parking, service and rest area information</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Informations sur les aires de stationnement et de repos</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Parking en stopplaatsen informatie</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Informationen zu Park- und Rastplätzen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/passenger-classes">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Passenger classes</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Catégories de voyageurs</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Passagiersklassen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Kategorien von Verkehrsdienstnutzern</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Payment methods</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Modes de paiement</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Betaalmethoden</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Zahlungsmöglichkeiten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods-for-tolls">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Payment methods for tolls</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Modes de paiement aux péages</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Betaalmethoden tolstations</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Zahlungsmöglichkeiten für die Maut</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-accessibility-facilities">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Pedestrian accessibility facilities</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Aménagements pour l'accessibilité des piétons</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Toegankelijkheidsfaciliteiten voetgangers</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Zugänglichkeitshilfen für Fußgänger</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-data">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-accessibility-facilities"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-geometry"/>
+    <skos:prefLabel xml:lang="en">Pedestrian network data</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Données sur le réseau piétonnier</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Voetgangersnetwerk informatie</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Fuβwegenetz</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-geometry">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/pedestrian-network-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Pedestrian network geometry</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Géométrie du réseau piétonnier</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Geometrie voetgangersnetwerk</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geometrie des Fußgängernetzes </skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/permanent-access-restrictions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Permanent access restrictions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Restrictions d'accès permanentes</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Permanente toegangsbeperkingen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Dauerhafte Zufahrtsbeschränkungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/planned-interchanges-between-scheduled-services">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Planned interchanges between scheduled services</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Correspondances planifiées entre services réguliers</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Geplande overstappen tussen geregeld vervoer</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Planmäßiges Umsteigen zwischen Linienverkehrsdiensten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/points-of-interest">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Points of interest</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Points d'intérêt</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">POI's (interessante plaatsen i.k.v. reizen)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Orte von Interesse</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/poor-road-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-events-and-conditions"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Poor road conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Etat dégradé de la chaussée</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Slechte wegentoestanden </skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Schlechter Straßenzustand</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/predicted-travel-times">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Predicted travel times</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Temps de parcours prévus</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Voorspelde reistijd</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Voraussichtliche Reisezeiten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/provider-data">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Provider data</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Données des prestataires</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Informatie dienstverlener</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Anbieterdaten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/accesibility-information-for-vehicles"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/environmental-standards-for-vehicles"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/fares"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/locations-and-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/provider-data"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/reservation-and-purchase-options"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/service-areas-and-service-times"/>
+    <skos:prefLabel xml:lang="en">Non-scheduled public transport</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Transports publics non réguliers</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Ongeregeld openbaar vervoer</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Öffentlicher Nicht-Linienverkehr</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-commercial-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/basic-common-standard-fares"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/common-fare-products"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/connection-links"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/disruptions-delays-cancellations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/environmental-standards-for-vehicles"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/hours-of-operation"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/network-topology-and-routes-lines"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/operational-calendar"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/passenger-classes"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/planned-interchanges-between-scheduled-services"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/purchase-information"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-estimated-departure-and-arrival-times"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/special-fare-products"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-accessibility-and-paths-within-facility"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-geometry-and-map-layout"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-location-and-features"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-status-of-features"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/timetables-static"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/transport-operators"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/vehicle-details"/>
+    <skos:prefLabel xml:lang="en">Scheduled public transport</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Transports publics réguliers</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Geregeld openbaar vervoer</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Öffentlicher Linienverkehr</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/purchase-information">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Purchase information</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Information sur les achats</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Verkoopinformatie</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Kaufinformationen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-estimated-departure-and-arrival-times">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Real-time estimated departure and arrival times</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Heures de départ et d’arrivée estimées en temps réel</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Real-time geraamde vertrek- en aankomsttijden</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geschätzte Abfahrts- und Ankunftszeiten in Echtzeit</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/current-travel-times"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/expected-delays"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-and-length-of-queues"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/predicted-travel-times"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/speed"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-data-at-border-crossings-to-third-countries"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-volume"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/waiting-time-at-border-crossings-to-non-eu-member-states"/>
+    <skos:prefLabel xml:lang="en">Real-time traffic data</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Données en temps réel sur la circulation</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Real-time verkeersinformatie</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Echtzeit-Verkehrsinformation</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/reservation-and-purchase-options">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Reservation and purchase options</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Modalités de réservation et d'achat</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Reservatie en aankoop mogelijkheden</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Reservierungs- und Kaufmöglichkeiten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-classification">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Road classification</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Classification de la route</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Wegclassificatie</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Straßenklasse</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-closures-and-access-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Road closures and access conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Fermetures de routes et conditions d'accès</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Sluitings- en toegangsvoorwaarden vaoorwegen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Straßensperrungen und Zufahrtsbedingungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-events-and-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/accidents-and-incidents"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/poor-road-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-weather-conditions"/>
+    <skos:prefLabel xml:lang="en">Road events and conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Evénements et conditions de route</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Wegenincidenten en condities</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Straβenereignisse und –zustände</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-weather-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-events-and-conditions"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Road weather conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Conditions météorologiques routières</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Weercondities wegen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Straβenwetterszustände</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-width">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Road width</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Largeur de la route</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Breedte van de weg</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Straßenbreite</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/road-work-information">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/long-term-road-works"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/short-term-road-works"/>
+    <skos:prefLabel xml:lang="en">Road work information</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Informations sur les travaux routiers</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Wegenwerken informatie</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Informationen zu Straβenbauarbeiten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-availability">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Service and rest area availability</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Disponibilité des aires de service et de repos</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Beschikbarheid service- en stopplaatsen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verfügbarkeit von sicheren Parkplätzen und Rastanlagen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/service-and-rest-area-locations-and-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Service and rest area locations and conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation et conditions des aires de service et de repos</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie en voorwaarden van service- en stopplaatsen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standort und Bedingungen von sicheren Parkplätzen und Rastanlagen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/service-areas-and-service-times">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-non-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Service areas and service times</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Zones desservies et horaires de service</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie en bedrijfsuren diensten</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Einzugsgebiete und Dienstzeiten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/sharing-and-hiring-services">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-hiring-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bike-sharing-locations-and-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-hiring-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/car-sharing-locations-and-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-availability"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/e-scooter-sharing-locations-and-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/environmental-standards-for-vehicles"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods"/>
+    <skos:prefLabel xml:lang="en">Sharing and Hiring Services</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Services de partage et de location</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Deel- en huurdiensten</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Gemeinsame Nutzung und Vermietung von Dienstleistungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/short-term-road-works">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-work-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Short-term road works</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Travaux routiers de courte durée</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Kortetermijn wegenwerken</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Kurzfristige Straßenbauarbeiten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/special-fare-products">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Special Fare Products</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Produits tarifaires spéciaux</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Speciale aanbiedingen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Sondertarifprodukte</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/speed">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Speed</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Vitesse</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Snelheid</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geschwindigkeit</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/speed-limits">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Speed limits</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Limitations de vitesse</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Snelheidsbeperkingen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geschwindigkeitsbegrenzungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/static-road-network-data">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/geometry"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/gradients"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/junctions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/number-of-lanes"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-classification"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/road-width"/>
+    <skos:prefLabel xml:lang="en">Static road network data</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Données routières statiques</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Statische weggegevens</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Statische Straβendaten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/bridge-access-conditions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-static-traffic-signs"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/other-traffic-regulations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/permanent-access-restrictions"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/speed-limits"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-circulation-plans"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-access-conditions"/>
+    <skos:prefLabel xml:lang="en">Static traffic signs and regulations</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Panneaux routiers et réglementations statiques</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Statische verkeerssignalisatie en verkeersregels</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Statische Verkehrszeichen und -regelungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-accessibility-and-paths-within-facility">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Stop facilities accessibility and paths within facility</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Accessibilité des points d'arrêt et voies de circulation au sein d'un point d'échange</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Toegankelijkheid van knooppunten en routes binnen knooppunten </skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Zugänglichkeit von Zugangsknoten und Wege innerhalb von Verkehrsknotenpunkten </skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-geometry-and-map-layout">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Stop facilities geometry and map layout</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Géométrie/structure de la carte des nœuds d'accès</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Geometrie/situering van de knooppunten op kaart</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Geometrie/Kartierung von Zugangsknoten </skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-location-and-features">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Stop facilities location and features</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation et situation aux nœuds d'accès</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie en toegangen tot het knooppunt</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standort und Angaben von Zugangsknoten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/stop-facilities-status-of-features">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Stop facilities status of features</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Situation aux nœuds d'accès</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Status van de toegangen tot het knooppunt</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Statusangaben für Zugangsknoten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/timetables-static">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Timetables static</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Horaires statiques</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Dienstregelingen statisch</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Fahrpläne statisch</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/toll-information">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/applicable-road-user-charges-and-payment-methods"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/identification-of-tolled-roads"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/location-of-tolling-stations"/>
+    <skos:narrower xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/payment-methods-for-tolls"/>
+    <skos:prefLabel xml:lang="en">Toll information</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Informations sur les péages</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Tol informatie</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Mautangaben</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/topographic-places">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/general-information-for-trip-planning-"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Topographic places</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Lieux topographiques</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Topografische gegevens</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Topografische Orte</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-circulation-plans">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Traffic circulation plans</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Plans de circulation routière</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Verkeerscirculatieplannen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verkehrspläne</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-data-at-border-crossings-to-third-countries">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Traffic data at border crossings to third countries</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Données sur le trafic aux frontières avec les pays tiers</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Verkeersdata bij grensovergangen naar derde landen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verkehrsdaten an Grenzübergängen zu Drittländern</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-volume">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Traffic volume</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Volume du traffic</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Verkeersvolume</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verkehrsaufkommen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/transport-operators">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Transport operators</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Exploitants d'entreprises de transport</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Transport operator</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verkehrsbetreiber</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-availability">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Truck parking availability</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Disponibilité des aires de stationnement pour camions</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Beschikbaarheid parkeerplaatsen voor vrachtwagens</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verfügbarkeit von Lkw-Parkplatzes</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/truck-parking-locations-and-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/parking-service-and-rest-area-information"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Truck parking locations and conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Localisation et conditions des aires de stationnement pour camions</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Locatie en voorwaarden parkeerplaatsen voor vrachtwagens</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Standort und Bedingungen von Pkw-Parkplätze</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-access-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/static-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Tunnel access conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Conditions d'accès aux tunnels</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Toegangsvoorwaarden voor tunnels</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Zufahrtsbedingungen für Tunnel</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/tunnel-closures-and-access-conditions">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Tunnel closures and access conditions</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Fermetures de tunnels et conditions d'accès</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Sluitings- en toegangsvoorwaarden voor tunnels</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Tunnelsperrungen und Zufahrtsbedingungen</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/vehicle-details">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport-scheduled-transport"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Vehicle details</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Détails du véhicule</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Voertuig details</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Fahrzeugdetails</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/waiting-time-at-border-crossings-to-non-eu-member-states">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/real-time-traffic-data"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Waiting time at border crossings to non-EU member states</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Temps d’attente aux frontières des pays non membres de l'UE</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Wachttijd bij grensovergangen naar niet EU-landen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Wartezeit an Grenzübergängen zu Nicht-EU-Mitgliedstaaten</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/mobility-theme/waterways-and-water-bodies">
+    <skos:broader xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
+    <skos:prefLabel xml:lang="en">Waterways and water-bodies</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Voies navigables et plans d'eau</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Zee en binnenwateren</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Wasserstraßen und Wasserkörper</skos:prefLabel>
   </skos:Concept>
 </rdf:RDF>
-

--- a/resources/thesauri/theme/mobility-transport-mode.rdf
+++ b/resources/thesauri/theme/mobility-transport-mode.rdf
@@ -1,22 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-         xmlns:terms="http://purl.org/dc/terms/"
-         xmlns:dc="http://purl.org/dc/elements/1.1/">
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:terms="http://purl.org/dc/terms/">
   <skos:ConceptScheme rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode">
     <terms:abstract xml:lang="en">Controlled vocabulary for the transport modes covered by a dataset as modified from
-      original By Vincent Bombaerts (SPW). Modifications include refactoring of the rdf file and translation to French
-    </terms:abstract>
+      original By Vincent Bombaerts (SPW). Modifications include refactoring of the rdf file and translation to French</terms:abstract>
     <terms:creator xml:lang="en">Mario Scrocca (Cefriel)</terms:creator>
     <terms:creator xml:lang="en">Peter Lubrich (BASt)</terms:creator>
     <terms:contributor xml:lang="en">Vincent Bombaerts (SPW)</terms:contributor>
-    <terms:description xml:lang="en">Controlled vocabulary for the transport modes covered by a dataset.
-    </terms:description>
+    <terms:description xml:lang="en">Controlled vocabulary for the transport modes covered by a dataset.</terms:description>
     <dc:description xml:lang="en">Controlled vocabulary for the transport modes covered by a dataset.</dc:description>
-    <dc:description xml:lang="fr">Vocabulaire controlé pour les modes de transports couverts par un jeu de données.
-    </dc:description>
+    <dc:description xml:lang="fr">Vocabulaire controlé pour les modes de transports couverts par un jeu de données.</dc:description>
     <terms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
     <terms:publisher xml:lang="en">NAPCORE SubWG4.4</terms:publisher>
     <terms:title xml:lang="en">Transport Mode</terms:title>
+    <terms:title xml:lang="nl">Transportmodus</terms:title>
+    <terms:title xml:lang="de">Transportmittel</terms:title>
     <terms:title xml:lang="fr">Mode de transport</terms:title>
     <skos:hasTopConcept rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode/air"/>
     <skos:hasTopConcept rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode/bicycle"/>
@@ -45,149 +42,196 @@
   </skos:ConceptScheme>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/air">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
-    <skos:prefLabel xml:lang="en">Air</skos:prefLabel>
-    <skos:prefLabel xml:lang="fr">Air</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="en">Air</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Aérien</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Vliegtuig</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Luftverkehr</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/bicycle">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Bicycle</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Vélo</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Fiets</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Fahrrad</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/bike-hire">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Bike Hire</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Location de vélo</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Huurfiets</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Leihfahrrad</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/bike-sharing">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Bike Sharing</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Partage de vélo</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Deelfiets</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Gemeinsame Nutzung von Fahrrädern (Bike-Sharing)</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/bus">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Bus</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Bus</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Bus</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Bus</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/car">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Car</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Voiture</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Auto</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Pkw</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/car-hire">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Car Hire</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Location de voiture</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Huurauto</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Mietwagen</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/car-pooling">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Car Pooling</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Covoiturage</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Carpooling</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Fahrgemeinschaften (Car-Pooling)</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/car-sharing">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Car Sharing</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Partage de voiture</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Deelauto</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Gemeinsame Pkw-Nutzung (Car-Sharing)</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/e-scooter">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">E-Scooter</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Trotinette électrique</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">E-scooter</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">E-rollern</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/long-distance-coach">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Long-distance coach</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Autocar longue distance</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Langeafstandsbus</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Fernbus</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/long-distance-rail">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
-    <skos:prefLabel xml:lang="en">Long-distance rail</skos:prefLabel>
-    <skos:prefLabel xml:lang="fr">Train longue distance</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="en">Rail (including high speed rail)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Ferroviaire (y compris ferroviaire à grande vitesse)</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Trein (m.i.v. hogesnelheidstrein)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Eisenbahn (einschl. Hochgeschwindigkeit)</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/maritime">
     <skos:definition xml:lang="en">Maritime including ferry</skos:definition>
     <skos:definition xml:lang="fr">Transport maritime et ferry</skos:definition>
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
-    <skos:prefLabel xml:lang="en">Maritime</skos:prefLabel>
-    <skos:prefLabel xml:lang="fr">Transport maritime</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="en">Maritime (including ferry)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Maritime (y compris les ferries)</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Schip (m.i.v. veerboten)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Schifffahrt (einschließlich Fähre)</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/metro-subway-train">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Metro, Subway train</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Metro</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Metro</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Untergrundbahn</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/motorcycle">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Motorcycle</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Moto</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Motorfiets</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Motorrad</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/other">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
-    <skos:prefLabel xml:lang="en">Other</skos:prefLabel>
-    <skos:prefLabel xml:lang="fr">Autre mode de transport</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="en">Other</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Autre</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Andere</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Andere</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/pedestrian">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Pedestrian</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Piéton</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Voetganger</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Fußgänger</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/regional-and-local-rail">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Regional and local rail</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Train local et régional</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Klassieke trein</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Konventioneller Bahnverkehr</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/ride-pooling">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Ride Pooling</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Ride Pooling</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Gedeelde ritten</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Mitfahrdienst</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/shuttle-bus">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Shuttle bus</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Navette de bus</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Shuttlebus</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Pendelbus</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/shuttle-ferry">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Shuttle ferry</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Navette ferry</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Shuttleveerboot</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Pendelfähre</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/taxi">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Taxi</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Taxi</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Taxi</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Taxi</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/tram-light-rail">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Tram, Light rail</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Tram, Métro léger, Prémétro</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Tram, Light rail</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Straßenbahn, Stadtbahn</skos:prefLabel>
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/transport-mode/truck">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
     <skos:prefLabel xml:lang="en">Truck</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Poids lourd</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
+    <skos:prefLabel xml:lang="nl">Vrachtwagen</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Lastwagen</skos:prefLabel>
   </skos:Concept>
 </rdf:RDF>
-

--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -28,17 +28,20 @@
                 xmlns:dc="http://purl.org/dc/elements/1.1/"
                 xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:dqv="http://www.w3.org/ns/dqv#"
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:skos="http://www.w3.org/2004/02/skos/core#"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
                 xmlns:locn="http://www.w3.org/ns/locn#"
                 xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:oa="http://www.w3.org/ns/oa#"
                 xmlns:owl="http://www.w3.org/2002/07/owl#"
                 xmlns:dcatap="http://data.europa.eu/r5r/"
                 xmlns:spdx="http://spdx.org/rdf/terms#"
                 xmlns:schema="http://schema.org/"
                 xmlns:mdcat="https://data.vlaanderen.be/ns/metadata-dcat#"
+                xmlns:mobilitydcatap="https://w3id.org/mobilitydcat-ap"
                 xmlns:gn-fn-render="http://geonetwork-opensource.org/xsl/functions/render"
                 xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
                 xmlns:gn-fn-dcat-ap="http://geonetwork-opensource.org/xsl/functions/profiles/dcat-ap"
@@ -386,6 +389,7 @@
     <xsl:variable name="sectionContent">
       <xsl:apply-templates mode="render-view" select="section|field"/>
     </xsl:variable>
+
     <!-- Hide sections if empty -->
     <xsl:if test="normalize-space($sectionContent)">
       <div id="gn-section-{generate-id()}" class="gn-tab-content">
@@ -433,7 +437,7 @@
   </xsl:template>
 
   <!-- Field with lang : display only field of current lang or first one if not exist -->
-  <xsl:template mode="render-field" match="dct:title|dct:description|foaf:name|adms:versionNotes">
+  <xsl:template mode="render-field" match="dct:title|dct:description|foaf:name|adms:versionNotes|foaf:firstName|foaf:surname">
     <xsl:param name="xpath"/>
     <xsl:variable name="stringValue" select="string()"/>
     <xsl:variable name="name" select="name()"/>
@@ -549,14 +553,15 @@
     </xsl:if>
   </xsl:template>
 
+  <!-- render the element name (key) and the @rdf:resource (value) -->
   <xsl:template mode="render-field"
-                match="dcat:accessURL|dcat:downloadURL|dcat:landingPage">
+                match="dcat:accessURL|dcat:downloadURL|dcat:landingPage|foaf:mbox|foaf:phone|foaf:workplaceHomepage">
     <xsl:param name="xpath"/>
     <xsl:variable name="stringValue" select="string(@rdf:resource)"/>
     <xsl:if test="normalize-space($stringValue) != ''">
       <tr>
         <th style="{$thStyle}">
-          <xsl:value-of select="gn-fn-metadata:getLabel($schema, 'rdf:resource', $labels, name(.), '', concat(gn-fn-dcat-ap:concatXPaths($xpath, gn-fn-metadata:getXPath(.), name(.)), '/@rdf:resource'))/label" />
+          <xsl:value-of select="gn-fn-metadata:getLabel($schema, name(.), $labels, name(..), '', gn-fn-dcat-ap:concatXPaths($xpath, gn-fn-metadata:getXPath(.), name(.)))/label" />
         </th>
         <td style="{$tdStyle}">
           <xsl:apply-templates mode="render-url" select="@rdf:resource" />
@@ -570,7 +575,9 @@
   <xsl:template mode="render-field" match="dct:type|dct:accrualPeriodicity|dcat:theme|dct:language|dct:format|dcat:mediaType|
                                            adms:status|mdcat:levensfase|mdcat:ontwikkelingstoestand|dct:accessRights|dcat:compressFormat|
                                            dcat:packageFormat|dct:subject|mdcat:MAGDA-categorie|mdcat:statuut|
-                                           dcatap:hvdCategory">
+                                           dcatap:hvdCategory|
+                                           mobilitydcatap:networkCoverage|mobilitydcatap:transportMode| mobilitydcatap:mobilityTheme|
+                                           mobilitydcatap:georeferencingMethod|mobilitydcatap:intendedInformationService">
     <xsl:param name="xpath"/>
     <xsl:variable name="name" select="name()"/>
     <xsl:if test="not(preceding-sibling::*[name(.) = $name and position()=1])">
@@ -597,6 +604,25 @@
           </td>
         </tr>
       </xsl:for-each-group>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- element that include an ao:hasBody -->
+  <xsl:template mode="render-field" match="mobilitydcatap:assessmentResult|dqv:hasQualityAnnotation">
+    <xsl:param name="xpath"/>
+    <xsl:variable name="stringValue" select="string(oa:hasBody/@rdf:resource)"/>
+    <xsl:if test="normalize-space($stringValue) != ''">
+      <tr>
+        <th style="{$thStyle}">
+          <xsl:value-of select="gn-fn-metadata:getLabel($schema, name(.), $labels, name(..), '', gn-fn-dcat-ap:concatXPaths($xpath, gn-fn-metadata:getXPath(.), name(.)))/label" />
+        </th>
+        <td style="{$tdStyle}">
+          <xsl:apply-templates mode="render-url" select="oa:hasBody/@rdf:resource" />
+          <xsl:if test="dct:issued">
+            (<xsl:value-of select="gn-fn-metadata:getLabel($schema, 'dct:issued', $labels)/label "/><xsl:value-of select="' '"/><xsl:value-of select="dct:issued"/>)
+          </xsl:if>
+        </td>
+      </tr>
     </xsl:if>
   </xsl:template>
 

--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -686,7 +686,7 @@
 
   <xsl:template mode="render-field" match="dcat:contactPoint|dct:publisher|dct:rightsHolder|dct:provenance|foaf:page|dct:temporal|
                                            dct:license|dct:rights|dct:conformsTo|dcat:distribution|adms:sample|
-                                           vcard:hasAddress|adms:identifier|dct:creator|dcat:qualifiedRelation">
+                                           vcard:hasAddress|adms:identifier|dct:creator|dcat:qualifiedRelation|adms:Identifier">
     <xsl:param name="xpath"/>
     <xsl:variable name="stringValue" select="string()"/>
     <!-- Special case for dct:license with an empty dct:LicenseDocument with only @rdf:about or for dcat:contactPoint with only vcard:hasEmail and vcard:hasURL-->

--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -29,6 +29,7 @@
                 xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
                 xmlns:dqv="http://www.w3.org/ns/dqv#"
+                xmlns:geodcatap="http://data.europa.eu/930/"
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:skos="http://www.w3.org/2004/02/skos/core#"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -684,9 +685,10 @@
     </tr>
   </xsl:template>
 
+  <!-- render nested content -->
   <xsl:template mode="render-field" match="dcat:contactPoint|dct:publisher|dct:rightsHolder|dct:provenance|foaf:page|dct:temporal|
                                            dct:license|dct:rights|dct:conformsTo|dcat:distribution|adms:sample|
-                                           vcard:hasAddress|adms:identifier|dct:creator|dcat:qualifiedRelation|adms:Identifier">
+                                           vcard:hasAddress|adms:identifier|dct:creator|dcat:qualifiedRelation|adms:Identifier|geodcatap:referenceSystem">
     <xsl:param name="xpath"/>
     <xsl:variable name="stringValue" select="string()"/>
     <!-- Special case for dct:license with an empty dct:LicenseDocument with only @rdf:about or for dcat:contactPoint with only vcard:hasEmail and vcard:hasURL-->

--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -343,25 +343,26 @@
     <label>Documentatie</label>
     <description>Documentatie</description>
     <btnLabel>Documentatie</btnLabel>
-  </element><element name="foaf:workplaceHomepage">
-    <label>URL</label>
-    <description>The Web site of the agent.</description>
+  </element>
+  <element name="foaf:workplaceHomepage">
+    <label>Werkplek startpagina</label>
+    <description>The startpagina van de werkplek van de agent.</description>
   </element>
   <element name="foaf:firstName">
-    <label>First name</label>
-    <description>The first name of the agent.</description>
+    <label>Voornaam</label>
+    <description>De voornaam van de agent.</description>
   </element>
   <element name="foaf:surname">
-    <label>Surname</label>
-    <description>The surname of the agent.</description>
+    <label>Achternaam</label>
+    <description>De achternaam van de agent.</description>
   </element>
   <element name="foaf:phone">
-    <label>Phone</label>
-    <description>The phone number of the agent, specified using fully qualified tel: URI scheme RFC3966.</description>
+    <label>Telefoon</label>
+    <description>Het telefoonnummer van de agent, gespecificeerd met behulp van het volledig gekwalificeerde tel: URI-schema RFC3966.</description>
   </element>
   <element name="foaf:mbox">
-    <label>Email</label>
-    <description>The email address of the agent, specified using fully qualified mailto: URI scheme RFC6068.</description>
+    <label>E-mail</label>
+    <description>Het e-mailadres van de agent, gespecificeerd met behulp van het volledig gekwalificeerde mailto: URI-schema RFC6068.</description>
   </element>
   <element name="org:memberOf">
     <label>Member of</label>
@@ -1046,9 +1047,9 @@
     <btnLabel>Dekking netwerk</btnLabel>
   </element>
   <element name="mobilitydcatap:georeferencingMethod">
-    <label>Georeferencing method</label>
-    <description>This property SHOULD be used to specify the georeferencing method used in the dataset.</description>
-    <btnLabel>Georeferencing method</btnLabel>
+    <label>Georeferentiemethode</label>
+    <description>Deze eigenschap MOET worden gebruikt om de georeferentiemethode te specificeren die in de dataset is gebruikt.</description>
+    <btnLabel>Georeferentiemethode</btnLabel>
   </element>
   <element name="mobilitydcatap:intendedInformationService">
     <label>Bedoelde informatie service</label>
@@ -1078,9 +1079,8 @@
     <description>The technical data grammar format of the delivered content within the Distribution. It describes the standard on top of the elementary syntax that describe data structures in the dataset.</description>
   </element>
   <element name="mobilitydcatap:assessmentResult">
-    <label>Assessment result</label>
-    <description>The results and outcomes from an assessment process by an external organisation, e.g., a National Body in the context of EU Delegated Regulations. EU Delegated Regulations require Member States to set up procedures to assess the compliance of the Delegated Regulations, e.g. regarding the provisioning of data via a NAP. These assessment processes are handled by National Bodies and installed individually in each Member State.
-      The property may point to the most recent assessment procedure, including its date, its result as a free-text and/or a link referring to an assessment report online.</description>
+    <label>Beoordelingsresultaat</label>
+    <description>De resultaten en uitkomsten van een beoordelingsproces door een externe organisatie, e.g., een nationale instantie in het kader van gedelegeerde EU-verordeningen. Gedelegeerde EU-verordeningen vereisen dat lidstaten procedures instellen om de naleving van de gedelegeerde verordeningen te beoordelen, bijvoorbeeld met betrekking tot de verstrekking van gegevens via een NAP. Deze beoordelingsprocessen worden uitgevoerd door nationale instanties en zijn per lidstaat afzonderlijk geïmplementeerd. De eigenschap kan verwijzen naar de meest recente beoordelingsprocedure, inclusief de datum, het resultaat als vrije tekst en/of een link naar een online beoordelingsrapport.</description>
   </element>
   <element name="mobilitydcatap:dataFormatNotes">
     <label>Data format notes</label>
@@ -1091,8 +1091,8 @@
     <description>The result of the latest assessment procedure, in form of a URL linking to further details or results. Alternatively, textual information is provided using the Embedded Textual Body construction of the Web Annotation Data Model, which allows to specify text formats and languages which might be relevant for multilingual purposes.</description>
   </element>
   <element name="dqv:hasQualityAnnotation">
-    <label>Quality annotation</label>
-    <description>An annotation about any quality aspects regarding the delivered content, in particular methods, metrics/indicators and results of a quality assessment in the responsibility of the Data Owner.</description>
+    <label>Kwaliteitsannotatie</label>
+    <description>Een toelichting over alle kwaliteitsaspecten met betrekking tot de geleverde inhoud, in het bijzonder methoden, meetmethoden/indicatoren en resultaten van een kwaliteitsbeoordeling waarvoor de Data Owner verantwoordelijk is.</description>
   </element>
   <element name="cnt:characterEncoding">
     <label>Character encoding</label>

--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -1102,8 +1102,8 @@
     </helper>
   </element>
   <element name="geodcatap:referenceSystem">
-    <label>Reference system</label>
-    <description>The spatial reference system used in the delivered content. To be specified via the “EPSG coordinate reference systems” register operated by OGC.</description>
+    <label>Referentiesysteem</label>
+    <description>Het ruimtelijke referentiesysteem dat in de geleverde inhoud wordt gebruikt. Dit dient te worden gespecificeerd via het register "EPSG-coördinatenreferentiesystemen" dat wordt beheerd door OGC.</description>
   </element>
   <element name="dcatap:hvdCategory" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
     <label>Hoogwaardige Dataset (HVD) Categorie</label>

--- a/src/main/plugin/dcat-ap/loc/eng/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/labels.xml
@@ -345,7 +345,7 @@
     <btnLabel>Documentation</btnLabel>
   </element>
   <element name="foaf:workplaceHomepage">
-    <label>URL</label>
+    <label>Workplace homepage</label>
     <description>The Web site of the agent.</description>
   </element>
   <element name="foaf:firstName">


### PR DESCRIPTION
- Added missing configuration for the mobility-related elements that were recently added, making sure they are rendered properly in the view. This includes, e.g., `mobilitydcatap:georeferencingMethod|networkCoverage|transportMode`.
- A couple of improvements made to the `dut` labels that were lacking translations.
- Fixed rendering of rdf:resource related elements that should display the label of their element, but instead were showing the "resource URI" label