### PR TITLE
Mobility / Standard xsd changes

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -847,6 +847,7 @@
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/adms:identifier/adms:Identifier"/>
           <!--
           TODO: This is a bit complicated, because GN does not support having 2 elements with same local-name.
+          TODO: Make adms:identifier deleteable: this is probably related
           Here we have dct:identifier and adms:identifier and it would require some changes to support that
           See 1049 of form-configurator.xsl:
           <action type="add"

--- a/src/main/plugin/dcat-ap/schema/profiles/eu-dcat-ap-mobility.xsd
+++ b/src/main/plugin/dcat-ap/schema/profiles/eu-dcat-ap-mobility.xsd
@@ -55,6 +55,9 @@
             Broken link in the spec to the vocabulary
             <xs:element ref="mobilitydcatap:specificContentModel" minOccurs="0"/>-->
             <xs:element ref="dct:identifier" minOccurs="0"/>
+            <xs:element ref="dct:title" minOccurs="0"/>
+            <xs:element ref="dct:description" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="dct:issued" minOccurs="0" maxOccurs="1"/>
             <!-- dct:conformsTo is used when a custom type of MobilityDataStandard is used, in which case we can show commonalities here. Not applicable yet. -->
             <!-- <xs:element ref="dct:conformsTo" minOccurs="0"/>-->
             <!--TODO In mobility v1 was owl:versionInfo, is dcat:version in v3 -->


### PR DESCRIPTION
Previously, mobilityDataStandard was fixed to be a proper dct:Standard. This necessitates adding relevant properties in the .xsd, which is done in this PR.