### PR TITLE
Mobility: BE NAP mandatory recommendations

### DIFF
--- a/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-mobility-rec.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/schematron-rules-dcat-ap-mobility-rec.xml
@@ -7,4 +7,10 @@
   <property.removed.title>De eigenschap #element in #context werd als verwijderd opgegeven in mobilityDCAT-AP.</property.removed.title>
   <property.removed.assert>De eigenschap #element werd gevonden in #context.</property.removed.assert>
   <property.removed.report>De eigenschap #element werd niet gevonden in #context.</property.removed.report>
+  <distribution.issued.mandatory.be.title>In het Belgische NAP wordt dct:issued als verplicht gezien. Indien dit record in een Belgische context gebruikt wordt is het aangeraden dit te volgen.</distribution.issued.mandatory.be.title>
+  <distribution.issued.mandatory.be.assert>Er werden ofwel geen, of meerdere, dct:issued elementen.</distribution.issued.mandatory.be.assert>
+  <distribution.issued.mandatory.be.report>Er werd exact één dct:issued element gevonden.</distribution.issued.mandatory.be.report>
+  <distribution.modified.mandatory.be.title>In het Belgische NAP wordt dct:modified als verplicht gezien. Indien dit record in een Belgische context gebruikt wordt is het aangeraden dit te volgen.</distribution.modified.mandatory.be.title>
+  <distribution.modified.mandatory.be.assert>Er werden ofwel geen, of meerdere, dct:modified elementen.</distribution.modified.mandatory.be.assert>
+  <distribution.modified.mandatory.be.report>Er werd exact één dct:modified element gevonden.</distribution.modified.mandatory.be.report>
 </strings>

--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-mobility-rec.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-mobility-rec.sch
@@ -36,6 +36,23 @@
     </sch:rule>
   </sch:pattern>
 
+  <!-- "Mandatory" properties in BE (NAP). These are not defined in a standard so they are highlighted in the recommendation section instead. -->
+  <sch:pattern id="distribution_issued_mandatory_be">
+    <sch:title>$loc/strings/distribution.issued.mandatory.be.title</sch:title>
+    <sch:rule context="dcat:Distribution">
+      <sch:assert test="count(dct:issued) = 1">$loc/strings/distribution.issued.mandatory.be.assert</sch:assert>
+      <sch:report test="count(dct:issued) = 1">$loc/strings/distribution.issued.mandatory.be.report</sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="distribution_modified_mandatory_be">
+    <sch:title>$loc/strings/distribution.modified.mandatory.be.title</sch:title>
+    <sch:rule context="dcat:Distribution">
+      <sch:assert test="count(dct:modified) = 1">$loc/strings/distribution.modified.mandatory.be.assert</sch:assert>
+      <sch:report test="count(dct:modified) = 1">$loc/strings/distribution.modified.mandatory.be.report</sch:report>
+    </sch:rule>
+  </sch:pattern>
+
+
   <!-- "Removed" properties in mobility are mentioned separately from the cardinalities as there is no consensus yet on whether these need to be dealt with as a strict removal. -->
   <sch:pattern abstract="true" id="PropertyRemovedCheck">
     <sch:title>geonet:replacePlaceholders($loc/strings/property.removed.title, ('#context', '#element'), ('$context', '$element'))</sch:title>


### PR DESCRIPTION
Some elements are considered mandatory in the BE NAP implementation of mobilityDCAT-AP. This PR adds those properties as a recommendations, awaiting the integration of an official application profile.