### PR TITLE
Editor / Fix for empty hvdCategory on creation

### DIFF
--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -831,7 +831,6 @@
                     <foaf:name/>
                     <dct:type>
                       <skos:Concept>
-                        <skos:prefLabel/>
                         <skos:inScheme rdf:resource="http://purl.org/adms/publishertype/1.0"/>
                       </skos:Concept>
                     </dct:type>
@@ -877,8 +876,7 @@
             <template>
               <snippet>
                 <mdcat:MAGDA-categorie>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel/>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/MAGDA-categorie"/>
                   </skos:Concept>
                 </mdcat:MAGDA-categorie>
@@ -896,8 +894,7 @@
             <template>
               <snippet>
                 <mdcat:statuut>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel/>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden"/>
                   </skos:Concept>
                 </mdcat:statuut>
@@ -1004,7 +1001,7 @@
             <template>
               <snippet>
                 <dct:accrualPeriodicity>
-                  <skos:Concept rdf:about="">
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/frequency"/>
                   </skos:Concept>
                 </dct:accrualPeriodicity>
@@ -1038,8 +1035,7 @@
             <template>
               <snippet>
                 <dct:accessRights>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel/>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/access-right"/>
                   </skos:Concept>
                 </dct:accessRights>
@@ -1066,7 +1062,6 @@
                     <foaf:name/>
                     <dct:type>
                       <skos:Concept>
-                        <skos:prefLabel/>
                         <skos:inScheme rdf:resource="http://purl.org/adms/publishertype/1.0"/>
                       </skos:Concept>
                     </dct:type>
@@ -1145,8 +1140,8 @@
             <template>
               <snippet>
                 <dcatap:hvdCategory>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel xml:lang=""></skos:prefLabel>
+                  <skos:Concept>
+                    <skos:inScheme rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
                   </skos:Concept>
                 </dcatap:hvdCategory>
               </snippet>
@@ -1179,8 +1174,7 @@
             <template>
               <snippet>
                 <mobilitydcatap:mobilityTheme>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel></skos:prefLabel>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme"/>
                   </skos:Concept>
                 </mobilitydcatap:mobilityTheme>
@@ -1198,8 +1192,7 @@
             <template>
               <snippet>
                 <mobilitydcatap:transportMode>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel></skos:prefLabel>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/transport-mode"/>
                   </skos:Concept>
                 </mobilitydcatap:transportMode>
@@ -1217,8 +1210,7 @@
             <template>
               <snippet>
                 <mobilitydcatap:networkCoverage>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel></skos:prefLabel>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage"/>
                   </skos:Concept>
                 </mobilitydcatap:networkCoverage>
@@ -1246,8 +1238,7 @@
             <template>
               <snippet>
                 <mobilitydcatap:georeferencingMethod>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel></skos:prefLabel>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/georeferencing-method"/>
                   </skos:Concept>
                 </mobilitydcatap:georeferencingMethod>
@@ -1265,8 +1256,7 @@
             <template>
               <snippet>
                 <mobilitydcatap:intendedInformationService>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel></skos:prefLabel>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/intended-information-service"/>
                   </skos:Concept>
                 </mobilitydcatap:intendedInformationService>
@@ -1422,8 +1412,7 @@
                 <template>
                   <snippet>
                     <mobilitydcatap:applicationLayerProtocol>
-                      <skos:Concept rdf:about="">
-                        <skos:prefLabel></skos:prefLabel>
+                      <skos:Concept>
                         <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/application-layer-protocol"/>
                       </skos:Concept>
                     </mobilitydcatap:applicationLayerProtocol>
@@ -1441,8 +1430,7 @@
                 <template>
                   <snippet>
                     <mobilitydcatap:communicationMethod>
-                      <skos:Concept rdf:about="">
-                        <skos:prefLabel></skos:prefLabel>
+                      <skos:Concept>
                         <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/communication-method"/>
                       </skos:Concept>
                     </mobilitydcatap:communicationMethod>
@@ -1459,8 +1447,7 @@
                 <template>
                   <snippet>
                     <mobilitydcatap:grammar>
-                      <skos:Concept rdf:about="">
-                        <skos:prefLabel></skos:prefLabel>
+                      <skos:Concept>
                         <skos:inScheme rdf:resource="https://w3id.org/mobilitydcat-ap/grammar"/>
                       </skos:Concept>
                     </mobilitydcatap:grammar>
@@ -1592,8 +1579,7 @@
             <template>
               <snippet>
                 <mdcat:MAGDA-categorie>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel/>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/MAGDA-categorie"/>
                   </skos:Concept>
                 </mdcat:MAGDA-categorie>
@@ -1611,8 +1597,7 @@
             <template>
               <snippet>
                 <mdcat:statuut>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel/>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden"/>
                   </skos:Concept>
                 </mdcat:statuut>
@@ -1630,8 +1615,7 @@
             <template>
               <snippet>
                 <mdcat:levensfase>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel/>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/levensfase"/>
                   </skos:Concept>
                 </mdcat:levensfase>
@@ -1648,8 +1632,7 @@
             <template>
               <snippet>
                 <mdcat:ontwikkelingstoestand>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel/>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="https://data.vlaanderen.be/id/conceptscheme/ontwikkelingstoestand"/>
                   </skos:Concept>
                 </mdcat:ontwikkelingstoestand>
@@ -1758,8 +1741,7 @@
             <template>
               <snippet>
                 <dct:accessRights>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel/>
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/access-right"/>
                   </skos:Concept>
                 </dct:accessRights>
@@ -1819,8 +1801,8 @@
             <template>
               <snippet>
                 <dcatap:hvdCategory>
-                  <skos:Concept rdf:about="">
-                    <skos:prefLabel/>
+                  <skos:Concept>
+                    <skos:inScheme rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
                   </skos:Concept>
                 </dcatap:hvdCategory>
               </snippet>
@@ -1902,7 +1884,6 @@
                     <foaf:name/>
                     <dct:type>
                       <skos:Concept>
-                        <skos:prefLabel/>
                         <skos:inScheme rdf:resource="http://purl.org/adms/publishertype/1.0"/>
                       </skos:Concept>
                     </dct:type>
@@ -1964,7 +1945,7 @@
             <template>
               <snippet>
                 <dct:accrualPeriodicity>
-                  <skos:Concept rdf:about="">
+                  <skos:Concept>
                     <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/frequency"/>
                   </skos:Concept>
                 </dct:accrualPeriodicity>
@@ -2372,7 +2353,6 @@
           <dct:LicenseDocument rdf:about="">
             <dct:type>
               <skos:Concept>
-                <skos:prefLabel/>
                 <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0"/>
               </skos:Concept>
             </dct:type>


### PR DESCRIPTION
An empty `dcatap:hvdCategory` was added when clicking the '+ hvdCategory' button in the editor. This was due to a missing conceptScheme in the definition. 

Additionally, this PR cleans up some spurious elements in the editor (empty prefLabels, rdf:about, ...).