### PR TITLE
Schema / Removed dcat:Dataset/dct:rights

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -1046,21 +1046,6 @@
             </template>
           </action>
 
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:rights"/>
-          <action type="add" or="rights" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
-            <template>
-              <snippet>
-                <dct:rights>
-                  <dct:RightsStatement>
-                    <dct:title/>
-                    <dct:description/>
-                  </dct:RightsStatement>
-                </dct:rights>
-              </snippet>
-            </template>
-          </action>
-
-
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:rightsHolder"/>
           <action type="add" or="rightsHolder" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
                   if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:rightsHolder) = 0">

--- a/src/main/plugin/dcat-ap/schema/dcat.xsd
+++ b/src/main/plugin/dcat-ap/schema/dcat.xsd
@@ -85,7 +85,6 @@
           <xs:element ref="dct:modified" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="dct:publisher" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="dct:relation" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="dct:rights" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="dct:spatial" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="dct:title" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="dct:type" minOccurs="0" maxOccurs="unbounded"/>


### PR DESCRIPTION
The currently supported application profiles do not describe `dct:rights` in a `dcat:Dataset`. This change makes sure it cannot be added through the editor.