### PR TITLE
Associated resource / Add dcat:prev support.

### DIFF
--- a/src/main/java/org/fao/geonet/schema/dcatap/DCATAPSchemaPlugin.java
+++ b/src/main/java/org/fao/geonet/schema/dcatap/DCATAPSchemaPlugin.java
@@ -143,24 +143,24 @@ public class DCATAPSchemaPlugin extends SchemaPlugin implements AssociatedResour
     /**
      * For next records, resolve dcat:next elements
      */
-    private Set<AssociatedResource> getAssociatedNext(Element metadata) {
-        Set<AssociatedResource> results = getAssociatedResourcesByXpath(metadata, "*//dcat:next/@rdf:resource");
+    private Set<AssociatedResource> getAssociatedPrevious(Element metadata) {
+        Set<AssociatedResource> results = getAssociatedResourcesByXpath(metadata, "*//dcat:prev/@rdf:resource");
         return results.stream()
-            .peek(ar -> ar.setAssociationType("nextResource"))
+            .peek(ar -> ar.setAssociationType("revisionOf"))
             .collect(Collectors.toSet());
     }
 
     /**
      * For previous records, find datasets that point to the current one with a dcat:next
      */
-    private Set<AssociatedResource> getAssociatedPrevious(Element metadata) {
+    private Set<AssociatedResource> getAssociatedNext(Element metadata) {
         try {
             String currentUuid = getCurrentUuid(metadata);
             if (currentUuid == null) {
                 return Collections.emptySet();
             }
             var searchManager = ApplicationContextHolder.get().getBean(EsSearchManager.class);
-            var response = searchManager.query(String.format("+nextUUIDInSeries:\"%s\"", currentUuid), null,
+            var response = searchManager.query(String.format("+previousUUIDInSeries:\"%s\"", currentUuid), null,
                 Sets.newHashSet("uuid", "resourceTitleObject.default"), 0, 100);
 
             if (response.hits().hits().isEmpty()) {
@@ -175,7 +175,7 @@ public class DCATAPSchemaPlugin extends SchemaPlugin implements AssociatedResour
                 AssociatedResource ar = new AssociatedResource(
                     (String) associatedRecord.get("uuid"),
                     "",
-                    "previousResource",
+                    "nextResource",
                     null,
                     ((Map<String, String>) associatedRecord.get("resourceTitleObject")).get("default")
                 );
@@ -183,7 +183,7 @@ public class DCATAPSchemaPlugin extends SchemaPlugin implements AssociatedResour
             }
             return res;
         } catch (Exception e) {
-            Log.error(Log.JEEVES, "GET associated previous resources error: " + e.getMessage(), e);
+            Log.error(Log.JEEVES, "GET associated next resources error: " + e.getMessage(), e);
         }
         return Collections.emptySet();
     }

--- a/src/main/plugin/dcat-ap/config/associated-panel/default.json
+++ b/src/main/plugin/dcat-ap/config/associated-panel/default.json
@@ -37,6 +37,12 @@
                 "isTemplate": "n"
               },
               "searchParamsPerType": {
+                "revisionOf-*": {
+                  "type": [
+                    "dataset",
+                    "service"
+                  ]
+                },
                 "nextResource-*": {
                   "type": [
                     "dataset",

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -307,6 +307,11 @@
             <xsl:value-of select="dcatutil:getUUIDByURI(normalize-space(@rdf:resource))"/>
           </nextUUIDInSeries>
         </xsl:for-each>
+        <xsl:for-each select="dcat:prev[normalize-space(@rdf:resource) != '']">
+          <previousUUIDInSeries>
+            <xsl:value-of select="dcatutil:getUUIDByURI(normalize-space(@rdf:resource))"/>
+          </previousUUIDInSeries>
+        </xsl:for-each>
         <!-- Index more fields in this element -->
         <xsl:apply-templates mode="index-extra-fields" select="."/>
       </doc>

--- a/src/main/plugin/dcat-ap/loc/dut/codelists.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/codelists.xml
@@ -25,10 +25,15 @@
 
 <codelists>
   <codelist name="dcat:Resource" alias="associationType">
-    <entry>
+    <!--<entry>
       <code>nextResource</code>
-      <label>Volgende resource</label>
-      <description>Volgende resource in reeks</description>
+      <label>Volgende Resource</label>
+      <description>Volgende Resource in reeks</description>
+    </entry>-->
+    <entry>
+      <code>revisionOf</code>
+      <label>Vorherige Resource</label>
+      <description>Vorherige Resource in series</description>
     </entry>
   </codelist>
 </codelists>

--- a/src/main/plugin/dcat-ap/loc/eng/codelists.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/codelists.xml
@@ -25,10 +25,15 @@
 
 <codelists>
   <codelist name="dcat:Resource" alias="associationType">
-    <entry>
+    <!--<entry>
       <code>nextResource</code>
       <label>Next resource</label>
       <description>Next resource in series</description>
+    </entry>-->
+    <entry>
+      <code>revisionOf</code>
+      <label>Previous resource</label>
+      <description>Previous resource in series</description>
     </entry>
   </codelist>
 </codelists>

--- a/src/main/plugin/dcat-ap/loc/fre/codelists.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/codelists.xml
@@ -25,10 +25,15 @@
 
 <codelists>
   <codelist name="dcat:Resource" alias="associationType">
-    <entry>
+    <!--<entry>
       <code>nextResource</code>
-      <label>Ressource suivante</label>
+      <label>Version suivante</label>
       <description>Ressource suivante dans la série</description>
+    </entry>-->
+    <entry>
+      <code>revisionOf</code>
+      <label>Version précédente</label>
+      <description>Ressource précédente dans la série</description>
     </entry>
   </codelist>
 </codelists>

--- a/src/main/plugin/dcat-ap/loc/ger/codelists.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/codelists.xml
@@ -25,10 +25,15 @@
 
 <codelists>
   <codelist name="dcat:Resource" alias="associationType">
-    <entry>
+    <!--<entry>
       <code>nextResource</code>
       <label>Nächste Ressource</label>
       <description>Nächste Ressource in der Reihe</description>
+    </entry>-->
+    <entry>
+      <code>revisionOf</code>
+      <label>Vorherige Ressource</label>
+      <description>Vorherige Ressource in series</description>
     </entry>
   </codelist>
 </codelists>

--- a/src/main/plugin/dcat-ap/process/sibling-add.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-add.xsl
@@ -81,7 +81,7 @@
     </xsl:for-each>
   </xsl:template>
 
-  <xsl:template match="*[name() = ('dcat:Dataset', 'dcat:DataService', 'dcat:DatasetSeries') and $associationType = 'nextResource']">
+  <xsl:template match="*[name() = ('dcat:Dataset', 'dcat:DataService', 'dcat:DatasetSeries') and $associationType = ('nextResource', 'revisionOf')]">
     <xsl:variable name="resourceWithNext">
       <xsl:copy>
         <xsl:copy-of select="@*"/>
@@ -102,10 +102,11 @@
             </xsl:if>
           </xsl:for-each>
         </xsl:variable>
+
         <xsl:for-each select="$uriToAdd">
-          <dcat:next>
+          <xsl:element name="{if ($associationType = 'nextResource') then 'dcat:next' else 'dcat:prev'}">
             <xsl:attribute name="rdf:resource" select="uri"/>
-          </dcat:next>
+          </xsl:element>
         </xsl:for-each>
       </xsl:copy>
     </xsl:variable>

--- a/src/main/plugin/dcat-ap/process/sibling-remove.xsl
+++ b/src/main/plugin/dcat-ap/process/sibling-remove.xsl
@@ -20,6 +20,7 @@
                                      dcat:CatalogRecord[starts-with(@rdf:about, 'http') and @rdf:about = $uuidref]"/>
 
   <xsl:template match="dcat:next[@rdf:resource = $uriRef]"/>
+  <xsl:template match="dcat:prev[@rdf:resource = $uriRef]"/>
 
   <xsl:template match="@*|*|text()">
     <xsl:copy>


### PR DESCRIPTION
* `dcat:next` is replaced by `dcat:prev`
* Relationship can be navigated in both direction

<img width="689" height="743" alt="image" src="https://github.com/user-attachments/assets/62b3a133-eb18-4554-9af9-210e3afe54fb" />


<img width="375" height="475" alt="image" src="https://github.com/user-attachments/assets/5fa5d2dd-8974-4e30-ae37-3bcf24732d04" />


* `revisionOf` is used in codelist (to mimic ISO)