### PR TITLE
Maintenance / Use PR head instead of premerge for tests in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up JDK 11
       uses: actions/setup-java@v4
@@ -52,6 +54,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Download GeoNetwork WAR
       uses: actions/download-artifact@v4

--- a/e2e/cypress/e2e/multilingual.cy.ts
+++ b/e2e/cypress/e2e/multilingual.cy.ts
@@ -10,7 +10,7 @@ describe('The multilingual functionality', () => {
 
   it('does not duplicate elements upon saving or navigating to other tabs', () => {
     cy.visit('/srv/eng/catalog.edit#/create')
-    cy.get('a').contains('Generieke Open data, conform DCAT-AP VL v2.0').click()
+    cy.get('a').contains('Generieke Open data, conform DCAT-AP-VL 2019-10-03').click()
     cy.get('button').contains('Create').click()
     // get the new metadata id from the location so we can query its xml content
     let hashRegexp = /^#\/metadata\/(\d+)\?.*/;


### PR DESCRIPTION
The default behaviour of the workflow would build and test the `pr branch`, merged into the `target branch`. This leads to unexpected results, e.g., if a template title was changed in `main` a PR that doesn't have that change yet will fail tests that depend on the changed template title.

See https://github.com/actions/checkout/blob/v3.0.2/README.md#user-content-checkout-pull-request-head-commit-instead-of-merge-commit for details. The new setting would build and test on the PR branch alone.