### PR TITLE
Mobility / XSD issues

### DIFF
--- a/src/main/plugin/dcat-ap/convert/thesaurus-transformation.xsl
+++ b/src/main/plugin/dcat-ap/convert/thesaurus-transformation.xsl
@@ -87,6 +87,18 @@
                 </dct:Standard>
               </dct:conformsTo>
             </xsl:when>
+            <xsl:when test="$wrapper = 'mobilitydcatap:mobilityDataStandard'">
+              <mobilitydcatap:mobilityDataStandard>
+                <mobilitydcatap:MobilityDataStandard rdf:about="{$rdfAbout}">
+                  <dct:identifier><xsl:value-of select="$rdfAbout"/></dct:identifier>
+                  <xsl:call-template name="build-element-from-concept">
+                    <xsl:with-param name="elementName" select="'dct:title'"/>
+                    <xsl:with-param name="listOfLanguage" select="$listOfLanguage"/>
+                    <xsl:with-param name="keyword" select="."/>
+                  </xsl:call-template>
+                </mobilitydcatap:MobilityDataStandard>
+              </mobilitydcatap:mobilityDataStandard>
+            </xsl:when>
             <xsl:otherwise>
               <xsl:element name="{$wrapper}">
                 <skos:Concept rdf:about="{$rdfAbout}">

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -590,9 +590,12 @@
     <name>spdx:Checksum</name>
     <name>mobilitydcatap:mobilityDataStandard</name>
     <name>mobilitydcatap:assessmentResult</name>
+    <name>mobilitydcatap:Assessment</name>
     <name>dqv:hasQualityAnnotation</name>
+    <name>dqv:QualityAnnotation</name>
     <name>geodcatap:referenceSystem</name>
     <name>locn:address</name>
+    <name>locn:Address</name>
   </fieldsWithFieldset>
 
   <multilingualFields>
@@ -629,6 +632,7 @@
       <name>dct:spatial</name>
       <name>dct:type</name>
       <name>dct:accrualPeriodicity</name>
+      <name>dqv:hasQualityAnnotation</name>
       <name>foaf:Agent</name>
       <name>foaf:Document</name>
       <name>foaf:primaryTopic</name>
@@ -641,11 +645,13 @@
       <name>skos:inScheme</name>
       <name>skos:notation</name>
       <name>mdcat:stars</name>
+      <name>mobilitydcatap:assessmentResult</name>
       <name>mobilitydcatap:mobilityDataStandard</name>
       <name>dcat:version</name>
       <name>dcat:hasVersion</name>
       <name>dcat:isVersionOf</name>
       <name>locn:address</name>
+      <name>locn:Address</name>
       <name>locn:fullAddress</name>
       <name>locn:poBox</name>
       <name>locn:thoroughfare</name>
@@ -1266,10 +1272,34 @@
           </action>
 
 
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mobilitydcatap:assessmentResult"
-                    or="assessmentResult" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dqv:hasQualityAnnotation"
-                    or="hasQualityAnnotation" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mobilitydcatap:assessmentResult"/>
+          <action type="add" or="assessmentResult" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mobilitydcatap:assessmentResult) = 0">
+            <template>
+              <snippet>
+                <mobilitydcatap:assessmentResult>
+                  <mobilitydcatap:Assessment>
+                    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"/>
+                    <oa:hasBody rdf:resource=""/>
+                  </mobilitydcatap:Assessment>
+                </mobilitydcatap:assessmentResult>
+              </snippet>
+            </template>
+          </action>
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dqv:hasQualityAnnotation"/>
+          <action type="add" or="hasQualityAnnotation" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
+                  if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dqv:hasQualityAnnotation) = 0">
+            <template>
+              <snippet>
+                <dqv:hasQualityAnnotation>
+                  <dqv:QualityAnnotation>
+                    <oa:hasBody rdf:resource=""/>
+                  </dqv:QualityAnnotation>
+                </dqv:hasQualityAnnotation>
+              </snippet>
+            </template>
+          </action>
         </section>
 
         <section name="extraInformation">
