### PR TITLE
Mobility / Various fixes in editor and view

### DIFF
--- a/resources/thesauri/theme/mobility-conditions-for-access-and-usage.rdf
+++ b/resources/thesauri/theme/mobility-conditions-for-access-and-usage.rdf
@@ -21,51 +21,81 @@
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/contractual-arrangement">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
     <skos:prefLabel xml:lang="en">Contractual arrangement</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Contractuele regeling</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Vertragliche Vereinbarung</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Accord contractuel</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/contractual-arrangement-fee-required">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
     <skos:prefLabel xml:lang="en">Contractual arrangement, fee required</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Contractuele regeling, vergoeding vereist</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Vertragliche Vereinbarung, Gebühr erforderlich</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Accord contractuel, frais requis</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/contractual-arrangement-free-of-charge">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
     <skos:prefLabel xml:lang="en">Contractual arrangement, free of charge</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Contractuele regeling, kosteloos</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Vertragliche Vereinbarung, kostenlos</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Accord contractuel, gratuit</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/fee-required">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
     <skos:prefLabel xml:lang="en">Fee required</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Vergoeding vereist</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Gebühr erforderlich</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Frais requis</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/free-of-charge">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
     <skos:prefLabel xml:lang="en">Free of charge</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Kosteloos</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Kostenlos</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Gratuit</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
     <skos:prefLabel xml:lang="en">Licence provided</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Licentie verstrekt</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Lizenz bereitgestellt</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Licence fournie</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided-fee-required">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
     <skos:prefLabel xml:lang="en">Licence provided, fee required</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Licentie verstrekt, vergoeding vereist</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Lizenz bereitgestellt, Gebühr erforderlich</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Licence fournie, frais requis</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided-free-of-charge">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
     <skos:prefLabel xml:lang="en">Licence provided, free of charge</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Licentie verstrekt, kosteloos</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Lizenz bereitgestellt, kostenlos</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Licence fournie, gratuite</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/other">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
     <skos:prefLabel xml:lang="en">Other</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Overige</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Sonstiges</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Autre</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
   </skos:Concept>
   <skos:Concept rdf:about="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/royalty-free">
     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
     <skos:prefLabel xml:lang="en">Royalty-free</skos:prefLabel>
+    <skos:prefLabel xml:lang="nl">Royaltyvrij</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Lizenzgebührenfrei</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Sans redevance</skos:prefLabel>
     <skos:topConceptOf rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" />
   </skos:Concept>
 </rdf:RDF>

--- a/resources/thesauri/theme/mobility-data-standard.rdf
+++ b/resources/thesauri/theme/mobility-data-standard.rdf
@@ -51,6 +51,9 @@
                         rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-data-standard/ocit-c"/>
     <skos:hasTopConcept
       xmlns:terms="http://purl.org/dc/terms/"
+                        rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-data-standard/ocpi"/>
+    <skos:hasTopConcept
+      xmlns:terms="http://purl.org/dc/terms/"
                         rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-data-standard/other"/>
     <skos:hasTopConcept
       xmlns:terms="http://purl.org/dc/terms/"
@@ -192,6 +195,18 @@
                    rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-data-standard"/>
     <skos:prefLabel
       xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">OCIT-C
+    </skos:prefLabel>
+    <skos:topConceptOf
+      xmlns:terms="http://purl.org/dc/terms/"
+                       rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-data-standard"/>
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                rdf:about="https://w3id.org/mobilitydcat-ap/mobility-data-standard/ocpi">
+    <skos:inScheme
+      xmlns:terms="http://purl.org/dc/terms/"
+                   rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-data-standard"/>
+    <skos:prefLabel
+      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">OCPI
     </skos:prefLabel>
     <skos:topConceptOf
       xmlns:terms="http://purl.org/dc/terms/"

