### PR TITLE
Editor / Added xsd date type to the relevant fields

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/e2e/cypress/e2e/testrecord.cy.ts
+++ b/e2e/cypress/e2e/testrecord.cy.ts
@@ -24,8 +24,9 @@ describe('The test record', () => {
       expect(catalogUuid).to.have.length.of.at.least(5)
       const dummyCatalogUuid = 'dummy-catalog-uuid'
       return xml
+        .trim()
         // modified will depend on the day of the cypress run, remove the element
-        .replace(/<dct:modified>.+?<\/dct:modified>/g, '')
+        .replace(/<dct:modified.+?<\/dct:modified>/g, '')
         // each time geonetwork is regenerated, the catalog uuid changes... replace it by a dummy value so it's always the same
         .split(catalogUuid).join(dummyCatalogUuid)
     }

--- a/e2e/cypress/sql/records.sql
+++ b/e2e/cypress/sql/records.sql
@@ -103,7 +103,7 @@ $$
     <dcat:record>
       <dcat:CatalogRecord rdf:about="http://localhost:8080/srv/api/records/345f47ef-abd5-4f2f-9ab7-d723565cccea">
         <foaf:primaryTopic rdf:resource="http://localhost:8080/srv/resources/datasets/16752832-7ef7-4539-9869-5236400cf249" />
-        <dct:modified>2025-12-24</dct:modified>
+        <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-12-24</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2019-10-03">
             <dct:identifier>https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2019-10-03</dct:identifier>
@@ -130,7 +130,7 @@ $$
     </dcat:record>
     <dct:description xml:lang="nl">Deze catalogus bevat datasets ontsloten door My organization</dct:description>
     <dct:identifier>eb248be8-549d-493f-b323-1dba08bb5417</dct:identifier>
-    <dct:issued>2019-09-01</dct:issued>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-09-01</dct:issued>
     <dct:language>
       <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
         <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem" />
@@ -441,7 +441,7 @@ $$
     </dcat:record>
     <dct:description xml:lang="en">Deze catalogus bevat datasets ontsloten door agentschap Digitaal Vlaanderen</dct:description>
     <dct:identifier>c678d0fb-894d-403f-b146-4b96706a1a16</dct:identifier>
-    <dct:issued>2019-09-01</dct:issued>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-09-01</dct:issued>
     <dct:language>
       <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
         <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem" />
@@ -474,6 +474,9 @@ $$
         </dct:type>
       </foaf:Agent>
     </dct:publisher>
+    <dct:spatial>
+      <dct:Location rdf:about="http://publications.europa.eu/resource/authority/country/BEL" />
+    </dct:spatial>
     <dct:title xml:lang="en">Open Data Catalogus van agentschap Digitaal Vlaanderen</dct:title>
     <foaf:homepage>
       <foaf:Document rdf:about="http://localhost:8080/srv/dut/">

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-dataset.xml
@@ -10,7 +10,6 @@
   <dcat:Catalog>
     <dcat:record>
       <dcat:CatalogRecord>
-        <dct:modified>2020-06-09</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2019-10-03">
             <dct:title xml:lang="nl">DCAT-AP Vlaanderen</dct:title>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-service.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-service.xml
@@ -10,7 +10,6 @@
   <dcat:Catalog>
     <dcat:record>
       <dcat:CatalogRecord>
-        <dct:modified>2020-06-09</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2019-10-03">
             <dct:title xml:lang="nl">DCAT-AP Vlaanderen</dct:title>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-virtualcatalogue.xml
@@ -17,7 +17,6 @@
   <dcat:Catalog rdf:about="https://metadata.vlaanderen.be/virtualcatalogtemplate">
     <dcat:record>
       <dcat:CatalogRecord>
-        <dct:modified>2025-06-18</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://joinup.ec.europa.eu/collection/semic-support-centre/solution/dcat-application-profile-data-portals-europe/release/200">
             <dct:identifier>https://joinup.ec.europa.eu/collection/semic-support-centre/solution/dcat-application-profile-data-portals-europe/release/200</dct:identifier>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-dataset.xml
@@ -10,7 +10,6 @@
   <dcat:Catalog>
     <dcat:record>
       <dcat:CatalogRecord>
-        <dct:modified>2020-06-09</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2026-02-12">
             <dct:title xml:lang="nl">DCAT-AP Vlaanderen</dct:title>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-service.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl3-service.xml
@@ -10,7 +10,6 @@
   <dcat:Catalog>
     <dcat:record>
       <dcat:CatalogRecord>
-        <dct:modified>2020-06-09</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2026-02-12">
             <dct:title xml:lang="nl">DCAT-AP Vlaanderen</dct:title>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
@@ -9,7 +9,6 @@
   <dcat:Catalog>
     <dcat:record>
       <dcat:CatalogRecord>
-        <dct:modified>2020-04-16</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22">
             <dct:title xml:lang="nl">Metadata DCAT</dct:title>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
@@ -9,7 +9,6 @@
   <dcat:Catalog>
     <dcat:record>
       <dcat:CatalogRecord>
-        <dct:modified>2020-04-16</dct:modified>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22">
             <dct:title xml:lang="nl">Metadata DCAT</dct:title>

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -269,10 +269,10 @@
           <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
         </skos:Concept>
       </dct:language>
-      <dct:issued>
+      <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
         <xsl:value-of select="'2019-09-01'"/>
       </dct:issued>
-      <dct:modified>
+      <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
         <xsl:value-of select="'2019-09-01'"/>
       </dct:modified>
       <xsl:for-each select="/root/gui/thesaurus/thesauri/thesaurus">
@@ -309,14 +309,14 @@
           <dcat:record>
             <dcat:CatalogRecord>
               <xsl:call-template name="handle-record-id"/>
-              <dct:modified>
+              <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
                 <xsl:value-of select="
                 if (matches(/root/env/changeDate, '^\d{4}-\d{2}-\d{2}$')) then format-date(/root/env/changeDate,'[Y0001]-[M01]-[D01]')
                   else if(/root/env/changeDate) then format-dateTime(/root/env/changeDate,'[Y0001]-[M01]-[D01]')
                   else dct:modified"/>
               </dct:modified>
               <xsl:if test="/root/env/createDate">
-                <dct:created><xsl:value-of select="format-dateTime(/root/env/createDate,'[Y0001]-[M01]-[D01]')"/></dct:created>
+                <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="format-dateTime(/root/env/createDate,'[Y0001]-[M01]-[D01]')"/></dct:created>
               </xsl:if>
             </dcat:CatalogRecord>
           </dcat:record>
@@ -336,14 +336,14 @@
                                           )]" priority="2">
     <xsl:copy copy-namespaces="no">
       <xsl:call-template name="handle-record-id"/>