@@ -2235,7 +2265,8 @@
         <for name="foaf:Agent/foaf:firstName"/>
         <for name="foaf:Agent/foaf:surname"/>
         <for name="foaf:Agent/foaf:phone"/>
-        <for name="foaf:Agent/locn:address"/>
+        <for name="locn:address"/>
+        <for name="locn:Address"/>
         <for name="locn:fullAddress"/>
         <for name="locn:poBox"/>
         <for name="locn:thoroughfare"/>
@@ -2273,6 +2304,7 @@
         <for name="mobilitydcatap:mobilityDataStandard/dct:conformsTo"/>
         <for name="mobilitydcatap:mobilityDataStandard/mobilitydcatap:schema"/>
         <for name="mobilitydcatap:assessmentResult"/>
+        <for name="mobilitydcatap:Assessment"/>
         <for name="mobilitydcatap:dataFormatNotes"/>
         <for name="dqv:hasQualityAnnotation"/>
         <for name="geodcatap:referenceSystem"/>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -67,12 +67,12 @@
         labelKey="dct:conformsTo"
       />
     </for>
-    <for name="dct:conformsTo" xpath="mobilitydcatap:mobilityDataStandard" use="thesaurus-list-picker">
+    <for name="mobilitydcatap:mobilityDataStandard" xpath="dcat:Distribution" use="thesaurus-list-picker">
       <directiveAttributes
         thesaurus="external.theme.mobility-data-standard"
         max="1"
-        xpath="/dct:conformsTo"
-        labelKey="dct:conformsTo"
+        xpath="/dcat:Distribution/mobilitydcatap:mobilityDataStandard"
+        labelKey="mobilitydcatap:mobilityDataStandard"
       />
     </for>
     <for name="dct:language" xpath="dcat:Catalog" use="thesaurus-list-picker">
@@ -589,6 +589,7 @@
     <name>spdx:checksum</name>
     <name>spdx:Checksum</name>
     <name>mobilitydcatap:mobilityDataStandard</name>
+    <name>mobilitydcatap:MobilityDataStandard</name>
     <name>mobilitydcatap:assessmentResult</name>
     <name>mobilitydcatap:Assessment</name>
     <name>dqv:hasQualityAnnotation</name>

--- a/src/main/plugin/dcat-ap/layout/layout-custom-fields-concepts.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout-custom-fields-concepts.xsl
@@ -58,7 +58,7 @@
                          priority="4000"
                         match="*[(skos:Concept or @rdf:resource) and gn-fn-dcat-ap:getThesaurusConfig(name(), name(..))]|dcat:theme|
                                                   dcat:Dataset/dct:conformsTo|
-                                                  mobilitydcatap:mobilityDataStandard/dct:conformsTo|
+                                                  mobilitydcatap:mobilityDataStandard|
                                                   dct:rights/dct:RightsStatement/dct:type">
     <xsl:param name="config" required="no"/>
 
@@ -260,7 +260,7 @@
     <xsl:choose>
       <xsl:when test="$xpath = (
         './dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:distribution/dcat:Distribution/dct:rights/dct:RightsStatement/dct:type',
-        './dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:distribution/dcat:Distribution/mobilitydcatap:mobilityDataStandard/dct:conformsTo'
+        './dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:distribution/dcat:Distribution/mobilitydcatap:mobilityDataStandard'
         )">
         <xsl:value-of select="$xpath"/>
       </xsl:when>

--- a/src/main/plugin/dcat-ap/layout/layout.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout.xsl
@@ -152,6 +152,7 @@
                                                 name() = 'dct:Standard' or
                                                 name() = 'dcat:Distribution' or
                                                 name() = 'dct:LicenseDocument' or
+                                                name() = 'locn:Address' or
                                                 name() = 'dct:RightsStatement' or
                                                 name() = 'foaf:Agent'"/>
     </xsl:call-template>

