### PR TITLE
View / Various fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -53,19 +53,19 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Download GeoNetwork WAR
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: geonetwork-war
         # Ensure the WAR is inside the docker build context (schemas/dcat-ap/utility)
         path: utility
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '24'
         cache: 'npm'
@@ -119,7 +119,7 @@ jobs:
 
     - name: Upload Cypress artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cypress-artifacts
         path: |

--- a/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/dcat-ap/formatter/xsl-view/view.xsl
@@ -808,7 +808,7 @@
     </span>
   </xsl:template>
 
-  <xsl:template mode="render-url" match="*[../name() = 'vcard:hasEmail']|@*[../name() = 'vcard:hasEmail']">
+  <xsl:template mode="render-url" match="*[../name() = ('vcard:hasEmail', 'foaf:mbox')]|@*[../name() = ('vcard:hasEmail', 'foaf:mbox')]">
     <xsl:choose>
       <xsl:when test="starts-with(normalize-space(.), 'mailto:')">
         <a href="{normalize-space(.)}" style="color:#06c; text-decoration: underline;">
@@ -817,6 +817,21 @@
       </xsl:when>
       <xsl:otherwise>
         <a href="{concat('mailto:', normalize-space(.))}" style="color:#06c; text-decoration: underline;">
+          <xsl:value-of select="." />
+        </a>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template mode="render-url" match="*[../name() = ('foaf:phone')]|@*[../name() = ('foaf:phone')]">
+    <xsl:choose>
+      <xsl:when test="starts-with(normalize-space(.), 'tel:')">
+        <a href="{normalize-space(.)}" style="color:#06c; text-decoration: underline;">
+          <xsl:value-of select="substring-after(normalize-space(.), 'tel:')" />
+        </a>
+      </xsl:when>
+      <xsl:otherwise>
+        <a href="{concat('tel:', normalize-space(.))}" style="color:#06c; text-decoration: underline;">
           <xsl:value-of select="." />
         </a>
       </xsl:otherwise>

--- a/src/main/plugin/dcat-ap/loc/dut/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/dut/labels.xml
@@ -1116,7 +1116,7 @@
     <description>Aanvullende informatie over het formaat van de geleverde inhoud binnen de distributie, in tekstuele vorm.</description>
   </element>
   <element name="oa:hasBody" context="dqv:QualityAnnotation">
-    <label>Beschrijft alle kwaliteitsaspecten met betrekking tot de geleverde context.</label>
+    <label>Beschrijft alle kwaliteitsaspecten met betrekking tot de geleverde inhoud.</label>
     <description>Deze eigenschap KAN worden gebruikt om kwaliteitsaspecten van de geleverde inhoud te beschrijven, in de vorm van een URL die linkt naar meer details of resultaten. Als alternatief KAN tekstuele informatie worden verstrekt met behulp van de Embedded Textual Body-constructie van het Web Annotation Data Model [Web-Annotation-Data-Model], waarmee tekstformaten en talen kunnen worden gespecificeerd die relevant kunnen zijn voor meertalige doeleinden.</description>
   </element>
   <element name="oa:hasBody" context="mobilitydcatap:Assessment">

--- a/src/main/plugin/dcat-ap/loc/eng/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/eng/labels.xml
@@ -1122,7 +1122,7 @@
     <description>Any additional information about the format of the delivered content within the distribution in a textual format.</description>
   </element>
   <element name="oa:hasBody" context="dqv:QualityAnnotation">
-    <label>Describes any quality aspects regarding the delivered context</label>
+    <label>Describes any quality aspects regarding the delivered content</label>
     <description>This property MAY be used to describe any quality aspects regarding the delivered content, in form of a URL linking to further details or results. Alternatively, textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model [Web-Annotation-Data-Model], which allows to specify text formats and languages which might be relevant for multilingual purposes.</description>
   </element>
   <element name="oa:hasBody" context="mobilitydcatap:Assessment">

--- a/src/main/plugin/dcat-ap/loc/fre/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/fre/labels.xml
@@ -1122,7 +1122,7 @@
     <description>Any additional information about the format of the delivered content within the distribution in a textual format.</description>
   </element>
   <element name="oa:hasBody" context="dqv:QualityAnnotation">
-    <label>Décrit tous les aspects qualitatifs relatifs au contexte livré</label>
+    <label>Décrit tous les aspects qualitatifs relatifs au contenu livré</label>
     <description>Cette propriété peut servir à décrire les aspects qualitatifs du contenu fourni, sous la forme d'une URL renvoyant à des informations ou résultats complémentaires. Il est également possible de fournir des informations textuelles en utilisant la construction « Embedded Textual Body » du modèle de données d'annotation Web [Web-Annotation-Data-Model], qui permet de spécifier les formats de texte et les langues pertinents pour un usage multilingue.</description>
   </element>
   <element name="oa:hasBody" context="mobilitydcatap:Assessment">

--- a/src/main/plugin/dcat-ap/loc/ger/labels.xml
+++ b/src/main/plugin/dcat-ap/loc/ger/labels.xml
@@ -2296,7 +2296,7 @@
     <description>Any additional information about the format of the delivered content within the distribution in a textual format.</description>
   </element>
   <element name="oa:hasBody" context="dqv:QualityAnnotation">
-    <label>Beschreibt alle Qualitätsaspekte des gelieferten Kontextes</label>
+    <label>Beschreibt alle Qualitätsaspekte des gelieferten Inhalts</label>
     <description>Diese Eigenschaft kann verwendet werden, um Qualitätsaspekte des bereitgestellten Inhalts in Form einer URL zu beschreiben, die auf weitere Details oder Ergebnisse verweist. Alternativ können Textinformationen mithilfe der Konstruktion „Eingebetteter Textkörper“ des Web-Annotationsdatenmodells [Web-Annotation-Data-Model] bereitgestellt werden, die die Angabe von Textformaten und Sprachen ermöglicht, die für mehrsprachige Zwecke relevant sein können.</description>
   </element>
   <element name="oa:hasBody" context="mobilitydcatap:Assessment">


### PR DESCRIPTION
# Content
- fixed typo "context" > "content" in the `oa:hasBody` translation
- now rendering `tel:` and `mailto:` in view (also see #219 )

# Maintenance
A warning popped in in the github pipeline on deprecation of Node. All used github actions were upgraded to their latest state.