### PR TITLE
Schematron checks for removed mobility properties

### DIFF
--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-mobility-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-mobility-rec.xml
@@ -4,4 +4,7 @@
   <recommended.dcat_theme_tran.title>DCAT thema</recommended.dcat_theme_tran.title>
   <recommended.dcat_theme_tran.report>Het Transport thema werd gebruikt</recommended.dcat_theme_tran.report>
   <recommended.dcat_theme_tran.assert>In de meeste gevallen wordt aangenomen dat de relevante waarde voor het thema van dataportalen in het domein Mobiliteit "Transport" is.</recommended.dcat_theme_tran.assert>
+  <property.removed.title>De eigenschap #element in #context werd als verwijderd opgegeven in mobilityDCAT-AP.</property.removed.title>
+  <property.removed.assert>De eigenschap #element werd gevonden in #context.</property.removed.assert>
+  <property.removed.report>De eigenschap #element werd niet gevonden in #context.</property.removed.report>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-mobility-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/schematron-rules-dcat-ap-mobility-rec.xml
@@ -4,4 +4,7 @@
   <recommended.dcat_theme_tran.title>DCAT theme</recommended.dcat_theme_tran.title>
   <recommended.dcat_theme_tran.report>The Transport theme was used</recommended.dcat_theme_tran.report>
   <recommended.dcat_theme_tran.assert>In most cases, it is assumed that the relevant value for mobility data portals theme is Transport. Check the DCAT theme.</recommended.dcat_theme_tran.assert>
+  <property.removed.title>The property #element in #context was removed in mobilityDCAT-AP.</property.removed.title>
+  <property.removed.assert>Property #element was found in #context.</property.removed.assert>
+  <property.removed.report>Property #element was not found in #context.</property.removed.report>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-mobility-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/schematron-rules-dcat-ap-mobility-rec.xml
@@ -4,4 +4,7 @@
   <recommended.dcat_theme_tran.title>DCAT thème</recommended.dcat_theme_tran.title>
   <recommended.dcat_theme_tran.report>Le thème Transport a été utilisé</recommended.dcat_theme_tran.report>
   <recommended.dcat_theme_tran.assert>Dans la plupart des cas, on considère que la valeur pertinente pour le sujet des portails de données dans le domaine de la mobilité est «Transport».</recommended.dcat_theme_tran.assert>
+  <property.removed.title>La propriété #element dans #context a été supprimée dans mobilityDCAT-AP.</property.removed.title>
+  <property.removed.assert>La propriété #element a été trouvée dans #context.</property.removed.assert>
+  <property.removed.report>La propriété #element n’a pas été trouvée dans #context.</property.removed.report>
 </strings>

--- a/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-mobility-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/schematron-rules-dcat-ap-mobility-rec.xml
@@ -4,4 +4,7 @@
   <recommended.dcat_theme_tran.title>DCAT Thema</recommended.dcat_theme_tran.title>
   <recommended.dcat_theme_tran.report>Das Thema Transport wurde verwendet</recommended.dcat_theme_tran.report>
   <recommended.dcat_theme_tran.assert>In den meisten Fällen wird davon ausgegangen, dass der relevante Wert für das Thema Datenportale im Mobilitätsbereich „Transport“ lautet.</recommended.dcat_theme_tran.assert>
+  <property.removed.title>Die Eigenschaft #element in #context wurde in mobilityDCAT-AP entfernt.</property.removed.title>
+  <property.removed.assert>Die Eigenschaft #element wurde in #context gefunden.</property.removed.assert>
+  <property.removed.report>Die Eigenschaft #element wurde in #context nicht gefunden.</property.removed.report>
 </strings>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-mobility-rec.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-mobility-rec.sch
@@ -19,6 +19,8 @@
   <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
   <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
   <sch:ns prefix="mdcat" uri="https://data.vlaanderen.be/ns/metadata-dcat#"/>
+  <sch:ns prefix="odrl" uri="http://www.w3.org/ns/odrl/2/"/>
+  <sch:ns prefix="prov" uri="http://www.w3.org/ns/prov#"/>
   <sch:ns prefix="geodcat" uri="http://data.europa.eu/930/"/>
   <sch:ns prefix="generiek" uri="https://data.vlaanderen.be/ns/generiek#"/>
   <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
@@ -33,4 +35,175 @@
       <sch:report test="count($tranDcatTheme) = 1">$loc/strings/recommended.dcat_theme_tran.report</sch:report>
     </sch:rule>
   </sch:pattern>
