### PR TITLE
VL: adding conformsTo for oslo standards to dataset

### DIFF
--- a/src/main/plugin/dcat-ap/convert/thesaurus-transformation.xsl
+++ b/src/main/plugin/dcat-ap/convert/thesaurus-transformation.xsl
@@ -67,37 +67,39 @@
     <xsl:variable name="response">
       <gn_replace_all>
         <xsl:for-each select="//keyword">
-          <xsl:element name="{$wrapper}">
-            <skos:Concept>
-              <xsl:attribute name="rdf:about">
-                <xsl:value-of select="if (contains(uri, '@@@'))
+
+          <xsl:variable name="rdfAbout"
+                         select="if (contains(uri, '@@@'))
                                       then substring-after(uri, '@@@')
                                       else uri"/>
-              </xsl:attribute>
-              <xsl:variable name="keyword" select="."/>
-              <xsl:choose>
-                <xsl:when test="count($listOfLanguage) > 0">
-                  <xsl:for-each select="$listOfLanguage">
-                    <xsl:variable name="lang" select="."/>
-                    <xsl:if test="$lang != ''">
-                      <skos:prefLabel>
-                        <xsl:attribute name="xml:lang" select="util:twoCharLangCode($lang)"/>
 
-                        <xsl:variable name="labelValue" select="$keyword/values/value[@language = $lang]/text()"/>
-                        <xsl:value-of select="if ($labelValue) then $labelValue else $keyword/value"/>
-                      </skos:prefLabel>
-                    </xsl:if>
-                  </xsl:for-each>
-                </xsl:when>
-                <xsl:otherwise>
-                  <skos:prefLabel>
-                    <xsl:value-of select="$keyword/value/text()"/>
-                  </skos:prefLabel>
-                </xsl:otherwise>
-              </xsl:choose>
-              <skos:inScheme rdf:resource="{$inSchemeURI}"/>
-            </skos:Concept>
-          </xsl:element>
+          <xsl:choose>
+            <xsl:when test="$wrapper = 'dct:conformsTo'">
+              <dct:conformsTo>
+                <dct:Standard rdf:about="{$rdfAbout}">
+                  <dct:identifier><xsl:value-of select="$rdfAbout"/></dct:identifier>
+
+                  <xsl:call-template name="build-element-from-concept">
+                    <xsl:with-param name="elementName" select="'dct:title'"/>
+                    <xsl:with-param name="listOfLanguage" select="$listOfLanguage"/>
+                    <xsl:with-param name="keyword" select="."/>
+                  </xsl:call-template>
+                </dct:Standard>
+              </dct:conformsTo>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:element name="{$wrapper}">
+                <skos:Concept rdf:about="{$rdfAbout}">
+                  <xsl:call-template name="build-element-from-concept">
+                    <xsl:with-param name="elementName" select="'skos:prefLabel'"/>
+                    <xsl:with-param name="listOfLanguage" select="$listOfLanguage"/>
+                    <xsl:with-param name="keyword" select="."/>
+                  </xsl:call-template>
+                  <skos:inScheme rdf:resource="{$inSchemeURI}"/>
+                </skos:Concept>
+              </xsl:element>
+            </xsl:otherwise>
+          </xsl:choose>
         </xsl:for-each>
       </gn_replace_all>
     </xsl:variable>
@@ -105,6 +107,32 @@
     <xsl:copy-of select="$response"/>
   </xsl:template>
 
+
+  <xsl:template name="build-element-from-concept">
+    <xsl:param name="elementName" select="'skos:prefLabel'"/>
+    <xsl:param name="listOfLanguage"/>
+    <xsl:param name="keyword"/>
+    <xsl:choose>
+      <xsl:when test="count($listOfLanguage) > 0">
+        <xsl:for-each select="$listOfLanguage">
+          <xsl:variable name="lang" select="."/>
+          <xsl:if test="$lang != ''">
+            <xsl:element name="{$elementName}">
+              <xsl:attribute name="xml:lang" select="util:twoCharLangCode($lang)"/>
+
+              <xsl:variable name="labelValue" select="$keyword/values/value[@language = $lang]/text()"/>
+              <xsl:value-of select="if ($labelValue) then $labelValue else $keyword/value"/>
+            </xsl:element>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:element name="{$elementName}">
+          <xsl:value-of select="$keyword/value/text()"/>
+        </xsl:element>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 
   <xsl:template name="to-dcat-ap-concept-reference">
     <xsl:variable name="listOfLanguage"
@@ -138,6 +166,8 @@
         </xsl:for-each>
       </gn_replace_all>
     </xsl:variable>
+
+
     <xsl:copy-of select="$response"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -902,6 +902,17 @@
               max=""
               labelKey="dcat.addOSLOstandard"/>
           </field>
+          <action type="add"
+                  or="conformsTo"
+                  in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:conformsTo) = 0"
+          >
+            <template>
+              <snippet>
+                <dct:conformsTo/>
+              </snippet>
+            </template>
+          </action>
         </section>
 
         <section name="versionInformation">

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -893,9 +893,7 @@
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:conformsTo"
                  if="$p2 = ('DCAT-AP-VL', 'metadata-dcat')"
                  name="dct:conformsTo"