-      <dct:modified>
+      <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
         <xsl:value-of select="
         if (matches(/root/env/changeDate, '^\d{4}-\d{2}-\d{2}$')) then format-date(/root/env/changeDate,'[Y0001]-[M01]-[D01]')
           else if(/root/env/changeDate) then format-dateTime(/root/env/changeDate,'[Y0001]-[M01]-[D01]')
           else dct:modified"/>
       </dct:modified>
       <xsl:if test="not(dct:created) and /root/env/createDate">
-        <dct:created><xsl:value-of select="format-dateTime(/root/env/createDate,'[Y0001]-[M01]-[D01]')"/></dct:created>
+        <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="format-dateTime(/root/env/createDate,'[Y0001]-[M01]-[D01]')"/></dct:created>
       </xsl:if>
       <xsl:apply-templates select="* except (dct:identifier|dct:modified|foaf:primaryTopic)"/>
     </xsl:copy>


### PR DESCRIPTION
As we are currently adding dates to dct:modified etc, now supplying the element with the correct datatype (xsd:date).

Previously: `<dct:modified>2026-05-26</dct:modified>`
Now: `<dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2026-05-26</dct:modified>`

This applies to `dct:modified`, `dct:created`, `dct:issued`. In scope of templates, update-fixed-info automatic updates.