+
+  <!-- "Removed" properties in mobility are mentioned separately from the cardinalities as there is no consensus yet on whether these need to be dealt with as a strict removal. -->
+  <sch:pattern abstract="true" id="PropertyRemovedCheck">
+    <sch:title>geonet:replacePlaceholders($loc/strings/property.removed.title, ('#context', '#element'), ('$context', '$element'))</sch:title>
+    <sch:rule context="$context">
+      <sch:assert test="count($element) = 0">
+        <sch:value-of select="geonet:replacePlaceholders($loc/strings/property.removed.assert, ('#context', '#element'), ('$context', '$element'))"/>
+      </sch:assert>
+      <sch:report test="count($element) = 0">
+        <sch:value-of select="geonet:replacePlaceholders($loc/strings/property.removed.report, ('#context', '#element'), ('$context', '$element'))"/>
+      </sch:report>
+    </sch:rule>
+  </sch:pattern>
+
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_Modified">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dct:modified"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Catalog_catalog">
+    <sch:param name="context" value="dcat:Catalog"/>
+    <sch:param name="element" value="dcat:catalog"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Catalog_service">
+    <sch:param name="context" value="dcat:Catalog"/>
+    <sch:param name="element" value="dcat:service"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Catalog_creator">
+    <sch:param name="context" value="dcat:Catalog"/>
+    <sch:param name="element" value="dct:creator"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Catalog_rights">
+    <sch:param name="context" value="dcat:Catalog"/>
+    <sch:param name="element" value="dct:rights"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="CatalogRecord_status">
+    <sch:param name="context" value="dcat:CatalogRecord"/>
+    <sch:param name="element" value="adms:status"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="CatalogRecord_conformsTo">
+    <sch:param name="context" value="dcat:CatalogRecord"/>
+    <sch:param name="element" value="dct:conformsTo"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="CatalogRecord_description">
+    <sch:param name="context" value="dcat:CatalogRecord"/>
+    <sch:param name="element" value="dct:description"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="CatalogRecord_issued">
+    <sch:param name="context" value="dcat:CatalogRecord"/>
+    <sch:param name="element" value="dct:issued"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="CatalogRecord_title">
+    <sch:param name="context" value="dcat:CatalogRecord"/>
+    <sch:param name="element" value="dct:title"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_sample ">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="adms:sample "/>
+  </sch:pattern>"
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_landingPage ">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="dcat:landingPage "/>
+  </sch:pattern>"
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_qualifiedRelation ">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="dcat:qualifiedRelation "/>
+  </sch:pattern>"
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_spatialResolutionInMeters">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="dcat:spatialResolutionInMeters"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_temporalResolution">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="dcat:temporalResolution"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_accessRights">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="dct:accessRights"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_conformsTo">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="dct:conformsTo"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_creator">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="dct:creator"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_provenance ">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="dct:provenance "/>
+  </sch:pattern>"
+  <sch:pattern Dataseta="PropertyRemovedCheck" id="Dataset_source ">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="dct:source "/>
+  </sch:pattern>"
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_type">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="dct:type"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_page">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="foaf:page"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_qualifiedAttribution ">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="prov:qualifiedAttribution "/>
+  </sch:pattern>"
+  <sch:pattern is-a="PropertyRemovedCheck" id="Dataset_wasGeneratedBy">
+    <sch:param name="context" value="dcat:Dataset"/>
+    <sch:param name="element" value="prov:wasGeneratedBy"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_status">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="adms:status"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_byteSize">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dcat:byteSize"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_compressFormat">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dcat:compressFormat"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_mediaType">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dcat:mediaType"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_packageFormat">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dcat:packageFormat"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_spatialResolutionInMeters">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dcat:spatialResolutionInMeters"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_temporalResolution">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dcat:temporalResolution"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_availability">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dcatap:availability"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_conformsTo">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dct:conformsTo"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_issued">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dct:issued"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_language">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dct:language"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_modified">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="dct:modified"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_page">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="foaf:page"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_hasPolicy">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="odrl:hasPolicy"/>
+  </sch:pattern>
+  <sch:pattern is-a="PropertyRemovedCheck" id="Distribution_checksum">
+    <sch:param name="context" value="dcat:Distribution"/>
+    <sch:param name="element" value="spdx:checksum"/>
+  </sch:pattern>
+
 </sch:schema>


### PR DESCRIPTION
A number of properties are marked as _removed_ in mobilityDCAT-AP. It is not clear to me whether this needs to handled strictly or not (see https://github.com/mobilityDCAT-AP/mobilityDCAT-AP/issues/156), so in the meanwhile I've added recommendation schematron checks to indicate potential issues. These could be refined in the future to indicate, per element, a recommended alternative.

<img width="799" height="866" alt="image" src="https://github.com/user-attachments/assets/b1b9a44b-cc6a-4290-b657-4b9e457fd7c5" />