--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -382,6 +382,10 @@
     <label>Adres</label>
     <description>Een "adresrepresentatie" zoals conceptueel gedefinieerd door het INSPIRE Address Representation-datatype. De eigenschap locn:addressId kan worden gebruikt om dit locn:Address te koppelen aan andere representaties.</description>
   </element>
+  <element name="locn:Address">
+    <label>Adres</label>
+    <description>Een "adresrepresentatie" zoals conceptueel gedefinieerd door het INSPIRE Address Representation-datatype. De eigenschap locn:addressId kan worden gebruikt om dit locn:Address te koppelen aan andere representaties.</description>
+  </element>
   <element name="locn:poBox">
     <label>Postbus</label>
     <description>Het postbusnummer. Het domein van locn:poBox is locn:Address.</description>
@@ -1103,6 +1107,10 @@
     <label>Beoordelingsresultaat</label>
     <description>De resultaten en uitkomsten van een beoordelingsproces door een externe organisatie, e.g., een nationale instantie in het kader van gedelegeerde EU-verordeningen. Gedelegeerde EU-verordeningen vereisen dat lidstaten procedures instellen om de naleving van de gedelegeerde verordeningen te beoordelen, bijvoorbeeld met betrekking tot de verstrekking van gegevens via een NAP. Deze beoordelingsprocessen worden uitgevoerd door nationale instanties en zijn per lidstaat afzonderlijk geïmplementeerd. De eigenschap kan verwijzen naar de meest recente beoordelingsprocedure, inclusief de datum, het resultaat als vrije tekst en/of een link naar een online beoordelingsrapport.</description>
   </element>
+  <element name="mobilitydcatap:Assessment">
+    <label>Beoordeling</label>
+    <description>Een beoordelingsprocedure door een externe organisatie.</description>
+  </element>
   <element name="mobilitydcatap:dataFormatNotes">
     <label>Opmerkingen over dataformaat</label>
     <description>Aanvullende informatie over het formaat van de geleverde inhoud binnen de distributie, in tekstuele vorm.</description>
@@ -1112,8 +1120,12 @@
     <description>Het resultaat van de meest recente beoordelingsprocedure, in de vorm van een URL die verwijst naar verdere details of resultaten. Als alternatief kan tekstuele informatie worden verstrekt via de Embedded Textual Body‑constructie van het Web Annotation Data Model, waarmee tekstformaten en talen kunnen worden gespecificeerd die relevant kunnen zijn voor meertalige doeleinden.</description>
   </element>
   <element name="dqv:hasQualityAnnotation">
+    <label>Heeft kwaliteitsannotatie</label>
+    <description>Een annotatie over alle kwaliteitsaspecten met betrekking tot de geleverde inhoud, in het bijzonder methoden, meetmethoden/indicatoren en resultaten van een kwaliteitsbeoordeling waarvoor de Data Owner verantwoordelijk is.</description>
+  </element>
+  <element name="dqv:QualityAnnotation">
     <label>Kwaliteitsannotatie</label>
-    <description>Een toelichting over alle kwaliteitsaspecten met betrekking tot de geleverde inhoud, in het bijzonder methoden, meetmethoden/indicatoren en resultaten van een kwaliteitsbeoordeling waarvoor de Data Owner verantwoordelijk is.</description>
+    <description>Dit vertegenwoordigt kwaliteitsannotaties, waaronder beoordelingen, kwaliteitscertificaten of feedback die aan datasets of distributies kunnen worden gekoppeld. Kwaliteitsannotaties moeten een oa:motivatedBy-verklaring bevatten met een instantie van oa:Motivation (en skos:Concept) die het doel van kwaliteitsbeoordeling weerspiegelt. We definiëren deze instantie als dqv:qualityAssessment.</description>
   </element>
   <element name="cnt:characterEncoding">
     <label>Tekencodering</label>