--- a/resources/thesauri/theme/mobility-intended-information-service.rdf
+++ b/resources/thesauri/theme/mobility-intended-information-service.rdf
@@ -21,45 +21,72 @@
     <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
     <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Dynamic availability check</skos:prefLabel>
     <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Dynamische beschikbaarheidscontrole</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Dynamische Verfügbarkeitsprüfung</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Vérification dynamique de disponibilité</skos:prefLabel>
   </skos:Concept>
   <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-information-service">
     <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
     <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Dynamic Information service</skos:prefLabel>
     <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Dynamische informatiedienst</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Dynamischer Informationsdienst</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Service d'information dynamique</skos:prefLabel>
   </skos:Concept>
   <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-passing-times-trip-plans-and-auxiliary-information">
     <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
     <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Dynamic Passing times, trip plans and auxiliary information</skos:prefLabel>
     <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Dynamische doorkomsttijden, reisplannen en aanvullende informatie</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Dynamische Durchfahrtszeiten, Reisepläne und Zusatzinformationen</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Heures de passage dynamiques, plans de trajet et informations auxiliaires</skos:prefLabel>
   </skos:Concept>
   <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/information-service">
     <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
     <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Information service</skos:prefLabel>
     <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Informatiedienst</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Informationsdienst</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Service d'information</skos:prefLabel>
   </skos:Concept>
   <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/location-search">
     <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
     <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Location search</skos:prefLabel>
     <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Localisatieservice</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Standortsuche</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Recherche de localisation</skos:prefLabel>
   </skos:Concept>
   <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/other">
     <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
     <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Other</skos:prefLabel>
     <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Overige</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Sonstiges</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Autre</skos:prefLabel>
   </skos:Concept>
   <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plan-computation-scheduled-modes-transport">
     <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
     <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Trip plan computation scheduled modes transport</skos:prefLabel>
     <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Reisplanberekening voor geplande vervoersmodi</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Reiseplanberechnung für geplante Verkehrsmodi</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Calcul d'itinéraires pour modes de transport planifiés</skos:prefLabel>
   </skos:Concept>
   <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plans">
     <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
     <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Trip plans</skos:prefLabel>
     <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Reisplannen</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Reisepläne</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Plans de trajet</skos:prefLabel>
   </skos:Concept>
   <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plans-auxiliary-information-availability-check">
     <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
     <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Trip plans, auxiliary information, availability check</skos:prefLabel>
     <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
-</skos:Concept>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="nl">Reisplannen, aanvullende informatie, beschikbaarheidscontrole</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="de">Reisepläne, Zusatzinformationen, Verfügbarkeitsprüfung</skos:prefLabel>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="fr">Plans de trajet, informations auxiliaires, vérification de disponibilité</skos:prefLabel>
+  </skos:Concept>
 </rdf:RDF>

--- a/resources/thesauri/theme/mobility-intended-information-service.rdf
+++ b/resources/thesauri/theme/mobility-intended-information-service.rdf
@@ -1,162 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <skos:ConceptScheme xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                      rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service">
-    <terms:creator xmlns:terms="http://purl.org/dc/terms/"
-                   xml:lang="en">Mario Scrocca (Cefriel)
-    </terms:creator>
-    <terms:creator xmlns:terms="http://purl.org/dc/terms/"
-                   xml:lang="en">Peter Lubrich (BASt)
-    </terms:creator>
-    <terms:description xmlns:terms="http://purl.org/dc/terms/"
-                       xml:lang="en">Controlled vocabulary describing the intended information service for a dataset.
-    </terms:description>
-    <terms:license xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-    <terms:publisher xmlns:terms="http://purl.org/dc/terms/"
-                     xml:lang="en">NAPCORE SubWG4.4
-    </terms:publisher>
-    <terms:title xmlns:terms="http://purl.org/dc/terms/"
-                 xml:lang="en">Intended information service
-    </terms:title>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-availability-check"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-information-service"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-passing-times-trip-plans-and-auxiliary-information"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/information-service"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/location-search"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/other"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plan-computation-scheduled-modes-transport"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plans"/>
-    <skos:hasTopConcept
-      xmlns:terms="http://purl.org/dc/terms/"
-                        rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plans-auxiliary-information-availability-check"/>
+  <skos:ConceptScheme xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service">
+    <terms:creator xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Mario Scrocca (Cefriel) </terms:creator>
+    <terms:creator xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Peter Lubrich (BASt) </terms:creator>
+    <terms:description xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Controlled vocabulary describing the intended information service for a dataset.</terms:description>
+    <terms:license xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+    <terms:publisher xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">NAPCORE SubWG4.4 </terms:publisher>
+    <terms:title xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Intended information service</terms:title>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-availability-check"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-information-service"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-passing-times-trip-plans-and-auxiliary-information"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/information-service"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/location-search"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/other"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plan-computation-scheduled-modes-transport"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plans"/>
+    <skos:hasTopConcept xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plans-auxiliary-information-availability-check"/>
   </skos:ConceptScheme>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-availability-check">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Dynamic availability check
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-availability-check">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Dynamic availability check</skos:prefLabel>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-information-service">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Dynamic Information service
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-information-service">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Dynamic Information service</skos:prefLabel>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-passing-times-trip-plans-and-auxiliary-information">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Dynamic Passing times, trip plans and
-      auxiliary information
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/dynamic-passing-times-trip-plans-and-auxiliary-information">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Dynamic Passing times, trip plans and auxiliary information</skos:prefLabel>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/information-service">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Information service
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/information-service">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Information service</skos:prefLabel>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/location-search">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Location search
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/location-search">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Location search</skos:prefLabel>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/other">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Other
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/other">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Other</skos:prefLabel>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plan-computation-scheduled-modes-transport">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Trip plan computation scheduled modes
-      transport
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plan-computation-scheduled-modes-transport">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Trip plan computation scheduled modes transport</skos:prefLabel>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plans">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Trip plans
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-                       rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plans">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Trip plans</skos:prefLabel>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
   </skos:Concept>
