### PR TITLE
Mobility / oa:hasBody fixes

### DIFF
--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -469,7 +469,7 @@
   <xsl:template mode="render-field" match="dct:LicenseDocument/dct:identifier"/>
 
   <!-- Field with lang : display only field of current lang or first one if not exist -->
-  <xsl:template mode="render-field" match="dct:title|dct:description|foaf:name|adms:versionNotes|foaf:firstName|foaf:surname|cnt:characterEncoding|mobilitydcatap:dataFormatNotes">
+  <xsl:template mode="render-field" match="dct:title|dct:description|foaf:name|adms:versionNotes|foaf:firstName|foaf:surname|cnt:characterEncoding|mobilitydcatap:dataFormatNotes|oa:hasBody">
     <xsl:param name="xpath"/>
     <xsl:variable name="stringValue" select="string()"/>
     <xsl:variable name="name" select="name()"/>
@@ -587,7 +587,7 @@
 
   <!-- render the element name (key) and the @rdf:resource (value) -->
   <xsl:template mode="render-field"
-                match="dcat:accessURL|dcat:downloadURL|dcat:landingPage|foaf:mbox|foaf:phone|foaf:workplaceHomepage|vcard:hasEmail|vcard:hasURL">
+                match="dcat:accessURL|dcat:downloadURL|dcat:landingPage|foaf:mbox|foaf:phone|foaf:workplaceHomepage|vcard:hasEmail|vcard:hasURL|oa:hasBody[@rdf:resource]">
     <xsl:param name="xpath"/>
     <xsl:variable name="stringValue" select="string(@rdf:resource)"/>
     <xsl:if test="normalize-space($stringValue) != ''">
@@ -638,25 +638,6 @@
           </td>
         </tr>
       </xsl:for-each-group>
-    </xsl:if>
-  </xsl:template>
-
-  <!-- element that include an ao:hasBody -->
-  <xsl:template mode="render-field" match="mobilitydcatap:assessmentResult|dqv:hasQualityAnnotation">
-    <xsl:param name="xpath"/>
-    <xsl:variable name="stringValue" select="string(oa:hasBody/@rdf:resource)"/>
-    <xsl:if test="normalize-space($stringValue) != ''">
-      <tr>
-        <th style="{$thStyle}">
-          <xsl:value-of select="gn-fn-metadata:getLabel($schema, name(.), $labels, name(..), '', gn-fn-dcat-ap:concatXPaths($xpath, gn-fn-metadata:getXPath(.), name(.)))/label" />
-        </th>
-        <td style="{$tdStyle}">
-          <xsl:apply-templates mode="render-url" select="oa:hasBody/@rdf:resource" />
-          <xsl:if test="dct:issued">
-            <br/>(<xsl:value-of select="gn-fn-metadata:getLabel($schema, 'dct:issued', $labels)/label "/><xsl:value-of select="' '"/><xsl:value-of select="dct:issued"/>)
-          </xsl:if>
-        </td>
-      </tr>
     </xsl:if>
   </xsl:template>
 
@@ -748,7 +729,7 @@
   </xsl:template>
 
   <!-- render nested content, but with the header above the table -->
-  <xsl:template mode="render-field" match="locn:address|dct:LicenseDocument|dct:RightsStatement|dct:rightsHolder|dct:Standard">
+  <xsl:template mode="render-field" match="locn:address|dct:LicenseDocument|dct:RightsStatement|dct:rightsHolder|dct:Standard|dqv:QualityAnnotation|mobilitydcatap:Assessment">
     <xsl:param name="xpath"/>
     <xsl:variable name="stringValue" select="string()"/>
     <!-- Special case for dct:license with an empty dct:LicenseDocument with only @rdf:about or for dcat:contactPoint with only vcard:hasEmail and vcard:hasURL-->

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -25,6 +25,7 @@
   <fields>
     <for name="dct:description" use="textarea"/>
     <for name="adms:versionNotes" use="textarea"/>
+    <for name="oa:hasBody" use="textarea" xpath="dqv:QualityAnnotation"/>
     <for name="dcat:byteSize" use="number"/>
     <for name="mdcat:stars" use="number"/>
     <for name="dcat:spatialResolutionInMeters" use="number"/>
@@ -407,7 +408,7 @@
         </snippet>
       </template>
     </for>
-    <for name="oa:hasBody" templateModeOnly="true" forceLabel="true" label="key">
+    <for name="oa:hasBody" xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/mobilitydcatap:assessmentResult/mobilitydcatap:Assessment/oa:hasBody" templateModeOnly="true" forceLabel="true" label="key">
       <template>
         <values>
           <key label="key" xpath="@rdf:resource" tooltip="oa:hasBody" required="true"/>
@@ -1295,7 +1296,7 @@
               <snippet>
                 <dqv:hasQualityAnnotation>
                   <dqv:QualityAnnotation>
-                    <oa:hasBody rdf:resource=""/>
+                    <oa:hasBody/>
                   </dqv:QualityAnnotation>
                 </dqv:hasQualityAnnotation>
               </snippet>

--- a/src/main/plugin/dcat-ap/schema/oa.xsd
+++ b/src/main/plugin/dcat-ap/schema/oa.xsd
@@ -17,6 +17,6 @@
   <xs:import namespace="http://www.w3.org/1999/02/22-rdf-syntax-ns#" schemaLocation="rdf.xsd"/>
   <xs:import namespace="http://www.w3.org/2004/02/skos/core#" schemaLocation="skos.xsd"/>
 
-  <xs:element name="hasBody" type="rdf:ResourceRef"/>
+  <xs:element name="hasBody" type="rdf:LiteralOrResource"/>
   <xs:element name="motivatedBy" type="skos:Concept"/>
 </xs:schema>

--- a/src/main/plugin/dcat-ap/schema/rdf.xsd
+++ b/src/main/plugin/dcat-ap/schema/rdf.xsd
@@ -21,6 +21,10 @@ The Resource Description Framework [RDF] is defined to have an extensible system
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
+  <!-- rdfs:Resource or rdfs:Literal -->
+  <xs:simpleType name="LiteralOrResource">
+    <xs:union memberTypes="rdf:ResourceRef rdf:PlainLiteral"/>
+  </xs:simpleType>
   <!-- rdf:typedLiteral -->
   <xs:complexType name="TypedLiteral">
     <xs:simpleContent>

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -32,6 +32,7 @@
                 xmlns:dcatap="http://data.europa.eu/r5r/"
                 xmlns:dqv="http://www.w3.org/ns/dqv#"
                 xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:oa="http://www.w3.org/ns/oa#"
                 xmlns:owl="http://www.w3.org/2002/07/owl#"
                 xmlns:schema="http://schema.org/"
                 xmlns:locn="http://www.w3.org/ns/locn#"


### PR DESCRIPTION
`oa:hasBody` was not added correctly through the editor: depending on the context it should either be a Literal or a Resource. See:
- https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/1.1.0/index.html#properties-for-assessment
- https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/1.1.0/index.html#properties-for-quality-annotation

This PR fixes the editor: hasBody is now added correctly depending on the parent element. The view is modified to take these changes into account, reverting a previous modification and simplifying things again.