--- a/src/main/plugin/dcat-ap/loc/eng/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/labels.xml
@@ -382,6 +382,10 @@
     <label>Address</label>
     <description>An "address representation" as conceptually defined by the INSPIRE Address Representation data type. The locn:addressId property may be used to link this locn:Address to other representations.</description>
   </element>
+  <element name="locn:Address">
+    <label>Adres</label>
+    <description>An "address representation" as conceptually defined by the INSPIRE Address Representation data type. The locn:addressId property may be used to link this locn:Address to other representations.</description>
+  </element>
   <element name="locn:poBox">
     <label>PO Box</label>
     <description>The Post Office Box number. The domain of locn:poBox is locn:Address.</description>
@@ -1109,6 +1113,10 @@
     <description>The results and outcomes from an assessment process by an external organisation, e.g., a National Body in the context of EU Delegated Regulations. EU Delegated Regulations require Member States to set up procedures to assess the compliance of the Delegated Regulations, e.g. regarding the provisioning of data via a NAP. These assessment processes are handled by National Bodies and installed individually in each Member State.
       The property may point to the most recent assessment procedure, including its date, its result as a free-text and/or a link referring to an assessment report online.</description>
   </element>
+  <element name="mobilitydcatap:Assessment">
+    <label>Assessment</label>
+    <description>An assessment procedure by an external organisation.</description>
+  </element>
   <element name="mobilitydcatap:dataFormatNotes">
     <label>Data format notes</label>
     <description>Any additional information about the format of the delivered content within the distribution in a textual format.</description>
@@ -1118,8 +1126,12 @@
     <description>The result of the latest assessment procedure, in form of a URL linking to further details or results. Alternatively, textual information is provided using the Embedded Textual Body construction of the Web Annotation Data Model, which allows to specify text formats and languages which might be relevant for multilingual purposes.</description>
   </element>
   <element name="dqv:hasQualityAnnotation">
-    <label>Quality annotation</label>
+    <label>Has Quality Annotation</label>
     <description>An annotation about any quality aspects regarding the delivered content, in particular methods, metrics/indicators and results of a quality assessment in the responsibility of the Data Owner.</description>
+  </element>
+  <element name="dqv:QualityAnnotation">
+    <label>Quality annotation</label>
+    <description>Represents quality annotations, including ratings, quality certificates or feedback that can be associated to datasets or distributions. Quality annotations must have one oa:motivatedBy statement with an instance of oa:Motivation (and skos:Concept) that reflects a quality assessment purpose. We define this instance as dqv:qualityAssessment.</description>
   </element>
   <element name="cnt:characterEncoding">
     <label>Character encoding</label>

--- a/src/main/plugin/dcat-ap/loc/fre/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/labels.xml
@@ -382,6 +382,10 @@
     <label>Address</label>
     <description>An "address representation" as conceptually defined by the INSPIRE Address Representation data type. The locn:addressId property may be used to link this locn:Address to other representations.</description>
   </element>
+  <element name="locn:Address">
+    <label>Adres</label>
+    <description>An "address representation" as conceptually defined by the INSPIRE Address Representation data type. The locn:addressId property may be used to link this locn:Address to other representations.</description>
+  </element>
   <element name="locn:poBox">
     <label>PO Box</label>
     <description>The Post Office Box number. The domain of locn:poBox is locn:Address.</description>
@@ -1109,6 +1113,10 @@
     <description>The results and outcomes from an assessment process by an external organisation, e.g., a National Body in the context of EU Delegated Regulations. EU Delegated Regulations require Member States to set up procedures to assess the compliance of the Delegated Regulations, e.g. regarding the provisioning of data via a NAP. These assessment processes are handled by National Bodies and installed individually in each Member State.
       The property may point to the most recent assessment procedure, including its date, its result as a free-text and/or a link referring to an assessment report online.</description>
   </element>
