### PR TITLE
Mobility / Removed recommended check on dcat:DataService/dcat:theme

### DIFF
--- a/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-mobility-rec.sch
+++ b/src/main/plugin/dcat-ap/schematron/schematron-rules-dcat-ap-mobility-rec.sch
@@ -29,7 +29,7 @@
 
   <sch:pattern id="recommended_theme">
     <sch:title>$loc/strings/recommended.dcat_theme_tran.title</sch:title>
-    <sch:rule context="//dcat:Dataset|//dcat:DataService">
+    <sch:rule context="//dcat:Dataset">
       <sch:let name="tranDcatTheme" value="dcat:theme[skos:Concept/@rdf:about='http://vocab.belgif.be/auth/datatheme/TRAN' or skos:Concept/@rdf:about='http://publications.europa.eu/resource/authority/data-theme/TRAN']"/>
       <sch:assert test="count($tranDcatTheme) = 1">$loc/strings/recommended.dcat_theme_tran.assert</sch:assert>
       <sch:report test="count($tranDcatTheme) = 1">$loc/strings/recommended.dcat_theme_tran.report</sch:report>


### PR DESCRIPTION
As DataService has no dcat:theme in mobility, the recommended TRAN check for it made no sense. Removing it here.

- https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/1.1.0/index.html#properties-for-data-service does not mention it
- DCAT 2.0.1 does not mention it
- https://semiceu.github.io/DCAT-AP/releases/3.0.1-draft/#DataService.theme mentioned the theme
- https://mobilitydcat-ap.github.io/mobilityDCAT-AP/drafts/latest/index.html#dcat-ap-removed-classes explicitly removes DataService, so for sure not applicable here