-  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plans-auxiliary-information-availability-check">
-    <skos:inScheme
-      xmlns:terms="http://purl.org/dc/terms/"
-                   rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
-    <skos:prefLabel
-      xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Trip plans, auxiliary information,
-      availability check
-    </skos:prefLabel>
-    <skos:topConceptOf
-      xmlns:terms="http://purl.org/dc/terms/"
-      rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
-  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://w3id.org/mobilitydcat-ap/intended-information-service/trip-plans-auxiliary-information-availability-check">
+    <skos:inScheme xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+    <skos:prefLabel xmlns:terms="http://purl.org/dc/terms/" xml:lang="en">Trip plans, auxiliary information, availability check</skos:prefLabel>
+    <skos:topConceptOf xmlns:terms="http://purl.org/dc/terms/" rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
+</skos:Concept>
 </rdf:RDF>
-

--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -653,7 +653,7 @@
         <td style="{$tdStyle}">
           <xsl:apply-templates mode="render-url" select="oa:hasBody/@rdf:resource" />
           <xsl:if test="dct:issued">
-            (<xsl:value-of select="gn-fn-metadata:getLabel($schema, 'dct:issued', $labels)/label "/><xsl:value-of select="' '"/><xsl:value-of select="dct:issued"/>)
+            <br/>(<xsl:value-of select="gn-fn-metadata:getLabel($schema, 'dct:issued', $labels)/label "/><xsl:value-of select="' '"/><xsl:value-of select="dct:issued"/>)
           </xsl:if>
         </td>
       </tr>

--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -718,8 +718,8 @@
   </xsl:template>
 
   <!-- render nested content, with the header left of the table -->
-  <xsl:template mode="render-field" match="dcat:contactPoint|dct:publisher/foaf:Agent|dct:publisher|dct:rightsHolder|dct:provenance|foaf:page|dct:temporal|
-                                           dct:license|dct:rights|dct:conformsTo|dcat:distribution|adms:sample|
+  <xsl:template mode="render-field" match="dcat:contactPoint|dct:rights/dct:RightsStatement|dct:publisher/foaf:Agent|dct:publisher|dct:rightsHolder|dct:provenance|foaf:page|dct:temporal|
+                                           dct:license|dct:conformsTo|dcat:distribution|adms:sample|
                                            vcard:hasAddress|adms:identifier|dct:creator|dcat:qualifiedRelation|adms:Identifier|geodcatap:referenceSystem">
     <xsl:param name="xpath"/>
     <xsl:variable name="stringValue" select="string()"/>