+  <element name="mobilitydcatap:Assessment">
+    <label>Évaluation</label>
+    <description>Une procédure d'évaluation réalisée par un organisme externe.</description>
+  </element>
   <element name="mobilitydcatap:dataFormatNotes">
     <label>Data format notes</label>
     <description>Any additional information about the format of the delivered content within the distribution in a textual format.</description>
@@ -1118,8 +1126,12 @@
     <description>The result of the latest assessment procedure, in form of a URL linking to further details or results. Alternatively, textual information is provided using the Embedded Textual Body construction of the Web Annotation Data Model, which allows to specify text formats and languages which might be relevant for multilingual purposes.</description>
   </element>
   <element name="dqv:hasQualityAnnotation">
-    <label>Quality annotation</label>
-    <description>An annotation about any quality aspects regarding the delivered content, in particular methods, metrics/indicators and results of a quality assessment in the responsibility of the Data Owner.</description>
+    <label>Possède une annotation de qualité</label>
+    <description>Une annotation concernant tout aspect qualitatif du contenu livré, notamment les méthodes, les indicateurs et les résultats d'une évaluation de la qualité relevant de la responsabilité du propriétaire des données.</description>
+  </element>
+  <element name="dqv:QualityAnnotation">
+    <label>Annotation de qualité</label>
+    <description>Représente les annotations de qualité, telles que les évaluations, les certificats de qualité ou les commentaires, pouvant être associées à des ensembles de données ou des distributions. Ces annotations doivent comporter une instruction `oa:motivatedBy` avec une instance de `oa:Motivation` (et `skos:Concept`) reflétant un objectif d'évaluation de la qualité. Cette instance est définie comme `dqv:qualityAssessment`.</description>
   </element>
   <element name="cnt:characterEncoding">
     <label>Character encoding</label>

--- a/src/main/plugin/dcat-ap/loc/ger/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/labels.xml
@@ -648,6 +648,14 @@
     <description>Tooltip: geometry</description>
     <btnLabel>geometry</btnLabel>
   </element>
+  <element name="locn:address">
+    <label>Address</label>
+    <description>An "address representation" as conceptually defined by the INSPIRE Address Representation data type. The locn:addressId property may be used to link this locn:Address to other representations.</description>
+  </element>
+  <element name="locn:Address">
+    <label>Adres</label>
+    <description>An "address representation" as conceptually defined by the INSPIRE Address Representation data type. The locn:addressId property may be used to link this locn:Address to other representations.</description>
+  </element>
   <element name="skos:prefLabel" context="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:spatial/dct:Location/skos:prefLabel">
     <label>Geographic description</label>
     <description>Tooltip: Geographic description</description>
@@ -2279,6 +2287,10 @@
     <description>The results and outcomes from an assessment process by an external organisation, e.g., a National Body in the context of EU Delegated Regulations. EU Delegated Regulations require Member States to set up procedures to assess the compliance of the Delegated Regulations, e.g. regarding the provisioning of data via a NAP. These assessment processes are handled by National Bodies and installed individually in each Member State.
       The property may point to the most recent assessment procedure, including its date, its result as a free-text and/or a link referring to an assessment report online.</description>
   </element>
+  <element name="mobilitydcatap:Assessment">
+    <label>Bewertung</label>
+    <description>Ein Bewertungsverfahren durch eine externe Organisation.</description>
+  </element>
   <element name="mobilitydcatap:dataFormatNotes">
     <label>Data format notes</label>
     <description>Any additional information about the format of the delivered content within the distribution in a textual format.</description>
@@ -2288,8 +2300,12 @@
     <description>The result of the latest assessment procedure, in form of a URL linking to further details or results. Alternatively, textual information is provided using the Embedded Textual Body construction of the Web Annotation Data Model, which allows to specify text formats and languages which might be relevant for multilingual purposes.</description>
   </element>
   <element name="dqv:hasQualityAnnotation">