-                 or="theme"
-                 use="data-gn-keyword-picker"
-                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+                 use="data-gn-keyword-picker">
             <directiveAttributes
               thesaurus="external.theme.oslo-datastandaarden"
               xpath="/dct:conformsTo"
@@ -905,7 +903,7 @@
           <action type="add"
                   or="conformsTo"
                   in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
-                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:conformsTo) = 0"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:conformsTo) = 0 and $p2 = ('DCAT-AP-VL', 'metadata-dcat')"
           >
             <template>
               <snippet>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -57,6 +57,16 @@
         max="1"
         labelKey="dcat.addAccessRight"/>
     </for>
+    <!-- conformsTo is a particular case. skos:Concept are converted
+     to dct:Standard (see thesaurus-transformation.xsl).
+     Editor form XPath pointing to the element is hardcoded (see layout-custom-fields-concepts.xsl). -->
+    <for name="dct:conformsTo" xpath="dcat:Dataset" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.oslo-datastandaarden"
+        xpath="/dct:conformsTo"
+        labelKey="dct:conformsTo"
+      />
+    </for>
     <for name="dct:language" xpath="dcat:Catalog" use="thesaurus-list-picker">
       <directiveAttributes
         thesaurus="external.theme.language"
@@ -892,7 +902,6 @@
               max=""
               labelKey="dcat.addOSLOstandard"/>
           </field>
-
         </section>
 
         <section name="versionInformation">
@@ -1266,22 +1275,6 @@
                     <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
                   </skos:Concept>
                 </dct:language>
-              </snippet>
-            </template>
-          </action>
-
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:conformsTo"/>
-
-          <action type="add" or="conformsTo" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
-            <template>
-              <snippet>
-                <dct:conformsTo>
-                  <dct:Standard>
-                    <dct:identifier/>
-                    <dct:title xml:lang=""/>
-                    <dct:description xml:lang=""/>
-                  </dct:Standard>
-                </dct:conformsTo>
               </snippet>
             </template>
           </action>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -880,6 +880,19 @@
               labelKey="dcat.addVLThemes"/>
           </field>
 
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:conformsTo"
+                 if="$p2 = ('DCAT-AP-VL', 'metadata-dcat')"
+                 name="dct:conformsTo"
+                 or="theme"
+                 use="data-gn-keyword-picker"
+                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
+            <directiveAttributes
+              thesaurus="external.theme.oslo-datastandaarden"
+              xpath="/dct:conformsTo"
+              max=""
+              labelKey="dcat.addOSLOstandard"/>
+          </field>
+
         </section>
 
         <section name="versionInformation">

--- a/src/main/plugin/dcat-ap/layout/layout-custom-fields-concepts.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout-custom-fields-concepts.xsl
@@ -4,6 +4,7 @@
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 xmlns:skos="http://www.w3.org/2004/02/skos/core#"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:mobilitydcatap="https://w3id.org/mobilitydcat-ap"
                 xmlns:gn="http://www.fao.org/geonetwork"
                 xmlns:gn-fn-dcat-ap="http://geonetwork-opensource.org/xsl/functions/profiles/dcat-ap"
@@ -55,7 +56,7 @@
   <!-- Element using a thesaurus .-->
   <xsl:template mode="mode-dcat-ap"
                          priority="4000"
-                        match="*[(skos:Concept or @rdf:resource) and gn-fn-dcat-ap:getThesaurusConfig(name(), name(..))]|dcat:theme">
+                        match="*[(skos:Concept or @rdf:resource) and gn-fn-dcat-ap:getThesaurusConfig(name(), name(..))]|dcat:theme|dcat:Dataset/dct:conformsTo">
     <xsl:param name="config" required="no"/>
 
     <xsl:if test="not(preceding-sibling::*[1]) or preceding-sibling::*[1]/name() != current()/name()">
@@ -264,7 +265,7 @@
         <!-- When a thesaurus is used to encode an element with reference ie. rdf:resource,
         we can't target by thesaurusUri so we target the element created-->
         <xsl:choose>
-          <xsl:when test="$config/useReference = 'true'">
+          <xsl:when test="$config/useReference = 'true' or $config/xpath = '/dct:conformsTo'">
             <xsl:value-of select="concat($resourcePath, $config/xpath)"/>
           </xsl:when>
           <xsl:otherwise>


### PR DESCRIPTION
Included the OSLO thesaurus so the values can be used in `dct:conformsTo`, resulting in a `dct:Standard` child. This element is removed when saving twice though, so not in a working state yet.

The default behaviour results in the dropdown functioning, then adding the new property above. Possible improvement: 
- render the dropdown and selected values in the picker (modify `thesaurus-list-picker`?).
- this would generically add support for a `dct:Standard` that is built 


<img width="607" height="265" alt="image" src="https://github.com/user-attachments/assets/f5159445-b78a-4f2a-b803-271c0a2a105b" />