--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -719,7 +719,7 @@
 
   <!-- render nested content, with the header left of the table -->
   <xsl:template mode="render-field" match="dcat:contactPoint|dct:rights/dct:RightsStatement|dct:publisher/foaf:Agent|dct:publisher|dct:rightsHolder|dct:provenance|foaf:page|dct:temporal|
-                                           dct:license|dct:conformsTo|dcat:distribution|adms:sample|
+                                           dct:license|dct:conformsTo/dct:Standard|dcat:distribution|adms:sample|
                                            vcard:hasAddress|adms:identifier|dct:creator|dcat:qualifiedRelation|adms:Identifier|geodcatap:referenceSystem">
     <xsl:param name="xpath"/>
     <xsl:variable name="stringValue" select="string()"/>

--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -469,7 +469,7 @@
   <xsl:template mode="render-field" match="dct:LicenseDocument/dct:identifier"/>
 
   <!-- Field with lang : display only field of current lang or first one if not exist -->
-  <xsl:template mode="render-field" match="dct:title|dct:description|foaf:name|adms:versionNotes|foaf:firstName|foaf:surname|cnt:characterEncoding">
+  <xsl:template mode="render-field" match="dct:title|dct:description|foaf:name|adms:versionNotes|foaf:firstName|foaf:surname|cnt:characterEncoding|mobilitydcatap:dataFormatNotes">
     <xsl:param name="xpath"/>
     <xsl:variable name="stringValue" select="string()"/>
     <xsl:variable name="name" select="name()"/>

--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -718,7 +718,7 @@
   </xsl:template>
 
   <!-- render nested content, with the header left of the table -->
-  <xsl:template mode="render-field" match="dcat:contactPoint|dct:publisher|dct:rightsHolder|dct:provenance|foaf:page|dct:temporal|
+  <xsl:template mode="render-field" match="dcat:contactPoint|dct:publisher/foaf:Agent|dct:publisher|dct:rightsHolder|dct:provenance|foaf:page|dct:temporal|
                                            dct:license|dct:rights|dct:conformsTo|dcat:distribution|adms:sample|
                                            vcard:hasAddress|adms:identifier|dct:creator|dcat:qualifiedRelation|adms:Identifier|geodcatap:referenceSystem">
     <xsl:param name="xpath"/>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -1054,7 +1054,6 @@
                   <dct:RightsStatement>
                     <dct:title/>
                     <dct:description/>
-                    <dct:type/>
                   </dct:RightsStatement>
                 </dct:rights>
               </snippet>

--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -156,9 +156,9 @@
     <btnLabel>Licentie Document</btnLabel>
   </element>
   <element name="dct:Location">
-    <label>Locatie</label>
-    <description>Locatie</description>
-    <btnLabel>Locatie</btnLabel>
+    <label>Ruimtelijke begrenzing</label>
+    <description>Ruimtelijke begrenzing</description>
+    <btnLabel>Ruimtelijke begrenzing</btnLabel>
   </element>
   <element name="dct:PeriodOfTime">
     <label>Begrenzing</label>

--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -171,9 +171,9 @@
     <btnLabel>Herkomstbeschrijving</btnLabel>
   </element>
   <element name="dct:RightsStatement">
-    <label>Bepaling</label>
-    <description>Bepaling</description>
-    <btnLabel>Bepaling</btnLabel>
+    <label>Rechtenverklaring</label>
+    <description>Rechtenverklaring</description>
+    <btnLabel>Rechtenverklaring</btnLabel>
   </element>
   <element name="dct:Standard">
     <label>Standaard</label>

--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -175,6 +175,11 @@
     <description>Rechtenverklaring</description>
     <btnLabel>Rechtenverklaring</btnLabel>
   </element>
+  <element name="dct:Standard" context="dct:conformsTo">
+    <label>Conformiteit met standaard</label>
+    <description>Conformiteit met standaard</description>
+    <btnLabel>Conformiteit met standaard</btnLabel>
+  </element>
   <element name="dct:Standard">
     <label>Standaard</label>
     <description>Standaard</description>

--- a/src/main/plugin/dcat-ap/loc/eng/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/labels.xml
@@ -175,6 +175,11 @@
     <description>A statement about the intellectual property rights (IPR) held in or over a resource, a legal document giving official permission to do something with a resource, or a statement about access rights.</description>
     <btnLabel>Rights statement</btnLabel>
   </element>