-    <label>Quality annotation</label>
-    <description>An annotation about any quality aspects regarding the delivered content, in particular methods, metrics/indicators and results of a quality assessment in the responsibility of the Data Owner.</description>
+    <label>Verfügt über eine hochwertige Annotation</label>
+    <description>Eine Anmerkung zu allen Qualitätsaspekten des gelieferten Inhalts, insbesondere zu Methoden, Kennzahlen/Indikatoren und Ergebnissen einer Qualitätsbewertung, die in der Verantwortung des Dateneigentümers liegt.</description>
+  </element>
+  <element name="dqv:QualityAnnotation">
+    <label>Qualitätsannotation</label>
+    <description>Stellt Qualitätsannotationen dar, darunter Bewertungen, Qualitätszertifikate oder Feedback, die Datensätzen oder Verteilungen zugeordnet werden können. Qualitätsannotationen müssen eine `oa:motivatedBy`-Anweisung mit einer Instanz von `oa:Motivation` (und `skos:Concept`) enthalten, die den Zweck einer Qualitätsbewertung widerspiegelt. Diese Instanz wird als `dqv:qualityAssessment` definiert.</description>
   </element>
   <element name="cnt:characterEncoding">
     <label>Character encoding</label>

--- a/src/main/plugin/dcat-ap/schema/dqv.xsd
+++ b/src/main/plugin/dcat-ap/schema/dqv.xsd
@@ -20,10 +20,16 @@
   <xs:import namespace="http://www.w3.org/ns/oa#" schemaLocation="oa.xsd"/>
 
   <xs:complexType name="QualityAnnotation">
-      <xs:sequence>
-        <xs:element ref="oa:hasBody"/>
-<!--     TODO   <xs:element ref="oa:hasTarget"/>-->
-      </xs:sequence>
+    <xs:sequence>
+      <xs:element name="QualityAnnotation" minOccurs="0" maxOccurs="1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="oa:hasBody"/>
+            <!-- TODO <xs:element ref="oa:hasTarget"/>-->
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
   </xs:complexType>
 
   <xs:element name="hasQualityAnnotation" type="dqv:QualityAnnotation"/>

--- a/src/main/plugin/dcat-ap/schema/locn.xsd
+++ b/src/main/plugin/dcat-ap/schema/locn.xsd
@@ -33,16 +33,22 @@
 
   <xs:complexType name="Address">
     <xs:sequence>
-      <xs:element name="fullAddress" type="rdf:TypedLiteral" minOccurs="0" />
-      <xs:element name="poBox" type="rdf:TypedLiteral" minOccurs="0" />
-      <xs:element name="thoroughfare" type="rdf:TypedLiteral" minOccurs="0" />
-      <xs:element name="locatorDesignator" type="rdf:TypedLiteral" minOccurs="0" />
-      <xs:element name="locatorName" type="rdf:TypedLiteral" minOccurs="0" />
-      <xs:element name="addressArea" type="rdf:TypedLiteral" minOccurs="0" />
-      <xs:element name="postName" type="rdf:TypedLiteral" minOccurs="0" />
-      <xs:element name="postCode" type="rdf:TypedLiteral" minOccurs="0" />
-      <xs:element name="adminUnitL2" type="rdf:TypedLiteral" minOccurs="0" />
-      <xs:element name="adminUnitL1" type="rdf:TypedLiteral" minOccurs="0" />
+      <xs:element name="Address" minOccurs="0" maxOccurs="1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="fullAddress" type="rdf:TypedLiteral" minOccurs="0"/>
+            <xs:element name="poBox" type="rdf:TypedLiteral" minOccurs="0"/>
+            <xs:element name="thoroughfare" type="rdf:TypedLiteral" minOccurs="0"/>
+            <xs:element name="locatorDesignator" type="rdf:TypedLiteral" minOccurs="0"/>
+            <xs:element name="locatorName" type="rdf:TypedLiteral" minOccurs="0"/>
+            <xs:element name="addressArea" type="rdf:TypedLiteral" minOccurs="0"/>
+            <xs:element name="postName" type="rdf:TypedLiteral" minOccurs="0"/>
+            <xs:element name="postCode" type="rdf:TypedLiteral" minOccurs="0"/>
+            <xs:element name="adminUnitL2" type="rdf:TypedLiteral" minOccurs="0"/>
+            <xs:element name="adminUnitL1" type="rdf:TypedLiteral" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
     </xs:sequence>
   </xs:complexType>
 

