### PR TITLE
Mobility / Added default dct:spatial for main mobility Catalog

### DIFF
--- a/e2e/cypress/sql/records.sql
+++ b/e2e/cypress/sql/records.sql
@@ -163,6 +163,9 @@ $$
         </dct:type>
       </foaf:Agent>
     </dct:publisher>
+    <dct:spatial>
+      <dct:Location rdf:about="http://publications.europa.eu/resource/authority/country/BEL" />
+    </dct:spatial>
     <dct:title xml:lang="nl">Open Data Catalogus van My organization</dct:title>
     <foaf:homepage>
       <foaf:Document rdf:about="http://localhost:8080/srv/eng/">

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -234,6 +234,9 @@
           </dct:type>
         </foaf:Agent>
       </dct:publisher>
+      <dct:spatial>
+        <dct:Location rdf:about="http://publications.europa.eu/resource/authority/country/BEL"/>
+      </dct:spatial>
       <foaf:homepage>
         <foaf:Document>
           <xsl:if test="normalize-space($serviceUrl) != ''">


### PR DESCRIPTION
Due to the inclusion of `mobilityDCAT-AP`, a `Catalog` should have a `dct:spatial` defined.

> For National Access Points (NAPs), this corresponds to the EU Member State or a country that installs such NAP. The property might be used for analyses about available datasets per country, or to identify country-specific metadata in case metadata are federated from multiple national portals into an international portal. It is not to be mixed up with country codes used within the dataset property [dct:spatial](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/drafts/latest/index.html#dataset-geographical-coverage), which might be different.
The obligation of this property is raised to “mandatory”, comparing to [DCAT-AP v3.0.0](https://semiceu.github.io/DCAT-AP/releases/3.0.0/).

Currently there are some hardcoded values in `updated-fixed-info` that should ideally be moved to a profile-specific file. I've included the spatial in there for now, though. To be refined at a later stage.