+  <element name="dct:Standard" context="dct:conformsTo">
+    <label>Conformity to standard</label>
+    <description>Conformity to standard</description>
+    <btnLabel>Conformity to standard</btnLabel>
+  </element>
   <element name="dct:Standard">
     <label>Standard</label>
     <description>A reference point against which other things can be evaluated or compared.</description>

--- a/src/main/plugin/dcat-ap/loc/fre/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/labels.xml
@@ -175,6 +175,11 @@
     <description>A statement about the intellectual property rights (IPR) held in or over a resource, a legal document giving official permission to do something with a resource, or a statement about access rights.</description>
     <btnLabel>Rights statement</btnLabel>
   </element>
+  <element name="dct:Standard" context="dct:conformsTo">
+    <label>Conformité aux normes</label>
+    <description>Conformité aux normes</description>
+    <btnLabel>Conformité aux normes</btnLabel>
+  </element>
   <element name="dct:Standard">
     <label>Standard</label>
     <description>A reference point against which other things can be evaluated or compared.</description>

--- a/src/main/plugin/dcat-ap/loc/ger/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/labels.xml
@@ -392,9 +392,9 @@
     <btnLabel>Conforms To</btnLabel>
   </element>
   <element name="dct:Standard" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:conformsTo/dct:Standard">
-    <label>standard</label>
-    <description>Tooltip: standard</description>
-    <btnLabel>standard</btnLabel>
+    <label>Konformität mit dem Standard</label>
+    <description>Konformität mit dem Standard</description>
+    <btnLabel>Konformität mit dem Standard</btnLabel>
   </element>
   <element name="rdf:about" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:conformsTo/dct:Standard/@rdf:about">
     <label>URI</label>


### PR DESCRIPTION
displaying dataFormatNotes
<img width="487" height="148" alt="image" src="https://github.com/user-attachments/assets/7c3ce8b4-10f3-4ebf-ac69-054dc40bdc6d" />

displaying assessment result `dct:issued` on a newline (a bit cleaner)
<img width="427" height="149" alt="image" src="https://github.com/user-attachments/assets/f268367f-e537-4681-b547-2cf22741bd65" />

showing publisher in nested table
<img width="519" height="108" alt="image" src="https://github.com/user-attachments/assets/ffdf4a1e-f5ef-4467-9977-aecbb6ebe07a" />

fixed empty tag in RightsStatement when adding a new one
<img width="181" height="71" alt="image" src="https://github.com/user-attachments/assets/245d3563-825d-40a8-acb3-d08a74aa2805" />
<img width="192" height="395" alt="image" src="https://github.com/user-attachments/assets/0a98e11d-7003-493c-8f2c-a354485b7b7c" />
<img width="472" height="158" alt="image" src="https://github.com/user-attachments/assets/3df7fe28-4583-4b02-a5f8-4fcc70f3ce38" />

updated NL label for dct:Location
<img width="311" height="161" alt="image" src="https://github.com/user-attachments/assets/2b90cc7f-278b-42a3-af0d-aa4df736f3d0" />

fixed dct:rights/dct:RightsStatement view
<img width="589" height="149" alt="image" src="https://github.com/user-attachments/assets/42ce3557-b7b9-4251-afc6-e573cfd4cbd1" />

standard conformity was cleaned up (now not in double nested table)
<img width="668" height="227" alt="image" src="https://github.com/user-attachments/assets/d693e29c-4a55-4db8-98a1-82b07f72ca08" />

added ocpi to mobility-data-standard thesaurus
<img width="229" height="181" alt="image" src="https://github.com/user-attachments/assets/d3ca6ca0-0d72-4980-8bfa-ccadee511093" />

added missing prefLabels for mobility-conditions-for-access-and-usage
<img width="357" height="440" alt="image" src="https://github.com/user-attachments/assets/798933aa-2cc3-459f-b792-47be56e7ca95" />

added missing prefLabels for mobility-intended-information-service
<img width="440" height="138" alt="image" src="https://github.com/user-attachments/assets/3b1c685e-a85a-4109-845f-a1e964399ce7" />