--- a/src/main/plugin/dcat-ap/schema/profiles/eu-dcat-ap-mobility.xsd
+++ b/src/main/plugin/dcat-ap/schema/profiles/eu-dcat-ap-mobility.xsd
@@ -50,8 +50,14 @@
 
   <xs:complexType name="Assessment">
     <xs:sequence>
-      <xs:element ref="dct:issued"/>
-      <xs:element ref="oa:hasBody"/>
+      <xs:element name="Assessment" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="dct:issued"/>
+            <xs:element ref="oa:hasBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
     </xs:sequence>
   </xs:complexType>
 </xs:schema>

--- a/src/main/plugin/dcat-ap/schema/profiles/eu-dcat-ap-mobility.xsd
+++ b/src/main/plugin/dcat-ap/schema/profiles/eu-dcat-ap-mobility.xsd
@@ -32,17 +32,38 @@
   <xs:element name="grammar" type="skos:Concept"/>
   <xs:element name="schema" type="rdf:ResourceRef"/>
   <xs:element name="dataFormatNotes" type="rdf:PlainLiteral"/>
-  <xs:element name="mobilityDataStandard" type="mobilitydcatap:DataStandard"/>
+  <xs:element name="mobilityDataStandard" type="mobilitydcatap:MobilityDataStandard"/>
 
-  <xs:complexType name="DataStandard">
+  <!--
+  Intended format:
+
+  <mobilitydcatap:mobilityDataStandard>
+    <mobilitydcatap:MobilityDataStandard rdf:about="https://w3id.org/mobilitydcat-ap/mobility-data-standard/siri">
+       <dct:identifier>https://w3id.org/mobilitydcat-ap/mobility-data-standard/siri</dct:identifier>
+       <dct:title xml:lang="nl">SIRI</dct:title>
+       <owl:versionInfo>versie</owl:versionInfo>
+       <mobilitydcatap:schema rdf:resource="schema" />
+    </mobilitydcatap:MobilityDataStandard>
+  </mobilitydcatap:mobilityDataStandard>
+  -->
+  <xs:complexType name="MobilityDataStandard">
     <xs:sequence>
-      <!--TODO Added in mobility DCAT 3
-      Broken link in the spec to the vocabulary
-      <xs:element ref="mobilitydcatap:specificContentModel" minOccurs="0"/>-->
-      <xs:element ref="dct:conformsTo" minOccurs="0"/><!-- is a skos:Concept in mobility dcat instead of dct:Standard -->
-      <!--TODO In mobility v1 was owl:versionInfo, is dcat:version in v3 -->
-      <xs:element ref="owl:versionInfo" minOccurs="0"/>
-      <xs:element ref="mobilitydcatap:schema" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="MobilityDataStandard" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <!--TODO Added in mobility DCAT 3
+            Broken link in the spec to the vocabulary
+            <xs:element ref="mobilitydcatap:specificContentModel" minOccurs="0"/>-->
+            <xs:element ref="dct:identifier" minOccurs="0"/>
+            <!-- dct:conformsTo is used when a custom type of MobilityDataStandard is used, in which case we can show commonalities here. Not applicable yet. -->
+            <!-- <xs:element ref="dct:conformsTo" minOccurs="0"/>-->
+            <!--TODO In mobility v1 was owl:versionInfo, is dcat:version in v3 -->
+            <xs:element ref="owl:versionInfo" minOccurs="0"/>
+            <xs:element ref="mobilitydcatap:schema" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute ref="rdf:about"/>
+        </xs:complexType>
+      </xs:element>
     </xs:sequence>
   </xs:complexType>
 

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -30,6 +30,7 @@
                 xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
                 xmlns:dcatap="http://data.europa.eu/r5r/"
+                xmlns:dqv="http://www.w3.org/ns/dqv#"
                 xmlns:foaf="http://xmlns.com/foaf/0.1/"
                 xmlns:owl="http://www.w3.org/2002/07/owl#"
                 xmlns:schema="http://schema.org/"


### PR DESCRIPTION
Fixes for incorrectly encoded elements:
- [x] locn:Address
- [x] dqv:QualityAnnotation
- [x] mobilitydcatap:Assessment
- [x] mobilitydcatap:mobilityDataStandard

It's mostly about missing wrapper elements, a diff explains what should be modified:

```diff
diff --git a/./mdv-dev-test-1.xml b/./mdv-dev-test-1-fixed.xml
index 7b5ebba6..006b3394 100644
--- a/./mdv-dev-test-1.xml
+++ b/./mdv-dev-test-1-fixed.xml
@@ -102,14 +102,12 @@
               </skos:Concept>
             </mobilitydcatap:grammar>
             <mobilitydcatap:mobilityDataStandard>
-              <dct:conformsTo>
-                <dct:Standard rdf:about="https://w3id.org/mobilitydcat-ap/mobility-data-standard/siri">
+              <mobilitydcatap:MobilityDataStandard rdf:about="https://w3id.org/mobilitydcat-ap/mobility-data-standard/siri">
                 <dct:identifier>https://w3id.org/mobilitydcat-ap/mobility-data-standard/siri</dct:identifier>
                 <dct:title xml:lang="nl">SIRI</dct:title>
-                </dct:Standard>
-              </dct:conformsTo>
                 <owl:versionInfo>versie</owl:versionInfo>
                 <mobilitydcatap:schema rdf:resource="schema" />
+              </mobilitydcatap:MobilityDataStandard>
             </mobilitydcatap:mobilityDataStandard>
             <dct:temporal>
               <dct:PeriodOfTime>
@@ -173,6 +171,7 @@ updated 13/4/26</dct:description>
             </dct:type>
             <foaf:workplaceHomepage rdf:resource="https//www.vlaanderen.be" />
             <locn:address>
+              <locn:Address>
                 <locn:fullAddress>adres</locn:fullAddress>
                 <locn:poBox>Postbus</locn:poBox>
                 <locn:thoroughfare>doorgaande weg</locn:thoroughfare>
@@ -183,6 +182,7 @@ updated 13/4/26</dct:description>
                 <locn:postCode>Postcode</locn:postCode>
                 <locn:adminUnitL2>Administratieve eenheid L2</locn:adminUnitL2>
                 <locn:adminUnitL1>Administratieve eenheid L1</locn:adminUnitL1>
+              </locn:Address>
             </locn:address>
             <foaf:mbox rdf:resource="bianca.drepper@vlaanderen.be" />
             <foaf:firstName xml:lang="nl">Bianca</foaf:firstName>
@@ -275,11 +275,15 @@ updated 13/4/26</dct:description>
           </skos:Concept>
         </mobilitydcatap:intendedInformationService>
         <mobilitydcatap:assessmentResult>
+          <mobilitydcatap:Assessment>
             <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2026-03-20</dct:issued>
             <oa:hasBody rdf:resource="www.vlaanderen.be" />
+          </mobilitydcatap:Assessment>
         </mobilitydcatap:assessmentResult>
         <dqv:hasQualityAnnotation>
+          <dqv:QualityAnnotation>
             <oa:hasBody rdf:resource="www.vlaanderen.be" />
+          </dqv:QualityAnnotation>
         </dqv:hasQualityAnnotation>
         <geodcatap:referenceSystem>
           <dct:Standard>
```

Thanks for the pointers, @fxprunayre !